### PR TITLE
Add a buffer size requesting option

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -4,7 +4,7 @@ fn main() {
     let device = cpal::default_output_device().expect("Failed to get default output device");
     let format = device.default_output_format().expect("Failed to get default output format");
     let event_loop = cpal::EventLoop::new();
-    let stream_id = event_loop.build_output_stream(&device, &format).unwrap();
+    let stream_id = event_loop.build_output_stream(&device, &format, &mut cpal::BufferSize::Default).unwrap();
     event_loop.play_stream(stream_id.clone());
 
     let sample_rate = format.sample_rate.0 as f32;

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -12,7 +12,7 @@ fn main() {
     let format = device.default_input_format().expect("Failed to get default input format");
     println!("Default input format: {:?}", format);
     let event_loop = cpal::EventLoop::new();
-    let stream_id = event_loop.build_input_stream(&device, &format)
+    let stream_id = event_loop.build_input_stream(&device, &format, &mut cpal::BufferSize::Default)
         .expect("Failed to build input stream");
     event_loop.play_stream(stream_id);
 

--- a/src/alsa/mod.rs
+++ b/src/alsa/mod.rs
@@ -639,7 +639,7 @@ impl EventLoop {
             }
             let hw_params = HwParams::alloc();
 
-            set_hw_params_from_format(capture_handle, &hw_params, format, buffer_size);
+            set_hw_params_from_format(capture_handle, &hw_params, format, *buffer_size);
 
             let can_pause = alsa::snd_pcm_hw_params_can_pause(hw_params.0) == 1;
 
@@ -701,7 +701,7 @@ impl EventLoop {
             }
             let hw_params = HwParams::alloc();
 
-            set_hw_params_from_format(playback_handle, &hw_params, format, buffer_size);
+            set_hw_params_from_format(playback_handle, &hw_params, format, *buffer_size);
 
             let can_pause = alsa::snd_pcm_hw_params_can_pause(hw_params.0) == 1;
 
@@ -764,7 +764,7 @@ unsafe fn set_hw_params_from_format(
     pcm_handle: *mut alsa::snd_pcm_t,
     hw_params: &HwParams,
     format: &Format,
-    buffer_size: &mut BufferSize,
+    buffer_size: BufferSize,
 ) {
     check_errors(alsa::snd_pcm_hw_params_any(pcm_handle, hw_params.0))
         .expect("Errors on pcm handle");
@@ -802,7 +802,7 @@ unsafe fn set_hw_params_from_format(
                                                           libc::c_uint))
         .expect("channel count could not be set");
 
-    match *buffer_size {
+    match buffer_size {
         BufferSize::Default => {
             let mut max_buffer_size = format.sample_rate.0 as alsa::snd_pcm_uframes_t /
                 format.channels as alsa::snd_pcm_uframes_t /

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -1,6 +1,7 @@
 extern crate coreaudio;
 extern crate core_foundation_sys;
 
+use BufferSize;
 use ChannelCount;
 use CreationError;
 use DefaultFormatError;
@@ -473,6 +474,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
+        _buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         // The scope and element for working with a device's input stream.
@@ -691,6 +693,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
+        _buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         let mut audio_unit = audio_unit_from_device(device, false)?;

--- a/src/coreaudio/mod.rs
+++ b/src/coreaudio/mod.rs
@@ -474,9 +474,11 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-        _buffer_size: &mut BufferSize,
+        buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
+        *buffer_size = BufferSize::Default; // afaik there's no way to get the buffer size beforehand and it can change
+
         // The scope and element for working with a device's input stream.
         let scope = Scope::Output;
         let element = Element::Input;
@@ -693,9 +695,11 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-        _buffer_size: &mut BufferSize,
+        buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
+        *buffer_size = BufferSize::Default; // afaik there's no way to get the buffer size beforehand and it can change
+
         let mut audio_unit = audio_unit_from_device(device, false)?;
 
         // The scope and element for working with a device's output stream.

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -8,6 +8,7 @@ use stdweb::unstable::TryInto;
 use stdweb::web::TypedArray;
 use stdweb::web::set_timeout;
 
+use BufferSize;
 use CreationError;
 use DefaultFormatError;
 use Format;
@@ -86,12 +87,12 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_input_stream(&self, _: &Device, _format: &Format, _buffer_size: &mut BufferSize) -> Result<StreamId, CreationError> {
         unimplemented!();
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_output_stream(&self, _: &Device, _format: &Format, _buffer_size: &mut BufferSize) -> Result<StreamId, CreationError> {
         let stream = js!(return new AudioContext()).into_reference().unwrap();
 
         let mut streams = self.streams.lock().unwrap();

--- a/src/emscripten/mod.rs
+++ b/src/emscripten/mod.rs
@@ -92,7 +92,9 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _format: &Format, _buffer_size: &mut BufferSize) -> Result<StreamId, CreationError> {
+    pub fn build_output_stream(&self, _: &Device, _format: &Format, buffer_size: &mut BufferSize) -> Result<StreamId, CreationError> {
+        *buffer_size = BufferSize::Default; // TODO maybe not this?
+
         let stream = js!(return new AudioContext()).into_reference().unwrap();
 
         let mut streams = self.streams.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,13 +185,16 @@ pub struct Format {
 }
 
 /// The buffer size to request when building an audio stream, if the backend supports buffer
-/// size requesting. Currently, only the alsa backend supports this (TODO).
+/// size requesting.
 ///
 /// Note that this is not guaranteed to return an audio stream of the specified size, in
 /// which case cpal will try to find the closest buffer size it can offer.
+///
+/// NOTE: Currently, only the alsa backend supports buffer sizerequesting, and only the
+/// wasapi and the alsa backend support returning the actual buffer size.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum BufferSize {
-    /// The default buffer size, which is ~200 ms.
+    /// The default buffer size.
     Default,
     /// The buffer size in frames to request.
     Fixed(usize),
@@ -417,7 +420,8 @@ impl EventLoop {
 
     /// Creates a new input stream that will run from the given device and with the given format.
     ///
-    /// On success, returns an identifier for the stream.
+    /// On success, returns an identifier for the stream and modifies `buffer_size` to reflect the
+    /// actual buffer size.
     ///
     /// Can return an error if the device is no longer valid, or if the input stream format is not
     /// supported by the device.
@@ -434,7 +438,8 @@ impl EventLoop {
 
     /// Creates a new output stream that will play on the given device and with the given format.
     ///
-    /// On success, returns an identifier for the stream.
+    /// On success, returns an identifier for the stream and modifies `buffer_size` to reflect the
+    /// actual buffer size.
     ///
     /// Can return an error if the device is no longer valid, or if the output stream format is not
     /// supported by the device.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,6 +678,13 @@ impl From<Format> for SupportedFormat {
     }
 }
 
+impl Default for BufferSize {
+    #[inline]
+    fn default() -> BufferSize {
+        BufferSize::Default
+    }
+}
+
 impl Iterator for Devices {
     type Item = Device;
 

--- a/src/null/mod.rs
+++ b/src/null/mod.rs
@@ -2,6 +2,7 @@
 
 use std::marker::PhantomData;
 
+use BufferSize;
 use CreationError;
 use DefaultFormatError;
 use Format;
@@ -25,12 +26,12 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_input_stream(&self, _: &Device, _: &Format, _: &mut BufferSize) -> Result<StreamId, CreationError> {
         Err(CreationError::DeviceNotAvailable)
     }
 
     #[inline]
-    pub fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, CreationError> {
+    pub fn build_output_stream(&self, _: &Device, _: &Format, _: &mut BufferSize) -> Result<StreamId, CreationError> {
         Err(CreationError::DeviceNotAvailable)
     }
 

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -20,6 +20,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use BufferSize;
 use CreationError;
 use Format;
 use SampleFormat;
@@ -110,6 +111,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
+        _buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         unsafe {
@@ -260,6 +262,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
+        _buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         unsafe {

--- a/src/wasapi/stream.rs
+++ b/src/wasapi/stream.rs
@@ -111,7 +111,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-        _buffer_size: &mut BufferSize,
+        buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         unsafe {
@@ -184,6 +184,7 @@ impl EventLoop {
 
                 max_frames_in_buffer
             };
+            *buffer_size = BufferSize::Fixed(max_frames_in_buffer as usize);
 
             // Creating the event that will be signalled whenever we need to submit some samples.
             let event = {
@@ -262,7 +263,7 @@ impl EventLoop {
         &self,
         device: &Device,
         format: &Format,
-        _buffer_size: &mut BufferSize,
+        buffer_size: &mut BufferSize,
     ) -> Result<StreamId, CreationError>
     {
         unsafe {
@@ -352,6 +353,7 @@ impl EventLoop {
 
                 max_frames_in_buffer
             };
+            *buffer_size = BufferSize::Fixed(max_frames_in_buffer as usize);
 
             // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
             let render_client = {


### PR DESCRIPTION
Partially implements #205.

I've only implemented it for alsa, so if someone else could implement it for the other backends or at least point me in the right direction that would be great.

Also I'm not sure if and how it should return the actual buffer size. Right now it takes a mutable reference for the buffer size and then modifies it to reflect the actual buffer size.

EDIT: I think I've figured out how to implement it for WASAPI, will implement when I find time. Still clueless on coreaudio though.

EDIT2: Ok WASAPI won't let you set the buffer size, but there's [IAudioClient3](https://docs.microsoft.com/en-us/windows/desktop/api/audioclient/nn-audioclient-iaudioclient3) which might work except it's not in winapi-rs. And it's only supported in Windows 10 and up. ¯\\\_(ツ)\_/¯