### PR TITLE
Getting rid of the EventLoop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cargo/
 .DS_Store
 recorded.wav
+rls*.log

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,37 +1,34 @@
 extern crate cpal;
 extern crate failure;
 
-use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+use cpal::traits::{DeviceTrait, StreamTrait, HostTrait};
 
 fn main() -> Result<(), failure::Error> {
     let host = cpal::default_host();
     let device = host.default_output_device().expect("failed to find a default output device");
     let format = device.default_output_format()?;
-    let event_loop = host.event_loop();
-    let stream_id = event_loop.build_output_stream(&device, &format)?;
-    event_loop.play_stream(stream_id.clone())?;
-
     let sample_rate = format.sample_rate.0 as f32;
+    let channels = format.channels;
     let mut sample_clock = 0f32;
 
     // Produce a sinusoid of maximum amplitude.
-    let mut next_value = || {
+    let mut next_value = move || {
         sample_clock = (sample_clock + 1.0) % sample_rate;
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    event_loop.run(move |id, result| {
+    let stream = device.build_output_stream(&format, move |result| {
         let data = match result {
             Ok(data) => data,
             Err(err) => {
-                eprintln!("an error occurred on stream {:?}: {}", id, err);
+                eprintln!("an error occurred on stream: {}", err);
                 return;
             }
         };
 
         match data {
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = ((next_value() * 0.5 + 0.5) * std::u16::MAX as f32) as u16;
                     for out in sample.iter_mut() {
                         *out = value;
@@ -39,7 +36,7 @@ fn main() -> Result<(), failure::Error> {
                 }
             },
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::I16(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = (next_value() * std::i16::MAX as f32) as i16;
                     for out in sample.iter_mut() {
                         *out = value;
@@ -47,7 +44,7 @@ fn main() -> Result<(), failure::Error> {
                 }
             },
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = next_value();
                     for out in sample.iter_mut() {
                         *out = value;
@@ -56,5 +53,10 @@ fn main() -> Result<(), failure::Error> {
             },
             _ => (),
         }
-    });
+    })?;
+    stream.play()?;
+    
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    Ok(())
 }

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -17,15 +17,7 @@ fn main() -> Result<(), failure::Error> {
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    let stream = device.build_output_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on stream: {}", err);
-                return;
-            }
-        };
-
+    let stream = device.build_output_stream(&format, move |data| {
         match data {
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer) } => {
                 for sample in buffer.chunks_mut(channels as usize) {
@@ -53,6 +45,8 @@ fn main() -> Result<(), failure::Error> {
             },
             _ => (),
         }
+    }, move |err| {
+        eprintln!("an error occurred on stream: {}", err);
     })?;
     stream.play()?;
     

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -44,15 +44,7 @@ fn main() -> Result<(), failure::Error> {
 
     // Build streams.
     println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream = input_device.build_input_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on input stream: {}", err);
-                return;
-            },
-        };
-
+    let input_stream = input_device.build_input_stream(&format, move |data| {
         match data {
             cpal::StreamData::Input {
                 buffer: cpal::UnknownTypeInputBuffer::F32(buffer),
@@ -69,15 +61,10 @@ fn main() -> Result<(), failure::Error> {
             },
             _ => panic!("Expected input with f32 data"),
         }
+    }, move |err| {
+        eprintln!("an error occurred on input stream: {}", err);
     })?;
-    let output_stream = output_device.build_output_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on output stream: {}", err);
-                return;
-            },
-        };
+    let output_stream = output_device.build_output_stream(&format, move |data| {
         match data {
             cpal::StreamData::Output {
                 buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer),
@@ -98,6 +85,8 @@ fn main() -> Result<(), failure::Error> {
             },
             _ => panic!("Expected output with f32 data"),
         }
+    }, move |err| {
+        eprintln!("an error occurred on output stream: {}", err);
     })?;
     println!("Successfully built streams.");
 

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -9,29 +9,26 @@
 extern crate cpal;
 extern crate failure;
 
-use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
 const LATENCY_MS: f32 = 150.0;
 
 fn main() -> Result<(), failure::Error> {
     let host = cpal::default_host();
-    let event_loop = host.event_loop();
 
     // Default devices.
-    let input_device = host.default_input_device().expect("failed to get default input device");
-    let output_device = host.default_output_device().expect("failed to get default output device");
+    let input_device = host
+        .default_input_device()
+        .expect("failed to get default input device");
+    let output_device = host
+        .default_output_device()
+        .expect("failed to get default output device");
     println!("Using default input device: \"{}\"", input_device.name()?);
     println!("Using default output device: \"{}\"", output_device.name()?);
 
     // We'll try and use the same format between streams to keep it simple
     let mut format = input_device.default_input_format()?;
     format.data_type = cpal::SampleFormat::F32;
-
-    // Build streams.
-    println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream_id = event_loop.build_input_stream(&input_device, &format)?;
-    let output_stream_id = event_loop.build_output_stream(&output_device, &format)?;
-    println!("Successfully built streams.");
 
     // Create a delay in case the input and output devices aren't synced.
     let latency_frames = (LATENCY_MS / 1_000.0) * format.sample_rate.0 as f32;
@@ -41,63 +38,82 @@ fn main() -> Result<(), failure::Error> {
     let (tx, rx) = std::sync::mpsc::sync_channel(latency_samples * 2);
 
     // Fill the samples with 0.0 equal to the length of the delay.
-    for _ in 0..latency_samples {
+    for _ in 0 .. latency_samples {
         tx.send(0.0)?;
     }
 
-    // Play the streams.
-    println!("Starting the input and output streams with `{}` milliseconds of latency.", LATENCY_MS);
-    event_loop.play_stream(input_stream_id.clone())?;
-    event_loop.play_stream(output_stream_id.clone())?;
+    // Build streams.
+    println!("Attempting to build both streams with `{:?}`.", format);
+    let input_stream = input_device.build_input_stream(&format, move |result| {
+        let data = match result {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("an error occurred on input stream: {}", err);
+                return;
+            },
+        };
 
-    // Run the event loop on a separate thread.
-    std::thread::spawn(move || {
-        event_loop.run(move |id, result| {
-            let data = match result {
-                Ok(data) => data,
-                Err(err) => {
-                    eprintln!("an error occurred on stream {:?}: {}", id, err);
-                    return;
+        match data {
+            cpal::StreamData::Input {
+                buffer: cpal::UnknownTypeInputBuffer::F32(buffer),
+            } => {
+                let mut output_fell_behind = false;
+                for &sample in buffer.iter() {
+                    if tx.try_send(sample).is_err() {
+                        output_fell_behind = true;
+                    }
                 }
-            };
+                if output_fell_behind {
+                    eprintln!("output stream fell behind: try increasing latency");
+                }
+            },
+            _ => panic!("Expected input with f32 data"),
+        }
+    })?;
+    let output_stream = output_device.build_output_stream(&format, move |result| {
+        let data = match result {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("an error occurred on output stream: {}", err);
+                return;
+            },
+        };
+        match data {
+            cpal::StreamData::Output {
+                buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer),
+            } => {
+                let mut input_fell_behind = None;
+                for sample in buffer.iter_mut() {
+                    *sample = match rx.try_recv() {
+                        Ok(s) => s,
+                        Err(err) => {
+                            input_fell_behind = Some(err);
+                            0.0
+                        },
+                    };
+                }
+                if let Some(err) = input_fell_behind {
+                    eprintln!("input stream fell behind: {}: try increasing latency", err);
+                }
+            },
+            _ => panic!("Expected output with f32 data"),
+        }
+    })?;
+    println!("Successfully built streams.");
 
-            match data {
-                cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::F32(buffer) } => {
-                    assert_eq!(id, input_stream_id);
-                    let mut output_fell_behind = false;
-                    for &sample in buffer.iter() {
-                        if tx.try_send(sample).is_err() {
-                            output_fell_behind = true;
-                        }
-                    }
-                    if output_fell_behind {
-                        eprintln!("output stream fell behind: try increasing latency");
-                    }
-                },
-                cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer) } => {
-                    assert_eq!(id, output_stream_id);
-                    let mut input_fell_behind = None;
-                    for sample in buffer.iter_mut() {
-                        *sample = match rx.try_recv() {
-                            Ok(s) => s,
-                            Err(err) => {
-                                input_fell_behind = Some(err);
-                                0.0
-                            },
-                        };
-                    }
-                    if let Some(err) = input_fell_behind {
-                        eprintln!("input stream fell behind: {}: try increasing latency", err);
-                    }
-                },
-                _ => panic!("we're expecting f32 data"),
-            }
-        });
-    });
+    // Play the streams.
+    println!(
+        "Starting the input and output streams with `{}` milliseconds of latency.",
+        LATENCY_MS
+    );
+    input_stream.play()?;
+    output_stream.play()?;
 
     // Run for 3 seconds before closing.
     println!("Playing for 3 seconds... ");
     std::thread::sleep(std::time::Duration::from_secs(3));
+    drop(input_stream);
+    drop(output_stream);
     println!("Done!");
     Ok(())
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -32,15 +32,7 @@ fn main() -> Result<(), failure::Error> {
 
     // Run the input stream on a separate thread.
     let writer_2 = writer.clone();
-    let stream = device.build_input_stream(&format, move |event| {
-        let data = match event {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on stream: {}", err);
-                return;
-            },
-        };
-
+    let stream = device.build_input_stream(&format, move |data| {
         // Otherwise write to the wav writer.
         match data {
             cpal::StreamData::Input {
@@ -79,6 +71,8 @@ fn main() -> Result<(), failure::Error> {
             },
             _ => (),
         }
+    }, move |err| {
+        eprintln!("an error occurred on stream: {}", err);
     })?;
     stream.play()?;
 

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -6,21 +6,21 @@ extern crate cpal;
 extern crate failure;
 extern crate hound;
 
-use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 
 fn main() -> Result<(), failure::Error> {
     // Use the default host for working with audio devices.
     let host = cpal::default_host();
 
     // Setup the default input device and stream with the default input format.
-    let device = host.default_input_device().expect("Failed to get default input device");
+    let device = host
+        .default_input_device()
+        .expect("Failed to get default input device");
     println!("Default input device: {}", device.name()?);
-    let format = device.default_input_format().expect("Failed to get default input format");
+    let format = device
+        .default_input_format()
+        .expect("Failed to get default input format");
     println!("Default input format: {:?}", format);
-    let event_loop = host.event_loop();
-    let stream_id = event_loop.build_input_stream(&device, &format)?;
-    event_loop.play_stream(stream_id)?;
-
     // The WAV file we're recording to.
     const PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
     let spec = wav_spec_from_format(&format);
@@ -29,63 +29,62 @@ fn main() -> Result<(), failure::Error> {
 
     // A flag to indicate that recording is in progress.
     println!("Begin recording...");
-    let recording = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true));
 
     // Run the input stream on a separate thread.
     let writer_2 = writer.clone();
-    let recording_2 = recording.clone();
-    std::thread::spawn(move || {
-        event_loop.run(move |id, event| {
-            let data = match event {
-                Ok(data) => data,
-                Err(err) => {
-                    eprintln!("an error occurred on stream {:?}: {}", id, err);
-                    return;
-                }
-            };
-
-            // If we're done recording, return early.
-            if !recording_2.load(std::sync::atomic::Ordering::Relaxed) {
+    let stream = device.build_input_stream(&format, move |event| {
+        let data = match event {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("an error occurred on stream: {}", err);
                 return;
-            }
-            // Otherwise write to the wav writer.
-            match data {
-                cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::U16(buffer) } => {
-                    if let Ok(mut guard) = writer_2.try_lock() {
-                        if let Some(writer) = guard.as_mut() {
-                            for sample in buffer.iter() {
-                                let sample = cpal::Sample::to_i16(sample);
-                                writer.write_sample(sample).ok();
-                            }
+            },
+        };
+
+        // Otherwise write to the wav writer.
+        match data {
+            cpal::StreamData::Input {
+                buffer: cpal::UnknownTypeInputBuffer::U16(buffer),
+            } => {
+                if let Ok(mut guard) = writer_2.try_lock() {
+                    if let Some(writer) = guard.as_mut() {
+                        for sample in buffer.iter() {
+                            let sample = cpal::Sample::to_i16(sample);
+                            writer.write_sample(sample).ok();
                         }
                     }
-                },
-                cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::I16(buffer) } => {
-                    if let Ok(mut guard) = writer_2.try_lock() {
-                        if let Some(writer) = guard.as_mut() {
-                            for &sample in buffer.iter() {
-                                writer.write_sample(sample).ok();
-                            }
+                }
+            },
+            cpal::StreamData::Input {
+                buffer: cpal::UnknownTypeInputBuffer::I16(buffer),
+            } => {
+                if let Ok(mut guard) = writer_2.try_lock() {
+                    if let Some(writer) = guard.as_mut() {
+                        for &sample in buffer.iter() {
+                            writer.write_sample(sample).ok();
                         }
                     }
-                },
-                cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::F32(buffer) } => {
-                    if let Ok(mut guard) = writer_2.try_lock() {
-                        if let Some(writer) = guard.as_mut() {
-                            for &sample in buffer.iter() {
-                                writer.write_sample(sample).ok();
-                            }
+                }
+            },
+            cpal::StreamData::Input {
+                buffer: cpal::UnknownTypeInputBuffer::F32(buffer),
+            } => {
+                if let Ok(mut guard) = writer_2.try_lock() {
+                    if let Some(writer) = guard.as_mut() {
+                        for &sample in buffer.iter() {
+                            writer.write_sample(sample).ok();
                         }
                     }
-                },
-                _ => (),
-            }
-        });
-    });
+                }
+            },
+            _ => (),
+        }
+    })?;
+    stream.play()?;
 
     // Let recording go for roughly three seconds.
     std::thread::sleep(std::time::Duration::from_secs(3));
-    recording.store(false, std::sync::atomic::Ordering::Relaxed);
+    drop(stream);
     writer.lock().unwrap().take().unwrap().finalize()?;
     println!("Recording {} complete!", PATH);
     Ok(())

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -18,7 +18,7 @@ use PlayStreamError;
 use SampleFormat;
 use SampleRate;
 use StreamData;
-use StreamDataResult;
+use StreamError;
 use SupportedFormat;
 use SupportedFormatsError;
 use traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -89,12 +89,12 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError> where F: FnMut(StreamDataResult) + Send + 'static {
-        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_CAPTURE)?), callback))
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_CAPTURE)?), data_callback, error_callback))
     }
 
-    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError> where F: FnMut(StreamDataResult) + Send + 'static {
-        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_PLAYBACK)?), callback))
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_PLAYBACK)?), data_callback, error_callback))
     }
 }
 
@@ -530,7 +530,10 @@ pub struct Stream {
 
 /// The inner body of the audio processing thread. Takes the polymorphic
 /// callback to avoid generating too much generic code.
-fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn FnMut(StreamDataResult) + Send + 'static)) {
+fn stream_worker(rx: TriggerReceiver,
+                 stream: &StreamInner,
+                 data_callback: &mut (dyn FnMut(StreamData) + Send + 'static),
+                 error_callback: &mut (dyn FnMut(StreamError) + Send + 'static)) {
     let mut descriptors = Vec::new();
     let mut buffer = Vec::new();
     loop {
@@ -563,11 +566,11 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
         };
         if res < 0 {
             let description = format!("`libc::poll()` failed: {}", io::Error::last_os_error());
-            callback(Err(BackendSpecificError { description }.into()));
+            error_callback(BackendSpecificError { description }.into());
             continue;
         } else if res == 0 {
             let description = String::from("`libc::poll()` spuriously returned");
-            callback(Err(BackendSpecificError { description }.into()));
+            error_callback(BackendSpecificError { description }.into());
             continue;
         }
 
@@ -593,7 +596,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
             Ok(n) => n,
             Err(err) => {
                 let description = format!("Failed to query the number of available samples: {}", err);
-                callback(Err(BackendSpecificError { description }.into()));
+                error_callback(BackendSpecificError { description }.into());
                 continue;
             }
         };
@@ -619,7 +622,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
                 };
                 if let Err(err) = check_errors(result as _) {
                     let description = format!("`snd_pcm_readi` failed: {}", err);
-                    callback(Err(BackendSpecificError { description }.into()));
+                    error_callback(BackendSpecificError { description }.into());
                     continue;
                 }
 
@@ -637,7 +640,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
                 let stream_data = StreamData::Input {
                     buffer: input_buffer,
                 };
-                callback(Ok(stream_data));
+                data_callback(stream_data);
             },
             StreamType::Output => {
                 {
@@ -657,7 +660,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
                     let stream_data = StreamData::Output {
                         buffer: output_buffer,
                     };
-                    callback(Ok(stream_data));
+                    data_callback(stream_data);
                 }
                 loop {
                     let result = unsafe {
@@ -674,7 +677,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
                         unsafe { alsa::snd_pcm_recover(stream.channel, result as i32, 0) };
                     } else if let Err(err) = check_errors(result as _) {
                         let description = format!("`snd_pcm_writei` failed: {}", err);
-                        callback(Err(BackendSpecificError { description }.into()));
+                        error_callback(BackendSpecificError { description }.into());
                         continue;
                     } else if result as usize != available_frames {
                         let description = format!(
@@ -683,7 +686,7 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
                             available_frames,
                             result,
                         );
-                        callback(Err(BackendSpecificError { description }.into()));
+                        error_callback(BackendSpecificError { description }.into());
                         continue;
                     } else {
                         break;
@@ -695,12 +698,13 @@ fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn 
 }
 
 impl Stream {
-    fn new<F>(inner: Arc<StreamInner>, mut callback: F) -> Stream where F: FnMut(StreamDataResult) + Send + 'static {
+    fn new<D, E>(inner: Arc<StreamInner>, mut data_callback: D, mut error_callback: E) -> Stream
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         let (tx, rx) = trigger();
         // Clone the handle for passing into worker thread.
         let stream = inner.clone();
         let thread = thread::spawn(move || {
-            stream_worker(rx, &*stream, &mut callback);
+            stream_worker(rx, &*stream, &mut data_callback, &mut error_callback);
         });
         Stream {
             thread: Some(thread),

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -587,7 +587,7 @@ fn stream_worker(rx: TriggerReceiver,
                 continue;
             },
             Err(err) => {
-                // TODO: signal errors
+                error_callback(err.into());
                 continue;
             }
         };

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1,11 +1,14 @@
 extern crate alsa_sys as alsa;
 extern crate libc;
 
-pub use self::enumerate::{Devices, default_input_device, default_output_device};
+use std::{cmp, ffi, io, mem, ptr};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::vec::IntoIter as VecIntoIter;
 
-use ChannelCount;
 use BackendSpecificError;
 use BuildStreamError;
+use ChannelCount;
 use DefaultFormatError;
 use DeviceNameError;
 use DevicesError;
@@ -14,20 +17,15 @@ use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
 use SampleRate;
-use SupportedFormatsError;
 use StreamData;
 use StreamDataResult;
-use StreamError;
 use SupportedFormat;
+use SupportedFormatsError;
+use traits::{DeviceTrait, HostTrait, StreamTrait};
 use UnknownTypeInputBuffer;
 use UnknownTypeOutputBuffer;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
 
-use std::{cmp, ffi, ptr};
-use std::sync::Mutex;
-use std::sync::mpsc::{channel, Sender, Receiver};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::vec::IntoIter as VecIntoIter;
+pub use self::enumerate::{default_input_device, default_output_device, Devices};
 
 pub type SupportedInputFormats = VecIntoIter<SupportedFormat>;
 pub type SupportedOutputFormats = VecIntoIter<SupportedFormat>;
@@ -47,7 +45,6 @@ impl Host {
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         // Assume ALSA is always available on linux/freebsd.
@@ -65,15 +62,12 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
 
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)
@@ -94,95 +88,132 @@ impl DeviceTrait for Device {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         Device::default_output_format(self)
     }
-}
 
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    fn build_input_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_input_stream(self, device, format)
+    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError> where F: FnMut(StreamDataResult) + Send + 'static {
+        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_CAPTURE)?), callback))
     }
 
-    fn build_output_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_output_stream(self, device, format)
-    }
-
-    fn play_stream(&self, stream: Self::StreamId) -> Result<(), PlayStreamError> {
-        EventLoop::play_stream(self, stream)
-    }
-
-    fn pause_stream(&self, stream: Self::StreamId) -> Result<(), PauseStreamError> {
-        EventLoop::pause_stream(self, stream)
-    }
-
-    fn destroy_stream(&self, stream: Self::StreamId) {
-        EventLoop::destroy_stream(self, stream)
-    }
-
-    fn run<F>(&self, callback: F) -> !
-    where
-        F: FnMut(Self::StreamId, StreamDataResult) + Send,
-    {
-        EventLoop::run(self, callback)
+    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError> where F: FnMut(StreamDataResult) + Send + 'static {
+        Ok(Stream::new(Arc::new(self.build_stream_inner(format, alsa::SND_PCM_STREAM_PLAYBACK)?), callback))
     }
 }
 
-impl StreamIdTrait for StreamId {}
 
-struct Trigger {
-    // [read fd, write fd]
-    fds: [libc::c_int; 2],
-}
+struct TriggerSender(libc::c_int);
 
-impl Trigger {
-    fn new() -> Self {
-        let mut fds = [0, 0];
-        match unsafe { libc::pipe(fds.as_mut_ptr()) } {
-            0 => Trigger { fds: fds },
-            _ => panic!("Could not create pipe"),
-        }
-    }
-    fn read_fd(&self) -> libc::c_int {
-        self.fds[0]
-    }
-    fn write_fd(&self) -> libc::c_int {
-        self.fds[1]
-    }
+struct TriggerReceiver(libc::c_int);
+
+impl TriggerSender {
     fn wakeup(&self) {
         let buf = 1u64;
-        let ret = unsafe { libc::write(self.write_fd(), &buf as *const u64 as *const _, 8) };
+        let ret = unsafe { libc::write(self.0, &buf as *const u64 as *const _, 8) };
         assert!(ret == 8);
     }
+}
+
+impl TriggerReceiver {
     fn clear_pipe(&self) {
         let mut out = 0u64;
-        let ret = unsafe { libc::read(self.read_fd(), &mut out as *mut u64 as *mut _, 8) };
+        let ret = unsafe { libc::read(self.0, &mut out as *mut u64 as *mut _, 8) };
         assert_eq!(ret, 8);
     }
 }
 
-impl Drop for Trigger {
+fn trigger() -> (TriggerSender, TriggerReceiver) {
+    let mut fds = [0, 0];
+    match unsafe { libc::pipe(fds.as_mut_ptr()) } {
+        0 => (TriggerSender(fds[1]), TriggerReceiver(fds[0])),
+        _ => panic!("Could not create pipe"),
+    }
+}
+
+impl Drop for TriggerSender {
     fn drop(&mut self) {
         unsafe {
-            libc::close(self.fds[0]);
-            libc::close(self.fds[1]);
+            libc::close(self.0);
         }
     }
 }
 
+impl Drop for TriggerReceiver {
+    fn drop(&mut self) {
+        unsafe {
+            libc::close(self.0);
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Device(String);
 
 impl Device {
+    fn build_stream_inner(&self, format: &Format, stream_type: alsa::snd_pcm_stream_t) -> Result<StreamInner, BuildStreamError> {
+        let name = ffi::CString::new(self.0.clone()).expect("unable to clone device");
+
+        let handle = unsafe {
+            let mut handle = ptr::null_mut();
+            match alsa::snd_pcm_open(
+                &mut handle,
+                name.as_ptr(),
+                stream_type,
+                alsa::SND_PCM_NONBLOCK,
+            ) {
+                -16 /* determined empirically */ => return Err(BuildStreamError::DeviceNotAvailable),
+                -22 => return Err(BuildStreamError::InvalidArgument),
+                e => if let Err(description) = check_errors(e) {
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+            }
+            handle
+        };
+        let can_pause = unsafe {
+            let hw_params = HwParams::alloc();
+            set_hw_params_from_format(handle, &hw_params, format)
+                .map_err(|description| BackendSpecificError { description })?;
+
+            alsa::snd_pcm_hw_params_can_pause(hw_params.0) == 1
+        };
+        let (buffer_len, period_len) = unsafe {
+            set_sw_params_from_format(handle, format)
+                .map_err(|description| BackendSpecificError { description })?
+        };
+
+        if let Err(desc) = check_errors(unsafe { alsa::snd_pcm_prepare(handle) }) {
+            let description = format!("could not get handle: {}", desc);
+            let err = BackendSpecificError { description };
+            return Err(err.into());
+        }
+
+        let num_descriptors = {
+            let num_descriptors = unsafe { alsa::snd_pcm_poll_descriptors_count(handle) };
+            if num_descriptors == 0 {
+                let description = "poll descriptor count for stream was 0".to_string();
+                let err = BackendSpecificError { description };
+                return Err(err.into());
+            }
+            num_descriptors as usize
+        };
+
+        let stream_inner = StreamInner {
+            channel: handle,
+            sample_format: format.data_type,
+            num_descriptors,
+            num_channels: format.channels as u16,
+            buffer_len,
+            period_len,
+            can_pause,
+        };
+
+        if let Err(desc) = check_errors(unsafe { alsa::snd_pcm_start(handle) }) {
+            let description = format!("could not start stream: {}", desc);
+            let err = BackendSpecificError { description };
+            return Err(err.into());
+        }
+
+        Ok(stream_inner)
+    }
+
     #[inline]
     fn name(&self) -> Result<String, DeviceNameError> {
         Ok(self.0.clone())
@@ -454,48 +485,7 @@ impl Device {
     }
 }
 
-pub struct EventLoop {
-    // Each newly-created stream gets a new ID from this counter. The counter is then incremented.
-    next_stream_id: AtomicUsize, // TODO: use AtomicU64 when stable?
-
-    // A trigger that uses a `pipe()` as backend. Signalled whenever a new command is ready, so
-    // that `poll()` can wake up and pick the changes.
-    pending_command_trigger: Trigger,
-
-    // This field is locked by the `run()` method.
-    // The mutex also ensures that only one thread at a time has `run()` running.
-    run_context: Mutex<RunContext>,
-
-    // Commands processed by the `run()` method that is currently running.
-    commands: Sender<Command>,
-}
-
-unsafe impl Send for EventLoop {
-}
-
-unsafe impl Sync for EventLoop {
-}
-
-enum Command {
-    NewStream(StreamInner),
-    PlayStream(StreamId),
-    PauseStream(StreamId),
-    DestroyStream(StreamId),
-}
-
-struct RunContext {
-    // Descriptors to wait for. Always contains `pending_command_trigger.read_fd()` as first element.
-    descriptors: Vec<libc::pollfd>,
-    // List of streams that are written in `descriptors`.
-    streams: Vec<StreamInner>,
-
-    commands: Receiver<Command>,
-}
-
 struct StreamInner {
-    // The id of the stream.
-    id: StreamId,
-
     // The ALSA channel.
     channel: *mut alsa::snd_pcm_t,
 
@@ -517,501 +507,230 @@ struct StreamInner {
 
     // Whether or not the hardware supports pausing the stream.
     can_pause: bool,
-
-    // Whether or not the sample stream is currently paused.
-    is_paused: bool,
-
-    // A file descriptor opened with `eventfd`.
-    // It is used to wait for resume signal.
-    resume_trigger: Trigger,
-
-    // Lazily allocated buffer that is reused inside the loop.
-    // Zero-allocate a new buffer (the fastest way to have zeroed memory) at the first time this is
-    // used.
-    buffer: Vec<u8>,
 }
 
-#[derive(Copy, Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamId(usize);
+// Assume that the ALSA library is built with thread safe option.
+unsafe impl Send for StreamInner {}
+
+unsafe impl Sync for StreamInner {}
 
 enum StreamType { Input, Output }
 
+pub struct Stream {
+    /// The high-priority audio processing thread calling callbacks.
+    /// Option used for moving out in destructor.
+    thread: Option<JoinHandle<()>>,
 
-impl EventLoop {
-    #[inline]
-    fn new() -> EventLoop {
-        let pending_command_trigger = Trigger::new();
+    /// Handle to the underlying stream for playback controls.
+    inner: Arc<StreamInner>,
 
-        let mut initial_descriptors = vec![];
-        reset_descriptors_with_pending_command_trigger(
-            &mut initial_descriptors,
-            &pending_command_trigger,
-        );
-
-        let (tx, rx) = channel();
-
-        let run_context = Mutex::new(RunContext {
-                                         descriptors: initial_descriptors,
-                                         streams: Vec::new(),
-                                         commands: rx,
-                                     });
-
-        EventLoop {
-            next_stream_id: AtomicUsize::new(0),
-            pending_command_trigger: pending_command_trigger,
-            run_context,
-            commands: tx,
-        }
-    }
-
-    #[inline]
-    fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult)
-    {
-        self.run_inner(&mut callback)
-    }
-
-    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamDataResult)) -> ! {
-        unsafe {
-            let mut run_context = self.run_context.lock().unwrap();
-            let run_context = &mut *run_context;
-
-            'stream_loop: loop {
-                process_commands(run_context);
-
-                reset_descriptors_with_pending_command_trigger(
-                    &mut run_context.descriptors,
-                    &self.pending_command_trigger,
-                );
-                append_stream_poll_descriptors(run_context);
-
-                // At this point, this should include the command `pending_commands_trigger` along
-                // with the poll descriptors for each stream.
-                match poll_all_descriptors(&mut run_context.descriptors) {
-                    Ok(true) => (),
-                    Ok(false) => continue,
-                    Err(err) => {
-                        for stream in run_context.streams.iter() {
-                            let result = Err(err.clone().into());
-                            callback(stream.id, result);
-                        }
-                        run_context.streams.clear();
-                        break 'stream_loop;
-                    }
-                }
-
-                // If the `pending_command_trigger` was signaled, we need to process the comands.
-                if run_context.descriptors[0].revents != 0 {
-                    run_context.descriptors[0].revents = 0;
-                    self.pending_command_trigger.clear_pipe();
-                }
-
-                // The set of streams that error within the following loop and should be removed.
-                let mut streams_to_remove: Vec<(StreamId, StreamError)> = vec![];
-
-                // Iterate over each individual stream/descriptor.
-                let mut i_stream = 0;
-                let mut i_descriptor = 1;
-                while (i_descriptor as usize) < run_context.descriptors.len() {
-                    let stream = &mut run_context.streams[i_stream];
-                    let stream_descriptor_ptr = run_context.descriptors.as_mut_ptr().offset(i_descriptor);
-
-                    // Only go on if this event was a pollout or pollin event.
-                    let stream_type = match check_for_pollout_or_pollin(stream, stream_descriptor_ptr) {
-                        Ok(Some(ty)) => ty,
-                        Ok(None) => {
-                            i_descriptor += stream.num_descriptors as isize;
-                            i_stream += 1;
-                            continue;
-                        },
-                        Err(err) => {
-                            streams_to_remove.push((stream.id, err.into()));
-                            i_descriptor += stream.num_descriptors as isize;
-                            i_stream += 1;
-                            continue;
-                        }
-                    };
-
-                    // Get the number of available samples for reading/writing.
-                    let available_samples = match get_available_samples(stream) {
-                        Ok(n) => n,
-                        Err(err) => {
-                            streams_to_remove.push((stream.id, err.into()));
-                            i_descriptor += stream.num_descriptors as isize;
-                            i_stream += 1;
-                            continue;
-                        }
-                    };
-
-                    // Only go on if there is at least `stream.period_len` samples.
-                    if available_samples < stream.period_len {
-                        i_descriptor += stream.num_descriptors as isize;
-                        i_stream += 1;
-                        continue;
-                    }
-
-                    // Prepare the data buffer.
-                    let buffer_size = stream.sample_format.sample_size() * available_samples;
-                    stream.buffer.resize(buffer_size, 0u8);
-                    let available_frames = available_samples / stream.num_channels as usize;
-
-                    match stream_type {
-                        StreamType::Input => {
-                            let result = alsa::snd_pcm_readi(
-                                stream.channel,
-                                stream.buffer.as_mut_ptr() as *mut _,
-                                available_frames as alsa::snd_pcm_uframes_t,
-                            );
-                            if let Err(err) = check_errors(result as _) {
-                                let description = format!("`snd_pcm_readi` failed: {}", err);
-                                let err = BackendSpecificError { description };
-                                streams_to_remove.push((stream.id, err.into()));
-                                continue;
-                            }
-
-                            let input_buffer = match stream.sample_format {
-                                SampleFormat::I16 => UnknownTypeInputBuffer::I16(::InputBuffer {
-                                    buffer: cast_input_buffer(&mut stream.buffer),
-                                }),
-                                SampleFormat::U16 => UnknownTypeInputBuffer::U16(::InputBuffer {
-                                    buffer: cast_input_buffer(&mut stream.buffer),
-                                }),
-                                SampleFormat::F32 => UnknownTypeInputBuffer::F32(::InputBuffer {
-                                    buffer: cast_input_buffer(&mut stream.buffer),
-                                }),
-                            };
-                            let stream_data = StreamData::Input {
-                                buffer: input_buffer,
-                            };
-                            callback(stream.id, Ok(stream_data));
-                        },
-                        StreamType::Output => {
-                            {
-                                // We're now sure that we're ready to write data.
-                                let output_buffer = match stream.sample_format {
-                                    SampleFormat::I16 => UnknownTypeOutputBuffer::I16(::OutputBuffer {
-                                        buffer: cast_output_buffer(&mut stream.buffer),
-                                    }),
-                                    SampleFormat::U16 => UnknownTypeOutputBuffer::U16(::OutputBuffer {
-                                        buffer: cast_output_buffer(&mut stream.buffer),
-                                    }),
-                                    SampleFormat::F32 => UnknownTypeOutputBuffer::F32(::OutputBuffer {
-                                        buffer: cast_output_buffer(&mut stream.buffer),
-                                    }),
-                                };
-
-                                let stream_data = StreamData::Output {
-                                    buffer: output_buffer,
-                                };
-                                callback(stream.id, Ok(stream_data));
-                            }
-                            loop {
-                                let result = alsa::snd_pcm_writei(
-                                    stream.channel,
-                                    stream.buffer.as_ptr() as *const _,
-                                    available_frames as alsa::snd_pcm_uframes_t,
-                                );
-
-                                if result as i32 == -libc::EPIPE {
-                                    // buffer underrun
-                                    // TODO: Notify the user of this.
-                                    alsa::snd_pcm_recover(stream.channel, result as i32, 0);
-                                } else if let Err(err) = check_errors(result as _) {
-                                    let description = format!("`snd_pcm_writei` failed: {}", err);
-                                    let err = BackendSpecificError { description };
-                                    streams_to_remove.push((stream.id, err.into()));
-                                    continue;
-                                } else if result as usize != available_frames {
-                                    let description = format!(
-                                        "unexpected number of frames written: expected {}, \
-                                        result {} (this should never happen)",
-                                        available_frames,
-                                        result,
-                                    );
-                                    let err = BackendSpecificError { description };
-                                    streams_to_remove.push((stream.id, err.into()));
-                                    continue;
-                                } else {
-                                    break;
-                                }
-                            }
-                        },
-                    }
-                }
-
-                // Remove any streams that have errored and notify the user.
-                for (stream_id, err) in streams_to_remove {
-                    run_context.streams.retain(|s| s.id != stream_id);
-                    callback(stream_id, Err(err.into()));
-                }
-            }
-        }
-
-        panic!("`cpal::EventLoop::run` API currently disallows returning");
-    }
-
-    fn build_input_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
-        unsafe {
-            let name = ffi::CString::new(device.0.clone()).expect("unable to clone device");
-
-            let mut capture_handle = ptr::null_mut();
-            match alsa::snd_pcm_open(
-                &mut capture_handle,
-                name.as_ptr(),
-                alsa::SND_PCM_STREAM_CAPTURE,
-                alsa::SND_PCM_NONBLOCK,
-            ) {
-                -16 /* determined empirically */ => return Err(BuildStreamError::DeviceNotAvailable),
-                -22 => return Err(BuildStreamError::InvalidArgument),
-                e => if let Err(description) = check_errors(e) {
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-            }
-            let hw_params = HwParams::alloc();
-
-            set_hw_params_from_format(capture_handle, &hw_params, format)
-                .map_err(|description| BackendSpecificError { description })?;
-
-            let can_pause = alsa::snd_pcm_hw_params_can_pause(hw_params.0) == 1;
-
-            let (buffer_len, period_len) = set_sw_params_from_format(capture_handle, format)
-                .map_err(|description| BackendSpecificError { description })?;
-
-            if let Err(desc) = check_errors(alsa::snd_pcm_prepare(capture_handle)) {
-                let description = format!("could not get capture handle: {}", desc);
-                let err = BackendSpecificError { description };
-                return Err(err.into());
-            }
-
-            let num_descriptors = {
-                let num_descriptors = alsa::snd_pcm_poll_descriptors_count(capture_handle);
-                if num_descriptors == 0 {
-                    let description = "poll descriptor count for capture stream was 0".to_string();
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-                num_descriptors as usize
-            };
-
-            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
-            if new_stream_id.0 == usize::max_value() {
-                panic!("number of streams used has overflowed usize");
-            }
-
-            let stream_inner = StreamInner {
-                id: new_stream_id.clone(),
-                channel: capture_handle,
-                sample_format: format.data_type,
-                num_descriptors: num_descriptors,
-                num_channels: format.channels as u16,
-                buffer_len: buffer_len,
-                period_len: period_len,
-                can_pause: can_pause,
-                is_paused: false,
-                resume_trigger: Trigger::new(),
-                buffer: vec![],
-            };
-
-            if let Err(desc) = check_errors(alsa::snd_pcm_start(capture_handle)) {
-                let description = format!("could not start capture stream: {}", desc);
-                let err = BackendSpecificError { description };
-                return Err(err.into());
-            }
-
-            self.push_command(Command::NewStream(stream_inner));
-            Ok(new_stream_id)
-        }
-    }
-
-    fn build_output_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
-        unsafe {
-            let name = ffi::CString::new(device.0.clone()).expect("unable to clone device");
-
-            let mut playback_handle = ptr::null_mut();
-            match alsa::snd_pcm_open(
-                &mut playback_handle,
-                name.as_ptr(),
-                alsa::SND_PCM_STREAM_PLAYBACK,
-                alsa::SND_PCM_NONBLOCK,
-            ) {
-                -16 /* determined empirically */ => return Err(BuildStreamError::DeviceNotAvailable),
-                -22 => return Err(BuildStreamError::InvalidArgument),
-                e => if let Err(description) = check_errors(e) {
-                    let err = BackendSpecificError { description };
-                    return Err(err.into())
-                }
-            }
-            let hw_params = HwParams::alloc();
-
-            set_hw_params_from_format(playback_handle, &hw_params, format)
-                .map_err(|description| BackendSpecificError { description })?;
-
-            let can_pause = alsa::snd_pcm_hw_params_can_pause(hw_params.0) == 1;
-
-            let (buffer_len, period_len) = set_sw_params_from_format(playback_handle, format)
-                .map_err(|description| BackendSpecificError { description })?;
-
-            if let Err(desc) = check_errors(alsa::snd_pcm_prepare(playback_handle)) {
-                let description = format!("could not get playback handle: {}", desc);
-                let err = BackendSpecificError { description };
-                return Err(err.into());
-            }
-
-            let num_descriptors = {
-                let num_descriptors = alsa::snd_pcm_poll_descriptors_count(playback_handle);
-                if num_descriptors == 0 {
-                    let description = "poll descriptor count for playback stream was 0".to_string();
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-                num_descriptors as usize
-            };
-
-            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
-            if new_stream_id.0 == usize::max_value() {
-                return Err(BuildStreamError::StreamIdOverflow);
-            }
-
-            let stream_inner = StreamInner {
-                id: new_stream_id.clone(),
-                channel: playback_handle,
-                sample_format: format.data_type,
-                num_descriptors: num_descriptors,
-                num_channels: format.channels as u16,
-                buffer_len: buffer_len,
-                period_len: period_len,
-                can_pause: can_pause,
-                is_paused: false,
-                resume_trigger: Trigger::new(),
-                buffer: vec![],
-            };
-
-            self.push_command(Command::NewStream(stream_inner));
-            Ok(new_stream_id)
-        }
-    }
-
-    #[inline]
-    fn push_command(&self, command: Command) {
-        // Safe to unwrap: sender outlives receiver.
-        self.commands.send(command).unwrap();
-        self.pending_command_trigger.wakeup();
-    }
-
-    #[inline]
-    fn destroy_stream(&self, stream_id: StreamId) {
-        self.push_command(Command::DestroyStream(stream_id));
-    }
-
-    #[inline]
-    fn play_stream(&self, stream_id: StreamId) -> Result<(), PlayStreamError> {
-        self.push_command(Command::PlayStream(stream_id));
-        Ok(())
-    }
-
-    #[inline]
-    fn pause_stream(&self, stream_id: StreamId) -> Result<(), PauseStreamError> {
-        self.push_command(Command::PauseStream(stream_id));
-        Ok(())
-    }
+    /// Used to signal to stop processing.
+    trigger: TriggerSender,
 }
 
-// Process any pending `Command`s within the `RunContext`'s queue.
-fn process_commands(run_context: &mut RunContext) {
-    for command in run_context.commands.try_iter() {
-        match command {
-            Command::DestroyStream(stream_id) => {
-                run_context.streams.retain(|s| s.id != stream_id);
-            },
-            Command::PlayStream(stream_id) => {
-                if let Some(stream) = run_context.streams.iter_mut()
-                    .find(|stream| stream.can_pause && stream.id == stream_id)
-                {
-                    unsafe {
-                        alsa::snd_pcm_pause(stream.channel, 0);
-                    }
-                    stream.is_paused = false;
-                }
-            },
-            Command::PauseStream(stream_id) => {
-                if let Some(stream) = run_context.streams.iter_mut()
-                    .find(|stream| stream.can_pause && stream.id == stream_id)
-                {
-                    unsafe {
-                        alsa::snd_pcm_pause(stream.channel, 1);
-                    }
-                    stream.is_paused = true;
-                }
-            },
-            Command::NewStream(stream_inner) => {
-                run_context.streams.push(stream_inner);
-            },
-        }
-    }
-}
+/// The inner body of the audio processing thread. Takes the polymorphic
+/// callback to avoid generating too much generic code.
+fn stream_worker(rx: TriggerReceiver, stream: &StreamInner, callback: &mut (dyn FnMut(StreamDataResult) + Send + 'static)) {
+    let mut descriptors = Vec::new();
+    let mut buffer = Vec::new();
+    loop {
+        descriptors.clear();
+        // Add the self-pipe for signaling termination.
+        descriptors.push(libc::pollfd {
+            fd: rx.0,
+            events: libc::POLLIN,
+            revents: 0,
+        });
 
-// Resets the descriptors so that only `pending_command_trigger.read_fd()` is contained.
-fn reset_descriptors_with_pending_command_trigger(
-    descriptors: &mut Vec<libc::pollfd>,
-    pending_command_trigger: &Trigger,
-) {
-    descriptors.clear();
-    descriptors.push(libc::pollfd {
-        fd: pending_command_trigger.read_fd(),
-        events: libc::POLLIN,
-        revents: 0,
-    });
-}
-
-// Appends the `poll` descriptors for each stream onto the `RunContext`'s descriptor slice, ready
-// for a call to `libc::poll`.
-fn append_stream_poll_descriptors(run_context: &mut RunContext) {
-    for stream in run_context.streams.iter() {
-        run_context.descriptors.reserve(stream.num_descriptors);
-        let len = run_context.descriptors.len();
+        // Add ALSA polling fds.
+        descriptors.reserve(stream.num_descriptors);
+        let len = descriptors.len();
         let filled = unsafe {
             alsa::snd_pcm_poll_descriptors(
                 stream.channel,
-                run_context.descriptors.as_mut_ptr().offset(len as isize),
+                descriptors[len..].as_mut_ptr(),
                 stream.num_descriptors as libc::c_uint,
             )
         };
         debug_assert_eq!(filled, stream.num_descriptors as libc::c_int);
         unsafe {
-            run_context.descriptors.set_len(len + stream.num_descriptors);
+            descriptors.set_len(len + stream.num_descriptors);
+        }
+
+        let res = unsafe {
+            // Don't timeout, wait forever.
+            libc::poll(descriptors.as_mut_ptr(), descriptors.len() as libc::nfds_t, -1)
+        };
+        if res < 0 {
+            let description = format!("`libc::poll()` failed: {}", io::Error::last_os_error());
+            callback(Err(BackendSpecificError { description }.into()));
+            continue;
+        } else if res == 0 {
+            let description = String::from("`libc::poll()` spuriously returned");
+            callback(Err(BackendSpecificError { description }.into()));
+            continue;
+        }
+
+        if descriptors[0].revents != 0 {
+            // The stream has been requested to be destroyed.
+            rx.clear_pipe();
+            return;
+        }
+
+        let stream_type = match check_for_pollout_or_pollin(stream, descriptors[1..].as_mut_ptr()) {
+            Ok(Some(ty)) => ty,
+            Ok(None) => {
+                // Nothing to process, poll again
+                continue;
+            },
+            Err(err) => {
+                // TODO: signal errors
+                continue;
+            }
+        };
+        // Get the number of available samples for reading/writing.
+        let available_samples = match get_available_samples(stream) {
+            Ok(n) => n,
+            Err(err) => {
+                let description = format!("Failed to query the number of available samples: {}", err);
+                callback(Err(BackendSpecificError { description }.into()));
+                continue;
+            }
+        };
+
+        // Only go on if there is at least `stream.period_len` samples.
+        if available_samples < stream.period_len {
+            continue;
+        }
+
+        // Prepare the data buffer.
+        let buffer_size = stream.sample_format.sample_size() * available_samples;
+        buffer.resize(buffer_size, 0u8);
+        let available_frames = available_samples / stream.num_channels as usize;
+
+        match stream_type {
+            StreamType::Input => {
+                let result = unsafe {
+                    alsa::snd_pcm_readi(
+                        stream.channel,
+                        buffer.as_mut_ptr() as *mut _,
+                        available_frames as alsa::snd_pcm_uframes_t,
+                    )
+                };
+                if let Err(err) = check_errors(result as _) {
+                    let description = format!("`snd_pcm_readi` failed: {}", err);
+                    callback(Err(BackendSpecificError { description }.into()));
+                    continue;
+                }
+
+                let input_buffer = match stream.sample_format {
+                    SampleFormat::I16 => UnknownTypeInputBuffer::I16(::InputBuffer {
+                        buffer: unsafe { cast_input_buffer(&mut buffer) },
+                    }),
+                    SampleFormat::U16 => UnknownTypeInputBuffer::U16(::InputBuffer {
+                        buffer: unsafe { cast_input_buffer(&mut buffer) },
+                    }),
+                    SampleFormat::F32 => UnknownTypeInputBuffer::F32(::InputBuffer {
+                        buffer: unsafe { cast_input_buffer(&mut buffer) },
+                    }),
+                };
+                let stream_data = StreamData::Input {
+                    buffer: input_buffer,
+                };
+                callback(Ok(stream_data));
+            },
+            StreamType::Output => {
+                {
+                    // We're now sure that we're ready to write data.
+                    let output_buffer = match stream.sample_format {
+                        SampleFormat::I16 => UnknownTypeOutputBuffer::I16(::OutputBuffer {
+                            buffer: unsafe { cast_output_buffer(&mut buffer) },
+                        }),
+                        SampleFormat::U16 => UnknownTypeOutputBuffer::U16(::OutputBuffer {
+                            buffer: unsafe { cast_output_buffer(&mut buffer) },
+                        }),
+                        SampleFormat::F32 => UnknownTypeOutputBuffer::F32(::OutputBuffer {
+                            buffer: unsafe { cast_output_buffer(&mut buffer) },
+                        }),
+                    };
+
+                    let stream_data = StreamData::Output {
+                        buffer: output_buffer,
+                    };
+                    callback(Ok(stream_data));
+                }
+                loop {
+                    let result = unsafe {
+                        alsa::snd_pcm_writei(
+                            stream.channel,
+                            buffer.as_ptr() as *const _,
+                            available_frames as alsa::snd_pcm_uframes_t,
+                        )
+                    };
+
+                    if result == -libc::EPIPE as i64 {
+                        // buffer underrun
+                        // TODO: Notify the user of this.
+                        unsafe { alsa::snd_pcm_recover(stream.channel, result as i32, 0) };
+                    } else if let Err(err) = check_errors(result as _) {
+                        let description = format!("`snd_pcm_writei` failed: {}", err);
+                        callback(Err(BackendSpecificError { description }.into()));
+                        continue;
+                    } else if result as usize != available_frames {
+                        let description = format!(
+                            "unexpected number of frames written: expected {}, \
+                                        result {} (this should never happen)",
+                            available_frames,
+                            result,
+                        );
+                        callback(Err(BackendSpecificError { description }.into()));
+                        continue;
+                    } else {
+                        break;
+                    }
+                }
+            },
         }
     }
 }
 
-// Poll all descriptors within the given set.
-//
-// Returns `Ok(true)` if some event has occurred or `Ok(false)` if no events have
-// occurred.
-//
-// Returns an `Err` if `libc::poll` returns a negative value for some reason.
-fn poll_all_descriptors(descriptors: &mut [libc::pollfd]) -> Result<bool, BackendSpecificError> {
-    let res = unsafe {
-        // Don't timeout, wait forever.
-        libc::poll(descriptors.as_mut_ptr(), descriptors.len() as libc::nfds_t, -1)
-    };
-    if res < 0 {
-        let description = format!("`libc::poll()` failed: {}", res);
-        Err(BackendSpecificError { description })
-    } else if res == 0 {
-        Ok(false)
-    } else {
-        Ok(true)
+impl Stream {
+    fn new<F>(inner: Arc<StreamInner>, mut callback: F) -> Stream where F: FnMut(StreamDataResult) + Send + 'static {
+        let (tx, rx) = trigger();
+        // Clone the handle for passing into worker thread.
+        let stream = inner.clone();
+        let thread = thread::spawn(move || {
+            stream_worker(rx, &*stream, &mut callback);
+        });
+        Stream {
+            thread: Some(thread),
+            inner,
+            trigger: tx,
+        }
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        self.trigger.wakeup();
+        self.thread.take().unwrap().join().unwrap();
+    }
+}
+
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        unsafe {
+            alsa::snd_pcm_pause(self.inner.channel, 0);
+        }
+        // TODO: error handling
+        Ok(())
+    }
+    fn pause(&self)-> Result<(), PauseStreamError> {
+        unsafe {
+            alsa::snd_pcm_pause(self.inner.channel, 1);
+        }
+        // TODO: error handling
+        Ok(())
     }
 }
 

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -77,13 +77,13 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    fn build_input_stream<D, E>(&self, _format: &Format, _data_callback: D, _error_callback: E) -> Result<Self::Stream, BuildStreamError>
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         unimplemented!()
     }
 
     /// Create an output stream.
-    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    fn build_output_stream<D, E>(&self, _format: &Format, _data_callback: D, _error_callback: E) -> Result<Self::Stream, BuildStreamError>
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static{
         unimplemented!()
     }

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -10,7 +10,7 @@ use PlayStreamError;
 use StreamDataResult;
 use SupportedFormatsError;
 use SupportedFormat;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 #[derive(Default)]
 pub struct Devices;
@@ -23,7 +23,7 @@ pub struct EventLoop;
 pub struct Host;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamId;
+pub struct Stream;
 
 pub struct SupportedInputFormats;
 pub struct SupportedOutputFormats;
@@ -49,6 +49,7 @@ impl EventLoop {
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     #[inline]
     fn name(&self) -> Result<String, DeviceNameError> {
@@ -74,49 +75,22 @@ impl DeviceTrait for Device {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         unimplemented!()
     }
-}
 
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    #[inline]
-    fn run<F>(&self, _callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult)
-    {
-        loop { /* TODO: don't spin */ }
-    }
-
-    #[inline]
-    fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
-        Err(BuildStreamError::DeviceNotAvailable)
-    }
-
-    #[inline]
-    fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
-        Err(BuildStreamError::DeviceNotAvailable)
-    }
-
-    #[inline]
-    fn destroy_stream(&self, _: StreamId) {
+    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
+        where F: FnMut(StreamDataResult) + Send + 'static {
         unimplemented!()
     }
 
-    #[inline]
-    fn play_stream(&self, _: StreamId) -> Result<(), PlayStreamError> {
-        panic!()
-    }
-
-    #[inline]
-    fn pause_stream(&self, _: StreamId) -> Result<(), PauseStreamError> {
-        panic!()
+    /// Create an output stream.
+    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
+        where F: FnMut(StreamDataResult) + Send + 'static{
+        unimplemented!()
     }
 }
 
 impl HostTrait for Host {
     type Device = Device;
     type Devices = Devices;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         false
@@ -133,13 +107,17 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Device> {
         None
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
 
-impl StreamIdTrait for StreamId {}
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        unimplemented!()
+    }
+
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        unimplemented!()
+    }
+}
 
 impl Iterator for Devices {
     type Item = Device;

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -7,7 +7,8 @@ use DeviceNameError;
 use Format;
 use PauseStreamError;
 use PlayStreamError;
-use StreamDataResult;
+use StreamData;
+use StreamError;
 use SupportedFormatsError;
 use SupportedFormat;
 use traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -76,14 +77,14 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static {
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         unimplemented!()
     }
 
     /// Create an output stream.
-    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static{
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static{
         unimplemented!()
     }
 }

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -3,8 +3,8 @@
 use super::check_result;
 use std::ptr;
 
-use super::winapi::um::objbase::{COINIT_MULTITHREADED};
 use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
+use super::winapi::um::objbase::COINIT_MULTITHREADED;
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -336,7 +336,7 @@ unsafe fn format_from_waveformatex_ptr(
     let format = Format {
         channels: (*waveformatex_ptr).nChannels as _,
         sample_rate: SampleRate((*waveformatex_ptr).nSamplesPerSec),
-        data_type: data_type,
+        data_type,
     };
     Some(format)
 }
@@ -400,7 +400,7 @@ impl Device {
     #[inline]
     fn from_immdevice(device: *mut IMMDevice) -> Self {
         Device {
-            device: device,
+            device,
             future_audio_client: Arc::new(Mutex::new(None)),
         }
     }
@@ -763,15 +763,15 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             {
                 let client_flow = AudioClientFlow::Capture {
-                    capture_client: capture_client,
+                    capture_client,
                 };
                 let inner = StreamInner {
                     id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
+                    audio_client,
+                    client_flow,
+                    event,
                     playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
+                    max_frames_in_buffer,
                     bytes_per_frame: waveformatex.nBlockAlign,
                     sample_format: format.data_type,
                 };
@@ -924,15 +924,15 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             {
                 let client_flow = AudioClientFlow::Render {
-                    render_client: render_client,
+                    render_client,
                 };
                 let inner = StreamInner {
                     id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
+                    audio_client,
+                    client_flow,
+                    event,
                     playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
+                    max_frames_in_buffer,
                     bytes_per_frame: waveformatex.nBlockAlign,
                     sample_format: format.data_type,
                 };
@@ -1039,7 +1039,7 @@ impl From<*const IMMDevice> for Endpoint {
     fn from(device: *const IMMDevice) -> Self {
         unsafe {
             let endpoint = immendpoint_from_immdevice(device);
-            Endpoint { endpoint: endpoint }
+            Endpoint { endpoint }
         }
     }
 }
@@ -1118,7 +1118,7 @@ impl Devices {
             check_result_backend_specific((*collection).GetCount(&mut count))?;
 
             Ok(Devices {
-                collection: collection,
+                collection,
                 total_count: count,
                 next_item: 0,
             })

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::ffi::OsStringExt;
 use std::ptr;
 use std::slice;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, atomic::Ordering};
 
 use BackendSpecificError;
 use DefaultFormatError;
@@ -33,6 +33,7 @@ use super::winapi::shared::guiddef::{
 use super::winapi::shared::winerror;
 use super::winapi::shared::minwindef::{
     DWORD,
+    WORD,
 };
 use super::winapi::shared::mmreg;
 use super::winapi::shared::wtypes;
@@ -41,12 +42,14 @@ use super::winapi::um::winnt::LPWSTR;
 use super::winapi::um::winnt::WCHAR;
 use super::winapi::um::coml2api;
 use super::winapi::um::audioclient::{
+    self,
     IAudioClient,
     IID_IAudioClient,
     AUDCLNT_E_DEVICE_INVALIDATED,
 };
 use super::winapi::um::audiosessiontypes::{
     AUDCLNT_SHAREMODE_SHARED,
+    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
 };
 use super::winapi::um::combaseapi::{
     CoCreateInstance,
@@ -68,7 +71,8 @@ use super::winapi::um::mmdeviceapi::{
     IMMEndpoint,
 };
 
-use crate::traits::DeviceTrait;
+use crate::{traits::DeviceTrait, BuildStreamError, StreamData, StreamError};
+use super::{stream::{Stream, AudioClientFlow, StreamInner, Command}, winapi::um::synchapi};
 
 pub type SupportedInputFormats = std::vec::IntoIter<SupportedFormat>;
 pub type SupportedOutputFormats = std::vec::IntoIter<SupportedFormat>;
@@ -111,6 +115,24 @@ impl DeviceTrait for Device {
 
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         Device::default_output_format(self)
+    }
+
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(
+            Arc::new(self.build_input_stream_inner(format)?),
+            data_callback,
+            error_callback,
+        ))
+    }
+
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(
+            Arc::new(self.build_output_stream_inner(format)?),
+            data_callback,
+            error_callback,
+        ))
     }
 }
 
@@ -600,6 +622,327 @@ impl Device {
             Err(DefaultFormatError::StreamTypeNotSupported)
         }
     }
+    
+    pub(crate) fn build_input_stream_inner(
+        &self,
+        format: &Format,
+    ) -> Result<Stream, BuildStreamError>
+    {
+        unsafe {
+            // Making sure that COM is initialized.
+            // It's not actually sure that this is required, but when in doubt do it.
+            com::com_initialized();
+
+            // Obtaining a `IAudioClient`.
+            let audio_client = match self.build_audioclient() {
+                Ok(client) => client,
+                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
+                    return Err(BuildStreamError::DeviceNotAvailable),
+                Err(e) => {
+                    let description = format!("{}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+            };
+
+            // Computing the format and initializing the device.
+            let waveformatex = {
+                let format_attempt = format_to_waveformatextensible(format)
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                let share_mode = AUDCLNT_SHAREMODE_SHARED;
+
+                // Ensure the format is supported.
+                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
+                    _ => (),
+                }
+
+                // finally initializing the audio client
+                let hresult = (*audio_client).Initialize(
+                    share_mode,
+                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                    0,
+                    0,
+                    &format_attempt.Format,
+                    ptr::null(),
+                );
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                format_attempt.Format
+            };
+
+            // obtaining the size of the samples buffer in number of frames
+            let max_frames_in_buffer = {
+                let mut max_frames_in_buffer = mem::uninitialized();
+                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                max_frames_in_buffer
+            };
+
+            // Creating the event that will be signalled whenever we need to submit some samples.
+            let event = {
+                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
+                if event == ptr::null_mut() {
+                    (*audio_client).Release();
+                    let description = format!("failed to create event");
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                if let Err(e) = check_result((*audio_client).SetEventHandle(event)) {
+                    (*audio_client).Release();
+                    let description = format!("failed to call SetEventHandle: {}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                event
+            };
+
+            // Building a `IAudioCaptureClient` that will be used to read captured samples.
+            let capture_client = {
+                let mut capture_client: *mut audioclient::IAudioCaptureClient = mem::uninitialized();
+                let hresult = (*audio_client).GetService(
+                    &audioclient::IID_IAudioCaptureClient,
+                    &mut capture_client as *mut *mut audioclient::IAudioCaptureClient as *mut _,
+                );
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to build capture client: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                &mut *capture_client
+            };
+
+            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
+            if new_stream_id.0 == usize::max_value() {
+                return Err(BuildStreamError::StreamIdOverflow);
+            }
+
+            // Once we built the `StreamInner`, we add a command that will be picked up by the
+            // `run()` method and added to the `RunContext`.
+            {
+                let client_flow = AudioClientFlow::Capture {
+                    capture_client: capture_client,
+                };
+                let inner = StreamInner {
+                    id: new_stream_id.clone(),
+                    audio_client: audio_client,
+                    client_flow: client_flow,
+                    event: event,
+                    playing: false,
+                    max_frames_in_buffer: max_frames_in_buffer,
+                    bytes_per_frame: waveformatex.nBlockAlign,
+                    sample_format: format.data_type,
+                };
+
+                self.push_command(Command::NewStream(inner));
+            };
+
+            Ok(new_stream_id)
+        }
+    }
+
+    pub(crate) fn build_output_stream_inner(
+        &self,
+        format: &Format,
+    ) -> Result<Stream, BuildStreamError>
+    {
+        unsafe {
+            // Making sure that COM is initialized.
+            // It's not actually sure that this is required, but when in doubt do it.
+            com::com_initialized();
+
+            // Obtaining a `IAudioClient`.
+            let audio_client = match self.build_audioclient() {
+                Ok(client) => client,
+                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
+                    return Err(BuildStreamError::DeviceNotAvailable),
+                Err(e) => {
+                    let description = format!("{}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+            };
+
+            // Computing the format and initializing the device.
+            let waveformatex = {
+                let format_attempt = format_to_waveformatextensible(format)
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                let share_mode = AUDCLNT_SHAREMODE_SHARED;
+
+                // Ensure the format is supported.
+                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
+                    _ => (),
+                }
+
+                // finally initializing the audio client
+                let hresult = (*audio_client).Initialize(share_mode,
+                                                         AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                                                         0,
+                                                         0,
+                                                         &format_attempt.Format,
+                                                         ptr::null());
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                format_attempt.Format
+            };
+
+            // Creating the event that will be signalled whenever we need to submit some samples.
+            let event = {
+                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
+                if event == ptr::null_mut() {
+                    (*audio_client).Release();
+                    let description = format!("failed to create event");
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                match check_result((*audio_client).SetEventHandle(event)) {
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to call SetEventHandle: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(_) => (),
+                };
+
+                event
+            };
+
+            // obtaining the size of the samples buffer in number of frames
+            let max_frames_in_buffer = {
+                let mut max_frames_in_buffer = mem::uninitialized();
+                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to obtain buffer size: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                max_frames_in_buffer
+            };
+
+            // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
+            let render_client = {
+                let mut render_client: *mut audioclient::IAudioRenderClient = mem::uninitialized();
+                let hresult = (*audio_client).GetService(&audioclient::IID_IAudioRenderClient,
+                                                         &mut render_client as
+                                                             *mut *mut audioclient::IAudioRenderClient as
+                                                             *mut _);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to build render client: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                &mut *render_client
+            };
+
+            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
+            if new_stream_id.0 == usize::max_value() {
+                return Err(BuildStreamError::StreamIdOverflow);
+            }
+
+            // Once we built the `StreamInner`, we add a command that will be picked up by the
+            // `run()` method and added to the `RunContext`.
+            {
+                let client_flow = AudioClientFlow::Render {
+                    render_client: render_client,
+                };
+                let inner = StreamInner {
+                    id: new_stream_id.clone(),
+                    audio_client: audio_client,
+                    client_flow: client_flow,
+                    event: event,
+                    playing: false,
+                    max_frames_in_buffer: max_frames_in_buffer,
+                    bytes_per_frame: waveformatex.nBlockAlign,
+                    sample_format: format.data_type,
+                };
+
+                self.push_command(Command::NewStream(inner));
+            };
+
+            Ok(new_stream_id)
+        }
+    }
 }
 
 impl PartialEq for Device {
@@ -841,4 +1184,59 @@ pub fn default_input_device() -> Option<Device> {
 
 pub fn default_output_device() -> Option<Device> {
     default_device(eRender)
+}
+
+
+// Turns a `Format` into a `WAVEFORMATEXTENSIBLE`.
+//
+// Returns `None` if the WAVEFORMATEXTENSIBLE does not support the given format.
+fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEXTENSIBLE> {
+    let format_tag = match format.data_type {
+        SampleFormat::I16 => mmreg::WAVE_FORMAT_PCM,
+        SampleFormat::F32 => mmreg::WAVE_FORMAT_EXTENSIBLE,
+        SampleFormat::U16 => return None,
+    };
+    let channels = format.channels as WORD;
+    let sample_rate = format.sample_rate.0 as DWORD;
+    let sample_bytes = format.data_type.sample_size() as WORD;
+    let avg_bytes_per_sec = channels as DWORD * sample_rate * sample_bytes as DWORD;
+    let block_align = channels * sample_bytes;
+    let bits_per_sample = 8 * sample_bytes;
+    let cb_size = match format.data_type {
+        SampleFormat::I16 => 0,
+        SampleFormat::F32 => {
+            let extensible_size = mem::size_of::<mmreg::WAVEFORMATEXTENSIBLE>();
+            let ex_size = mem::size_of::<mmreg::WAVEFORMATEX>();
+            (extensible_size - ex_size) as WORD
+        },
+        SampleFormat::U16 => return None,
+    };
+    let waveformatex = mmreg::WAVEFORMATEX {
+        wFormatTag: format_tag,
+        nChannels: channels,
+        nSamplesPerSec: sample_rate,
+        nAvgBytesPerSec: avg_bytes_per_sec,
+        nBlockAlign: block_align,
+        wBitsPerSample: bits_per_sample,
+        cbSize: cb_size,
+    };
+
+    // CPAL does not care about speaker positions, so pass audio straight through.
+    // TODO: This constant should be defined in winapi but is missing.
+    const KSAUDIO_SPEAKER_DIRECTOUT: DWORD = 0;
+    let channel_mask = KSAUDIO_SPEAKER_DIRECTOUT;
+
+    let sub_format = match format.data_type {
+        SampleFormat::I16 => ksmedia::KSDATAFORMAT_SUBTYPE_PCM,
+        SampleFormat::F32 => ksmedia::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT,
+        SampleFormat::U16 => return None,
+    };
+    let waveformatextensible = mmreg::WAVEFORMATEXTENSIBLE {
+        Format: waveformatex,
+        Samples: bits_per_sample as WORD,
+        dwChannelMask: channel_mask,
+        SubFormat: sub_format,
+    };
+
+    Some(waveformatextensible)
 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -358,8 +358,7 @@ impl Device {
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }
-            let ptr_usize: usize = *(&property_value.data as *const _ as *const usize);
-            let ptr_utf16 = ptr_usize as *const u16;
+            let ptr_utf16 = *(&property_value.data as *const _ as *const (*const u16));
 
             // Find the length of the friendly name.
             let mut len = 0;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -113,7 +113,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         Ok(Stream::new(
-            Arc::new(self.build_input_stream_inner(format)?),
+            self.build_input_stream_inner(format)?,
             data_callback,
             error_callback,
         ))
@@ -130,7 +130,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         Ok(Stream::new(
-            Arc::new(self.build_output_stream_inner(format)?),
+            self.build_output_stream_inner(format)?,
             data_callback,
             error_callback,
         ))

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -68,6 +68,8 @@ use super::winapi::um::mmdeviceapi::{
     IMMEndpoint,
 };
 
+use crate::traits::DeviceTrait;
+
 pub type SupportedInputFormats = std::vec::IntoIter<SupportedFormat>;
 pub type SupportedOutputFormats = std::vec::IntoIter<SupportedFormat>;
 
@@ -85,6 +87,31 @@ pub struct Device {
     /// We cache an uninitialized `IAudioClient` so that we can call functions from it without
     /// having to create/destroy audio clients all the time.
     future_audio_client: Arc<Mutex<Option<IAudioClientWrapper>>>, // TODO: add NonZero around the ptr
+}
+
+impl DeviceTrait for Device {
+    type SupportedInputFormats = SupportedInputFormats;
+    type SupportedOutputFormats = SupportedOutputFormats;
+
+    fn name(&self) -> Result<String, DeviceNameError> {
+        Device::name(self)
+    }
+
+    fn supported_input_formats(&self) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
+        Device::supported_input_formats(self)
+    }
+
+    fn supported_output_formats(&self) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
+        Device::supported_output_formats(self)
+    }
+
+    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+        Device::default_input_format(self)
+    }
+
+    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+        Device::default_output_format(self)
+    }
 }
 
 struct Endpoint {

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -96,6 +96,7 @@ pub struct Device {
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -6,7 +6,7 @@ use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
 use traits::{HostTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::{StreamId};
+pub use self::stream::Stream;
 
 mod com;
 mod device;

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,12 +1,15 @@
 extern crate winapi;
 
-use BackendSpecificError;
-use DevicesError;
+pub use self::device::{
+    default_input_device, default_output_device, Device, Devices, SupportedInputFormats,
+    SupportedOutputFormats,
+};
+pub use self::stream::Stream;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{HostTrait};
-pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::Stream;
+use traits::HostTrait;
+use BackendSpecificError;
+use DevicesError;
 
 mod com;
 mod device;
@@ -56,10 +59,8 @@ fn check_result(result: HRESULT) -> Result<(), IoError> {
 fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificError> {
     match check_result(result) {
         Ok(()) => Ok(()),
-        Err(err) => {
-            Err(BackendSpecificError { 
-                description: format!("{}", err),
-            })
-        }
+        Err(err) => Err(BackendSpecificError {
+            description: format!("{}", err),
+        }),
     }
 }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,20 +1,12 @@
 extern crate winapi;
 
 use BackendSpecificError;
-use BuildStreamError;
-use DefaultFormatError;
-use DeviceNameError;
 use DevicesError;
-use Format;
-use PlayStreamError;
-use PauseStreamError;
-use StreamDataResult;
-use SupportedFormatsError;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{HostTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::{EventLoop, StreamId};
+pub use self::stream::{StreamId};
 
 mod com;
 mod device;
@@ -33,7 +25,6 @@ impl Host {
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         // Assume WASAPI is always available on windows.
@@ -51,53 +42,7 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
-
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    fn build_input_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_input_stream(self, device, format)
-    }
-
-    fn build_output_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_output_stream(self, device, format)
-    }
-
-    fn play_stream(&self, stream: Self::StreamId) -> Result<(), PlayStreamError> {
-        EventLoop::play_stream(self, stream)
-    }
-
-    fn pause_stream(&self, stream: Self::StreamId) -> Result<(), PauseStreamError> {
-        EventLoop::pause_stream(self, stream)
-    }
-
-    fn destroy_stream(&self, stream: Self::StreamId) {
-        EventLoop::destroy_stream(self, stream)
-    }
-
-    fn run<F>(&self, callback: F) -> !
-    where
-        F: FnMut(Self::StreamId, StreamDataResult) + Send,
-    {
-        EventLoop::run(self, callback)
-    }
-}
-
-impl StreamIdTrait for StreamId {}
 
 #[inline]
 fn check_result(result: HRESULT) -> Result<(), IoError> {

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -12,7 +12,7 @@ use StreamDataResult;
 use SupportedFormatsError;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{EventLoopTrait, HostTrait, StreamIdTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
 pub use self::stream::{EventLoop, StreamId};
 
@@ -54,31 +54,6 @@ impl HostTrait for Host {
 
     fn event_loop(&self) -> Self::EventLoop {
         EventLoop::new()
-    }
-}
-
-impl DeviceTrait for Device {
-    type SupportedInputFormats = SupportedInputFormats;
-    type SupportedOutputFormats = SupportedOutputFormats;
-
-    fn name(&self) -> Result<String, DeviceNameError> {
-        Device::name(self)
-    }
-
-    fn supported_input_formats(&self) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
-        Device::supported_input_formats(self)
-    }
-
-    fn supported_output_formats(&self) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
-        Device::supported_output_formats(self)
-    }
-
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_input_format(self)
-    }
-
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_output_format(self)
     }
 }
 

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -57,8 +57,9 @@ fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificE
     match check_result(result) {
         Ok(()) => Ok(()),
         Err(err) => {
-            let description = format!("{}", err);
-            return Err(BackendSpecificError { description });
+            Err(BackendSpecificError { 
+                description: format!("{}", err),
+            })
         }
     }
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -148,12 +148,17 @@ impl EventLoop {
     }
 }
 
-impl Drop for EventLoop {
+impl Drop for Stream {
     #[inline]
     fn drop(&mut self) {
         unsafe {
             handleapi::CloseHandle(self.pending_scheduled_event);
         }
+        unsafe { 
+            let result = synchapi::SetEvent(self.pending_scheduled_event); 
+            assert!(result != 0); 
+        }
+        self.thread.take().unwrap().join().unwrap();
     }
 }
 

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -224,7 +224,6 @@ fn wait_for_handle_signal(handles: &[winnt::HANDLE]) -> Result<usize, BackendSpe
         return Err(err);
     }
     // Notifying the corresponding task handler.
-    debug_assert!(result >= winbase::WAIT_OBJECT_0);
     let handle_idx = (result - winbase::WAIT_OBJECT_0) as usize;
     Ok(handle_idx)
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,9 +1,6 @@
 use super::check_result;
-use super::com;
 use super::winapi::shared::basetsd::UINT32;
-use super::winapi::shared::ksmedia;
-use super::winapi::shared::minwindef::{BYTE, DWORD, FALSE, WORD};
-use super::winapi::shared::mmreg;
+use super::winapi::shared::minwindef::{BYTE, FALSE, WORD};
 use super::winapi::um::audioclient::{self, AUDCLNT_E_DEVICE_INVALIDATED, AUDCLNT_S_BUFFER_EMPTY};
 use super::winapi::um::handleapi;
 use super::winapi::um::synchapi;
@@ -13,17 +10,13 @@ use super::winapi::um::winnt;
 use std::mem;
 use std::ptr;
 use std::slice;
-use std::sync::Mutex;
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::sync::atomic::AtomicUsize;
 
 use std::{sync::{Arc},
 thread::{self, JoinHandle}};
 use crate::traits::StreamTrait;
 
 use BackendSpecificError;
-use BuildStreamError;
-use Format;
 use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
@@ -257,7 +250,7 @@ fn stream_error_from_hresult(hresult: winnt::HRESULT) -> Result<(), StreamError>
     Ok(())
 }
 
-fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) -> () {
+fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) {
     unsafe {
         'stream_loop: loop {
             // Process queued commands.

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -87,14 +87,14 @@ pub (crate) struct StreamInner {
 }
 
 impl Stream {
-    fn new<D, E>(stream_inner: Arc<StreamInner>, mut data_callback: D, mut error_callback: E) -> Stream
+    pub (crate) fn new<D, E>(stream_inner: Arc<StreamInner>, mut data_callback: D, mut error_callback: E) -> Stream
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         let pending_scheduled_event =
             unsafe { synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null()) };
         let (tx, rx) = channel();
 
         let run_context = RunContext {
-            stream: Arc::new(stream_inner),
+            stream: stream_inner,
             handles: vec![pending_scheduled_event],
             commands: rx,
         };

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -66,10 +66,8 @@ struct RunContext {
 }
 
 enum Command {
-    NewStream(StreamInner),
-    DestroyStream(StreamId),
-    PlayStream(StreamId),
-    PauseStream(StreamId),
+    PlayStream,
+    PauseStream,
 }
 
 enum AudioClientFlow {
@@ -568,75 +566,38 @@ fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEX
 }
 
 // Process any pending commands that are queued within the `RunContext`.
-fn process_commands(
-    run_context: &mut RunContext,
-    callback: &mut dyn FnMut(StreamId, StreamData),
-) {
+fn process_commands(run_context: &mut RunContext) -> Result<(), StreamError> {
     // Process the pending commands.
     for command in run_context.commands.try_iter() {
         match command {
-            Command::NewStream(stream_inner) => {
-                let event = stream_inner.event;
-                run_context.stream.push(stream_inner);
-                run_context.handles.push(event);
-            },
-            Command::DestroyStream(stream_id) => {
-                match run_context.stream.iter().position(|s| s.id == stream_id) {
-                    None => continue,
-                    Some(p) => {
-                        run_context.handles.remove(p + 1);
-                        run_context.stream.remove(p);
-                    },
-                }
-            },
-            Command::PlayStream(stream_id) => {
-                match run_context.stream.iter().position(|s| s.id == stream_id) {
-                    None => continue,
-                    Some(p) => {
-                        if !run_context.stream[p].playing {
-                            let hresult = unsafe {
-                                (*run_context.stream[p].audio_client).Start()
-                            };
-                            match stream_error_from_hresult(hresult) {
-                                Ok(()) => {
-                                    run_context.stream[p].playing = true;
-                                }
-                                Err(err) => {
-                                    callback(stream_id, Err(err.into()));
-                                    run_context.handles.remove(p + 1);
-                                    run_context.stream.remove(p);
-                                }
-                            }
-                        }
+            Command::PlayStream => {
+                if !run_context.stream.playing {
+                    let hresult = unsafe {
+                        (*run_context.stream.audio_client).Start()
+                    };
+
+                    if let Err(err) = stream_error_from_hresult(hresult) {
+                        return Err(err);
                     }
+                    run_context.stream.playing = true;
                 }
             },
-            Command::PauseStream(stream_id) => {
-                match run_context.stream.iter().position(|s| s.id == stream_id) {
-                    None => continue,
-                    Some(p) => {
-                        if run_context.stream[p].playing {
-                            let hresult = unsafe {
-                                (*run_context.stream[p].audio_client).Stop()
-                            };
-                            match stream_error_from_hresult(hresult) {
-                                Ok(()) => {
-                                    run_context.stream[p].playing = false;
-                                }
-                                Err(err) => {
-                                    callback(stream_id, Err(err.into()));
-                                    run_context.handles.remove(p + 1);
-                                    run_context.stream.remove(p);
-                                }
-                            }
-                        }
-                    },
+            Command::PauseStream => {
+                if run_context.stream.playing {
+                    let hresult = unsafe {
+                        (*run_context.stream.audio_client).Stop()
+                    };
+                    if let Err(err) = stream_error_from_hresult(hresult) {
+                        return Err(err);
+                    }
+                    run_context.stream.playing = false;
                 }
             },
         }
     }
-}
 
+    Ok(())
+}
 // Wait for any of the given handles to be signalled.
 //
 // Returns the index of the `handle` that was signalled, or an `Err` if

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -695,43 +695,21 @@ fn stream_error_from_hresult(hresult: winnt::HRESULT) -> Result<(), StreamError>
 
 fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) -> () {
     unsafe {
-        // We keep `run_context` locked forever, which guarantees that two invocations of
-        // `run()` cannot run simultaneously.
-        let mut run_context = self.run_context.lock().unwrap();
-        // Force a deref so that borrow checker can operate on each field independently.
-        // Shadow the name because we don't use (or drop) it otherwise.
-        let run_context = &mut *run_context;
-
-        // Keep track of the set of streams that should be removed due to some error occurring.
-        //
-        // Checked at the start of each loop.
-        let mut streams_to_remove: Vec<(StreamId, StreamError)> = vec![];
-
         'stream_loop: loop {
-            // Remove any failed streams.
-            for (stream_id, err) in streams_to_remove.drain(..) {
-                match run_context.stream.iter().position(|s| s.id == stream_id) {
-                    None => continue,
-                    Some(p) => {
-                        run_context.handles.remove(p + 1);
-                        run_context.stream.remove(p);
-                        callback(stream_id, Err(err.into()));
-                    },
-                }
-            }
-
             // Process queued commands.
-            process_commands(run_context, callback);
+            match process_commands(run_context, error_callback) {
+                Ok(()) => (),
+                Err(err) => {
+                    error_callback(err);
+                    break 'stream_loop;
+                }
+            };
 
             // Wait for any of the handles to be signalled.
             let handle_idx = match wait_for_handle_signal(&run_context.handles) {
                 Ok(idx) => idx,
                 Err(err) => {
-                    for stream in &run_context.stream {
-                        callback(stream.id.clone(), Err(err.clone().into()));
-                    }
-                    run_context.stream.clear();
-                    run_context.handles.truncate(1);
+                    error_callback(err);
                     break 'stream_loop;
                 }
             };
@@ -742,9 +720,7 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                 continue;
             }
 
-            let stream_idx = handle_idx - 1;
-            let stream = &mut run_context.stream[stream_idx];
-
+            let stream = run_context.stream;
             let sample_size = stream.sample_format.sample_size();
 
             // Obtaining a pointer to the buffer.
@@ -758,8 +734,8 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                     loop {
                         let hresult = (*capture_client).GetNextPacketSize(&mut frames_available);
                         if let Err(err) = stream_error_from_hresult(hresult) {
-                            streams_to_remove.push((stream.id.clone(), err));
-                            break; // Identical to continuing the outer loop
+                            error_callback(err);
+                            break 'stream_loop;
                         }
                         if frames_available == 0 {
                             break;
@@ -776,8 +752,8 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                         if hresult == AUDCLNT_S_BUFFER_EMPTY {
                             continue;
                         } else if let Err(err) = stream_error_from_hresult(hresult) {
-                            streams_to_remove.push((stream.id.clone(), err));
-                            break; // Identical to continuing the outer loop
+                            error_callback(err);
+                            break 'stream_loop;
                         }
 
                         debug_assert!(!buffer.is_null());
@@ -794,12 +770,12 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                                     buffer: slice,
                                 });
                                 let data = StreamData::Input { buffer: unknown_buffer };
-                                callback(stream.id.clone(), Ok(data));
+                                data_callback(stream.id.clone(), Ok(data));
                                 // Release the buffer.
                                 let hresult = (*capture_client).ReleaseBuffer(frames_available);
                                 if let Err(err) = stream_error_from_hresult(hresult) {
-                                    streams_to_remove.push((stream.id.clone(), err));
-                                    continue;
+                                    error_callback(err);
+                                    break 'stream_loop;
                                 }
                             }};
                         }
@@ -818,8 +794,8 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                         Ok(0) => continue, // TODO: Can this happen?
                         Ok(n) => n,
                         Err(err) => {
-                            streams_to_remove.push((stream.id.clone(), err));
-                            continue;
+                            error_callback(err);
+                            break 'stream_loop;
                         }
                     };
 
@@ -830,8 +806,8 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                     );
 
                     if let Err(err) = stream_error_from_hresult(hresult) {
-                        streams_to_remove.push((stream.id.clone(), err));
-                        continue;
+                        error_callback(err);
+                        break 'stream_loop;
                     }
 
                     debug_assert!(!buffer.is_null());
@@ -847,12 +823,12 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
                                 buffer: slice
                             });
                             let data = StreamData::Output { buffer: unknown_buffer };
-                            callback(stream.id.clone(), Ok(data));
+                            data_callback(stream.id.clone(), Ok(data));
                             let hresult = (*render_client)
                                 .ReleaseBuffer(frames_available as u32, 0);
                             if let Err(err) = stream_error_from_hresult(hresult) {
-                                streams_to_remove.push((stream.id.clone(), err));
-                                continue;
+                                error_callback(err);
+                                break 'stream_loop;
                             }
                         }}
                     }
@@ -866,6 +842,4 @@ fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData),
             }
         }
     }
-
-    panic!("`cpal::EventLoop::run` API currently disallows returning");
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,4 +1,3 @@
-use super::Device;
 use super::check_result;
 use super::com;
 use super::winapi::shared::basetsd::UINT32;
@@ -6,7 +5,6 @@ use super::winapi::shared::ksmedia;
 use super::winapi::shared::minwindef::{BYTE, DWORD, FALSE, WORD};
 use super::winapi::shared::mmreg;
 use super::winapi::um::audioclient::{self, AUDCLNT_E_DEVICE_INVALIDATED, AUDCLNT_S_BUFFER_EMPTY};
-use super::winapi::um::audiosessiontypes::{AUDCLNT_SHAREMODE_SHARED, AUDCLNT_STREAMFLAGS_EVENTCALLBACK};
 use super::winapi::um::handleapi;
 use super::winapi::um::synchapi;
 use super::winapi::um::winbase;
@@ -65,12 +63,12 @@ struct RunContext {
     commands: Receiver<Command>,
 }
 
-enum Command {
+pub (crate) enum Command {
     PlayStream,
     PauseStream,
 }
 
-enum AudioClientFlow {
+pub (crate) enum AudioClientFlow {
     Render {
         render_client: *mut audioclient::IAudioRenderClient,
     },
@@ -79,7 +77,7 @@ enum AudioClientFlow {
     },
 }
 
-struct StreamInner {
+pub (crate) struct StreamInner {
     id: StreamId,
     audio_client: *mut audioclient::IAudioClient,
     client_flow: AudioClientFlow,
@@ -111,329 +109,6 @@ impl EventLoop {
                                     }),
             next_stream_id: AtomicUsize::new(0),
             commands: tx,
-        }
-    }
-
-    pub(crate) fn build_input_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
-        unsafe {
-            // Making sure that COM is initialized.
-            // It's not actually sure that this is required, but when in doubt do it.
-            com::com_initialized();
-
-            // Obtaining a `IAudioClient`.
-            let audio_client = match device.build_audioclient() {
-                Ok(client) => client,
-                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
-                    return Err(BuildStreamError::DeviceNotAvailable),
-                Err(e) => {
-                    let description = format!("{}", e);
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-            };
-
-            // Computing the format and initializing the device.
-            let waveformatex = {
-                let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(BuildStreamError::FormatNotSupported)?;
-                let share_mode = AUDCLNT_SHAREMODE_SHARED;
-
-                // Ensure the format is supported.
-                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
-                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
-                    _ => (),
-                }
-
-                // finally initializing the audio client
-                let hresult = (*audio_client).Initialize(
-                    share_mode,
-                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-                    0,
-                    0,
-                    &format_attempt.Format,
-                    ptr::null(),
-                );
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("{}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                format_attempt.Format
-            };
-
-            // obtaining the size of the samples buffer in number of frames
-            let max_frames_in_buffer = {
-                let mut max_frames_in_buffer = mem::uninitialized();
-                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
-
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("{}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                max_frames_in_buffer
-            };
-
-            // Creating the event that will be signalled whenever we need to submit some samples.
-            let event = {
-                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
-                if event == ptr::null_mut() {
-                    (*audio_client).Release();
-                    let description = format!("failed to create event");
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-
-                if let Err(e) = check_result((*audio_client).SetEventHandle(event)) {
-                    (*audio_client).Release();
-                    let description = format!("failed to call SetEventHandle: {}", e);
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-
-                event
-            };
-
-            // Building a `IAudioCaptureClient` that will be used to read captured samples.
-            let capture_client = {
-                let mut capture_client: *mut audioclient::IAudioCaptureClient = mem::uninitialized();
-                let hresult = (*audio_client).GetService(
-                    &audioclient::IID_IAudioCaptureClient,
-                    &mut capture_client as *mut *mut audioclient::IAudioCaptureClient as *mut _,
-                );
-
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("failed to build capture client: {}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                &mut *capture_client
-            };
-
-            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
-            if new_stream_id.0 == usize::max_value() {
-                return Err(BuildStreamError::StreamIdOverflow);
-            }
-
-            // Once we built the `StreamInner`, we add a command that will be picked up by the
-            // `run()` method and added to the `RunContext`.
-            {
-                let client_flow = AudioClientFlow::Capture {
-                    capture_client: capture_client,
-                };
-                let inner = StreamInner {
-                    id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
-                    playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
-                    bytes_per_frame: waveformatex.nBlockAlign,
-                    sample_format: format.data_type,
-                };
-
-                self.push_command(Command::NewStream(inner));
-            };
-
-            Ok(new_stream_id)
-        }
-    }
-
-    pub(crate) fn build_output_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
-        unsafe {
-            // Making sure that COM is initialized.
-            // It's not actually sure that this is required, but when in doubt do it.
-            com::com_initialized();
-
-            // Obtaining a `IAudioClient`.
-            let audio_client = match device.build_audioclient() {
-                Ok(client) => client,
-                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
-                    return Err(BuildStreamError::DeviceNotAvailable),
-                Err(e) => {
-                    let description = format!("{}", e);
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-            };
-
-            // Computing the format and initializing the device.
-            let waveformatex = {
-                let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(BuildStreamError::FormatNotSupported)?;
-                let share_mode = AUDCLNT_SHAREMODE_SHARED;
-
-                // Ensure the format is supported.
-                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
-                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
-                    _ => (),
-                }
-
-                // finally initializing the audio client
-                let hresult = (*audio_client).Initialize(share_mode,
-                                                         AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-                                                         0,
-                                                         0,
-                                                         &format_attempt.Format,
-                                                         ptr::null());
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("{}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                format_attempt.Format
-            };
-
-            // Creating the event that will be signalled whenever we need to submit some samples.
-            let event = {
-                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
-                if event == ptr::null_mut() {
-                    (*audio_client).Release();
-                    let description = format!("failed to create event");
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-
-                match check_result((*audio_client).SetEventHandle(event)) {
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("failed to call SetEventHandle: {}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(_) => (),
-                };
-
-                event
-            };
-
-            // obtaining the size of the samples buffer in number of frames
-            let max_frames_in_buffer = {
-                let mut max_frames_in_buffer = mem::uninitialized();
-                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
-
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("failed to obtain buffer size: {}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                max_frames_in_buffer
-            };
-
-            // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
-            let render_client = {
-                let mut render_client: *mut audioclient::IAudioRenderClient = mem::uninitialized();
-                let hresult = (*audio_client).GetService(&audioclient::IID_IAudioRenderClient,
-                                                         &mut render_client as
-                                                             *mut *mut audioclient::IAudioRenderClient as
-                                                             *mut _);
-
-                match check_result(hresult) {
-                    Err(ref e)
-                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-                        (*audio_client).Release();
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    },
-                    Err(e) => {
-                        (*audio_client).Release();
-                        let description = format!("failed to build render client: {}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    },
-                    Ok(()) => (),
-                };
-
-                &mut *render_client
-            };
-
-            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
-            if new_stream_id.0 == usize::max_value() {
-                return Err(BuildStreamError::StreamIdOverflow);
-            }
-
-            // Once we built the `StreamInner`, we add a command that will be picked up by the
-            // `run()` method and added to the `RunContext`.
-            {
-                let client_flow = AudioClientFlow::Render {
-                    render_client: render_client,
-                };
-                let inner = StreamInner {
-                    id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
-                    playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
-                    bytes_per_frame: waveformatex.nBlockAlign,
-                    sample_format: format.data_type,
-                };
-
-                self.push_command(Command::NewStream(inner));
-            };
-
-            Ok(new_stream_id)
         }
     }
 
@@ -509,60 +184,6 @@ impl Drop for StreamInner {
             handleapi::CloseHandle(self.event);
         }
     }
-}
-
-// Turns a `Format` into a `WAVEFORMATEXTENSIBLE`.
-//
-// Returns `None` if the WAVEFORMATEXTENSIBLE does not support the given format.
-fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEXTENSIBLE> {
-    let format_tag = match format.data_type {
-        SampleFormat::I16 => mmreg::WAVE_FORMAT_PCM,
-        SampleFormat::F32 => mmreg::WAVE_FORMAT_EXTENSIBLE,
-        SampleFormat::U16 => return None,
-    };
-    let channels = format.channels as WORD;
-    let sample_rate = format.sample_rate.0 as DWORD;
-    let sample_bytes = format.data_type.sample_size() as WORD;
-    let avg_bytes_per_sec = channels as DWORD * sample_rate * sample_bytes as DWORD;
-    let block_align = channels * sample_bytes;
-    let bits_per_sample = 8 * sample_bytes;
-    let cb_size = match format.data_type {
-        SampleFormat::I16 => 0,
-        SampleFormat::F32 => {
-            let extensible_size = mem::size_of::<mmreg::WAVEFORMATEXTENSIBLE>();
-            let ex_size = mem::size_of::<mmreg::WAVEFORMATEX>();
-            (extensible_size - ex_size) as WORD
-        },
-        SampleFormat::U16 => return None,
-    };
-    let waveformatex = mmreg::WAVEFORMATEX {
-        wFormatTag: format_tag,
-        nChannels: channels,
-        nSamplesPerSec: sample_rate,
-        nAvgBytesPerSec: avg_bytes_per_sec,
-        nBlockAlign: block_align,
-        wBitsPerSample: bits_per_sample,
-        cbSize: cb_size,
-    };
-
-    // CPAL does not care about speaker positions, so pass audio straight through.
-    // TODO: This constant should be defined in winapi but is missing.
-    const KSAUDIO_SPEAKER_DIRECTOUT: DWORD = 0;
-    let channel_mask = KSAUDIO_SPEAKER_DIRECTOUT;
-
-    let sub_format = match format.data_type {
-        SampleFormat::I16 => ksmedia::KSDATAFORMAT_SUBTYPE_PCM,
-        SampleFormat::F32 => ksmedia::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT,
-        SampleFormat::U16 => return None,
-    };
-    let waveformatextensible = mmreg::WAVEFORMATEXTENSIBLE {
-        Format: waveformatex,
-        Samples: bits_per_sample as WORD,
-        dwChannelMask: channel_mask,
-        SubFormat: sub_format,
-    };
-
-    Some(waveformatextensible)
 }
 
 // Process any pending commands that are queued within the `RunContext`.

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -27,7 +27,6 @@ use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
 use StreamData;
-use StreamDataResult;
 use StreamError;
 use UnknownTypeOutputBuffer;
 use UnknownTypeInputBuffer;
@@ -445,12 +444,12 @@ impl EventLoop {
 
     #[inline]
     pub(crate) fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult)
+        where F: FnMut(StreamId, StreamData)
     {
         self.run_inner(&mut callback);
     }
 
-    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamDataResult)) -> ! {
+    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamData)) -> ! {
         unsafe {
             // We keep `run_context` locked forever, which guarantees that two invocations of
             // `run()` cannot run simultaneously.
@@ -746,7 +745,7 @@ fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEX
 // Process any pending commands that are queued within the `RunContext`.
 fn process_commands(
     run_context: &mut RunContext,
-    callback: &mut dyn FnMut(StreamId, StreamDataResult),
+    callback: &mut dyn FnMut(StreamId, StreamData),
 ) {
     // Process the pending commands.
     for command in run_context.commands.try_iter() {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -20,6 +20,8 @@ use std::sync::mpsc::{channel, Sender, Receiver};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 
+use std::sync::{Arc};
+
 use BackendSpecificError;
 use BuildStreamError;
 use Format;
@@ -54,7 +56,7 @@ pub struct EventLoop {
 
 struct RunContext {
     // Streams that have been created in this event loop.
-    streams: Vec<StreamInner>,
+    stream: Arc<StreamInner>,
 
     // Handles corresponding to the `event` field of each element of `voices`. Must always be in
     // sync with `voices`, except that the first element is always `pending_scheduled_event`.
@@ -105,7 +107,7 @@ impl EventLoop {
         EventLoop {
             pending_scheduled_event: pending_scheduled_event,
             run_context: Mutex::new(RunContext {
-                                        streams: Vec::new(),
+                                        stream: Arc::new(),
                                         handles: vec![pending_scheduled_event],
                                         commands: rx,
                                     }),
@@ -466,11 +468,11 @@ impl EventLoop {
             'stream_loop: loop {
                 // Remove any failed streams.
                 for (stream_id, err) in streams_to_remove.drain(..) {
-                    match run_context.streams.iter().position(|s| s.id == stream_id) {
+                    match run_context.stream.iter().position(|s| s.id == stream_id) {
                         None => continue,
                         Some(p) => {
                             run_context.handles.remove(p + 1);
-                            run_context.streams.remove(p);
+                            run_context.stream.remove(p);
                             callback(stream_id, Err(err.into()));
                         },
                     }
@@ -483,10 +485,10 @@ impl EventLoop {
                 let handle_idx = match wait_for_handle_signal(&run_context.handles) {
                     Ok(idx) => idx,
                     Err(err) => {
-                        for stream in &run_context.streams {
+                        for stream in &run_context.stream {
                             callback(stream.id.clone(), Err(err.clone().into()));
                         }
-                        run_context.streams.clear();
+                        run_context.stream.clear();
                         run_context.handles.truncate(1);
                         break 'stream_loop;
                     }
@@ -499,7 +501,7 @@ impl EventLoop {
                 }
 
                 let stream_idx = handle_idx - 1;
-                let stream = &mut run_context.streams[stream_idx];
+                let stream = &mut run_context.stream[stream_idx];
 
                 let sample_size = stream.sample_format.sample_size();
 
@@ -752,34 +754,34 @@ fn process_commands(
         match command {
             Command::NewStream(stream_inner) => {
                 let event = stream_inner.event;
-                run_context.streams.push(stream_inner);
+                run_context.stream.push(stream_inner);
                 run_context.handles.push(event);
             },
             Command::DestroyStream(stream_id) => {
-                match run_context.streams.iter().position(|s| s.id == stream_id) {
+                match run_context.stream.iter().position(|s| s.id == stream_id) {
                     None => continue,
                     Some(p) => {
                         run_context.handles.remove(p + 1);
-                        run_context.streams.remove(p);
+                        run_context.stream.remove(p);
                     },
                 }
             },
             Command::PlayStream(stream_id) => {
-                match run_context.streams.iter().position(|s| s.id == stream_id) {
+                match run_context.stream.iter().position(|s| s.id == stream_id) {
                     None => continue,
                     Some(p) => {
-                        if !run_context.streams[p].playing {
+                        if !run_context.stream[p].playing {
                             let hresult = unsafe {
-                                (*run_context.streams[p].audio_client).Start()
+                                (*run_context.stream[p].audio_client).Start()
                             };
                             match stream_error_from_hresult(hresult) {
                                 Ok(()) => {
-                                    run_context.streams[p].playing = true;
+                                    run_context.stream[p].playing = true;
                                 }
                                 Err(err) => {
                                     callback(stream_id, Err(err.into()));
                                     run_context.handles.remove(p + 1);
-                                    run_context.streams.remove(p);
+                                    run_context.stream.remove(p);
                                 }
                             }
                         }
@@ -787,21 +789,21 @@ fn process_commands(
                 }
             },
             Command::PauseStream(stream_id) => {
-                match run_context.streams.iter().position(|s| s.id == stream_id) {
+                match run_context.stream.iter().position(|s| s.id == stream_id) {
                     None => continue,
                     Some(p) => {
-                        if run_context.streams[p].playing {
+                        if run_context.stream[p].playing {
                             let hresult = unsafe {
-                                (*run_context.streams[p].audio_client).Stop()
+                                (*run_context.stream[p].audio_client).Stop()
                             };
                             match stream_error_from_hresult(hresult) {
                                 Ok(()) => {
-                                    run_context.streams[p].playing = false;
+                                    run_context.stream[p].playing = false;
                                 }
                                 Err(err) => {
                                     callback(stream_id, Err(err.into()));
                                     run_context.handles.remove(p + 1);
-                                    run_context.streams.remove(p);
+                                    run_context.stream.remove(p);
                                 }
                             }
                         }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -451,183 +451,6 @@ impl EventLoop {
         self.run_inner(&mut callback);
     }
 
-    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamData)) -> ! {
-        unsafe {
-            // We keep `run_context` locked forever, which guarantees that two invocations of
-            // `run()` cannot run simultaneously.
-            let mut run_context = self.run_context.lock().unwrap();
-            // Force a deref so that borrow checker can operate on each field independently.
-            // Shadow the name because we don't use (or drop) it otherwise.
-            let run_context = &mut *run_context;
-
-            // Keep track of the set of streams that should be removed due to some error occurring.
-            //
-            // Checked at the start of each loop.
-            let mut streams_to_remove: Vec<(StreamId, StreamError)> = vec![];
-
-            'stream_loop: loop {
-                // Remove any failed streams.
-                for (stream_id, err) in streams_to_remove.drain(..) {
-                    match run_context.stream.iter().position(|s| s.id == stream_id) {
-                        None => continue,
-                        Some(p) => {
-                            run_context.handles.remove(p + 1);
-                            run_context.stream.remove(p);
-                            callback(stream_id, Err(err.into()));
-                        },
-                    }
-                }
-
-                // Process queued commands.
-                process_commands(run_context, callback);
-
-                // Wait for any of the handles to be signalled.
-                let handle_idx = match wait_for_handle_signal(&run_context.handles) {
-                    Ok(idx) => idx,
-                    Err(err) => {
-                        for stream in &run_context.stream {
-                            callback(stream.id.clone(), Err(err.clone().into()));
-                        }
-                        run_context.stream.clear();
-                        run_context.handles.truncate(1);
-                        break 'stream_loop;
-                    }
-                };
-
-                // If `handle_idx` is 0, then it's `pending_scheduled_event` that was signalled in
-                // order for us to pick up the pending commands. Otherwise, a stream needs data.
-                if handle_idx == 0 {
-                    continue;
-                }
-
-                let stream_idx = handle_idx - 1;
-                let stream = &mut run_context.stream[stream_idx];
-
-                let sample_size = stream.sample_format.sample_size();
-
-                // Obtaining a pointer to the buffer.
-                match stream.client_flow {
-
-                    AudioClientFlow::Capture { capture_client } => {
-                        let mut frames_available = 0;
-                        // Get the available data in the shared buffer.
-                        let mut buffer: *mut BYTE = mem::uninitialized();
-                        let mut flags = mem::uninitialized();
-                        loop {
-                            let hresult = (*capture_client).GetNextPacketSize(&mut frames_available);
-                            if let Err(err) = stream_error_from_hresult(hresult) {
-                                streams_to_remove.push((stream.id.clone(), err));
-                                break; // Identical to continuing the outer loop
-                            }
-                            if frames_available == 0 {
-                                break;
-                            }
-                            let hresult = (*capture_client).GetBuffer(
-                                &mut buffer,
-                                &mut frames_available,
-                                &mut flags,
-                                ptr::null_mut(),
-                                ptr::null_mut(),
-                            );
-
-                            // TODO: Can this happen?
-                            if hresult == AUDCLNT_S_BUFFER_EMPTY {
-                                continue;
-                            } else if let Err(err) = stream_error_from_hresult(hresult) {
-                                streams_to_remove.push((stream.id.clone(), err));
-                                break; // Identical to continuing the outer loop
-                            }
-
-                            debug_assert!(!buffer.is_null());
-
-                            let buffer_len = frames_available as usize
-                                * stream.bytes_per_frame as usize / sample_size;
-
-                            // Simplify the capture callback sample format branches.
-                            macro_rules! capture_callback {
-                                ($T:ty, $Variant:ident) => {{
-                                    let buffer_data = buffer as *mut _ as *const $T;
-                                    let slice = slice::from_raw_parts(buffer_data, buffer_len);
-                                    let unknown_buffer = UnknownTypeInputBuffer::$Variant(::InputBuffer {
-                                        buffer: slice,
-                                    });
-                                    let data = StreamData::Input { buffer: unknown_buffer };
-                                    callback(stream.id.clone(), Ok(data));
-                                    // Release the buffer.
-                                    let hresult = (*capture_client).ReleaseBuffer(frames_available);
-                                    if let Err(err) = stream_error_from_hresult(hresult) {
-                                        streams_to_remove.push((stream.id.clone(), err));
-                                        continue;
-                                    }
-                                }};
-                            }
-
-                            match stream.sample_format {
-                                SampleFormat::F32 => capture_callback!(f32, F32),
-                                SampleFormat::I16 => capture_callback!(i16, I16),
-                                SampleFormat::U16 => capture_callback!(u16, U16),
-                            }
-                        }
-                    },
-
-                    AudioClientFlow::Render { render_client } => {
-                        // The number of frames available for writing.
-                        let frames_available = match get_available_frames(stream) {
-                            Ok(0) => continue, // TODO: Can this happen?
-                            Ok(n) => n,
-                            Err(err) => {
-                                streams_to_remove.push((stream.id.clone(), err));
-                                continue;
-                            }
-                        };
-
-                        let mut buffer: *mut BYTE = mem::uninitialized();
-                        let hresult = (*render_client).GetBuffer(
-                            frames_available,
-                            &mut buffer as *mut *mut _,
-                        );
-
-                        if let Err(err) = stream_error_from_hresult(hresult) {
-                            streams_to_remove.push((stream.id.clone(), err));
-                            continue;
-                        }
-
-                        debug_assert!(!buffer.is_null());
-                        let buffer_len = frames_available as usize
-                            * stream.bytes_per_frame as usize / sample_size;
-
-                        // Simplify the render callback sample format branches.
-                        macro_rules! render_callback {
-                            ($T:ty, $Variant:ident) => {{
-                                let buffer_data = buffer as *mut $T;
-                                let slice = slice::from_raw_parts_mut(buffer_data, buffer_len);
-                                let unknown_buffer = UnknownTypeOutputBuffer::$Variant(::OutputBuffer {
-                                    buffer: slice
-                                });
-                                let data = StreamData::Output { buffer: unknown_buffer };
-                                callback(stream.id.clone(), Ok(data));
-                                let hresult = (*render_client)
-                                    .ReleaseBuffer(frames_available as u32, 0);
-                                if let Err(err) = stream_error_from_hresult(hresult) {
-                                    streams_to_remove.push((stream.id.clone(), err));
-                                    continue;
-                                }
-                            }}
-                        }
-
-                        match stream.sample_format {
-                            SampleFormat::F32 => render_callback!(f32, F32),
-                            SampleFormat::I16 => render_callback!(i16, I16),
-                            SampleFormat::U16 => render_callback!(u16, U16),
-                        }
-                    },
-                }
-            }
-        }
-
-        panic!("`cpal::EventLoop::run` API currently disallows returning");
-    }
-
     #[inline]
     pub(crate) fn play_stream(&self, stream: StreamId) -> Result<(), PlayStreamError> {
         self.push_command(Command::PlayStream(stream));
@@ -868,4 +691,181 @@ fn stream_error_from_hresult(hresult: winnt::HRESULT) -> Result<(), StreamError>
         return Err(err.into());
     }
     Ok(())
+}
+
+fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) -> () {
+    unsafe {
+        // We keep `run_context` locked forever, which guarantees that two invocations of
+        // `run()` cannot run simultaneously.
+        let mut run_context = self.run_context.lock().unwrap();
+        // Force a deref so that borrow checker can operate on each field independently.
+        // Shadow the name because we don't use (or drop) it otherwise.
+        let run_context = &mut *run_context;
+
+        // Keep track of the set of streams that should be removed due to some error occurring.
+        //
+        // Checked at the start of each loop.
+        let mut streams_to_remove: Vec<(StreamId, StreamError)> = vec![];
+
+        'stream_loop: loop {
+            // Remove any failed streams.
+            for (stream_id, err) in streams_to_remove.drain(..) {
+                match run_context.stream.iter().position(|s| s.id == stream_id) {
+                    None => continue,
+                    Some(p) => {
+                        run_context.handles.remove(p + 1);
+                        run_context.stream.remove(p);
+                        callback(stream_id, Err(err.into()));
+                    },
+                }
+            }
+
+            // Process queued commands.
+            process_commands(run_context, callback);
+
+            // Wait for any of the handles to be signalled.
+            let handle_idx = match wait_for_handle_signal(&run_context.handles) {
+                Ok(idx) => idx,
+                Err(err) => {
+                    for stream in &run_context.stream {
+                        callback(stream.id.clone(), Err(err.clone().into()));
+                    }
+                    run_context.stream.clear();
+                    run_context.handles.truncate(1);
+                    break 'stream_loop;
+                }
+            };
+
+            // If `handle_idx` is 0, then it's `pending_scheduled_event` that was signalled in
+            // order for us to pick up the pending commands. Otherwise, a stream needs data.
+            if handle_idx == 0 {
+                continue;
+            }
+
+            let stream_idx = handle_idx - 1;
+            let stream = &mut run_context.stream[stream_idx];
+
+            let sample_size = stream.sample_format.sample_size();
+
+            // Obtaining a pointer to the buffer.
+            match stream.client_flow {
+
+                AudioClientFlow::Capture { capture_client } => {
+                    let mut frames_available = 0;
+                    // Get the available data in the shared buffer.
+                    let mut buffer: *mut BYTE = mem::uninitialized();
+                    let mut flags = mem::uninitialized();
+                    loop {
+                        let hresult = (*capture_client).GetNextPacketSize(&mut frames_available);
+                        if let Err(err) = stream_error_from_hresult(hresult) {
+                            streams_to_remove.push((stream.id.clone(), err));
+                            break; // Identical to continuing the outer loop
+                        }
+                        if frames_available == 0 {
+                            break;
+                        }
+                        let hresult = (*capture_client).GetBuffer(
+                            &mut buffer,
+                            &mut frames_available,
+                            &mut flags,
+                            ptr::null_mut(),
+                            ptr::null_mut(),
+                        );
+
+                        // TODO: Can this happen?
+                        if hresult == AUDCLNT_S_BUFFER_EMPTY {
+                            continue;
+                        } else if let Err(err) = stream_error_from_hresult(hresult) {
+                            streams_to_remove.push((stream.id.clone(), err));
+                            break; // Identical to continuing the outer loop
+                        }
+
+                        debug_assert!(!buffer.is_null());
+
+                        let buffer_len = frames_available as usize
+                            * stream.bytes_per_frame as usize / sample_size;
+
+                        // Simplify the capture callback sample format branches.
+                        macro_rules! capture_callback {
+                            ($T:ty, $Variant:ident) => {{
+                                let buffer_data = buffer as *mut _ as *const $T;
+                                let slice = slice::from_raw_parts(buffer_data, buffer_len);
+                                let unknown_buffer = UnknownTypeInputBuffer::$Variant(::InputBuffer {
+                                    buffer: slice,
+                                });
+                                let data = StreamData::Input { buffer: unknown_buffer };
+                                callback(stream.id.clone(), Ok(data));
+                                // Release the buffer.
+                                let hresult = (*capture_client).ReleaseBuffer(frames_available);
+                                if let Err(err) = stream_error_from_hresult(hresult) {
+                                    streams_to_remove.push((stream.id.clone(), err));
+                                    continue;
+                                }
+                            }};
+                        }
+
+                        match stream.sample_format {
+                            SampleFormat::F32 => capture_callback!(f32, F32),
+                            SampleFormat::I16 => capture_callback!(i16, I16),
+                            SampleFormat::U16 => capture_callback!(u16, U16),
+                        }
+                    }
+                },
+
+                AudioClientFlow::Render { render_client } => {
+                    // The number of frames available for writing.
+                    let frames_available = match get_available_frames(stream) {
+                        Ok(0) => continue, // TODO: Can this happen?
+                        Ok(n) => n,
+                        Err(err) => {
+                            streams_to_remove.push((stream.id.clone(), err));
+                            continue;
+                        }
+                    };
+
+                    let mut buffer: *mut BYTE = mem::uninitialized();
+                    let hresult = (*render_client).GetBuffer(
+                        frames_available,
+                        &mut buffer as *mut *mut _,
+                    );
+
+                    if let Err(err) = stream_error_from_hresult(hresult) {
+                        streams_to_remove.push((stream.id.clone(), err));
+                        continue;
+                    }
+
+                    debug_assert!(!buffer.is_null());
+                    let buffer_len = frames_available as usize
+                        * stream.bytes_per_frame as usize / sample_size;
+
+                    // Simplify the render callback sample format branches.
+                    macro_rules! render_callback {
+                        ($T:ty, $Variant:ident) => {{
+                            let buffer_data = buffer as *mut $T;
+                            let slice = slice::from_raw_parts_mut(buffer_data, buffer_len);
+                            let unknown_buffer = UnknownTypeOutputBuffer::$Variant(::OutputBuffer {
+                                buffer: slice
+                            });
+                            let data = StreamData::Output { buffer: unknown_buffer };
+                            callback(stream.id.clone(), Ok(data));
+                            let hresult = (*render_client)
+                                .ReleaseBuffer(frames_available as u32, 0);
+                            if let Err(err) = stream_error_from_hresult(hresult) {
+                                streams_to_remove.push((stream.id.clone(), err));
+                                continue;
+                            }
+                        }}
+                    }
+
+                    match stream.sample_format {
+                        SampleFormat::F32 => render_callback!(f32, F32),
+                        SampleFormat::I16 => render_callback!(i16, I16),
+                        SampleFormat::U16 => render_callback!(u16, U16),
+                    }
+                },
+            }
+        }
+    }
+
+    panic!("`cpal::EventLoop::run` API currently disallows returning");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,15 @@ extern crate lazy_static;
 #[macro_use]
 extern crate stdweb;
 
-pub use platform::{
-    ALL_HOSTS, Device, Devices, EventLoop, Host, HostId, SupportedInputFormats,
-    SupportedOutputFormats, StreamId, available_hosts, default_host, host_from_id,
-};
-pub use samples_formats::{Sample, SampleFormat};
+use std::ops::{Deref, DerefMut};
 
 use failure::Fail;
-use std::ops::{Deref, DerefMut};
+
+pub use platform::{
+    ALL_HOSTS, available_hosts, default_host, Device, Devices, Host, host_from_id,
+    HostId, Stream, SupportedInputFormats, SupportedOutputFormats,
+};
+pub use samples_formats::{Sample, SampleFormat};
 
 mod host;
 pub mod platform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,10 +207,6 @@ pub enum StreamData<'a> {
     },
 }
 
-/// Stream data passed to the `EventLoop::run` callback, or an error in the case that the device
-/// was invalidated or some backend-specific error occurred.
-pub type StreamDataResult<'a> = Result<StreamData<'a>, StreamError>;
-
 /// Represents a buffer containing audio data that may be read.
 ///
 /// This struct implements the `Deref` trait targeting `[T]`. Therefore this buffer can be read the

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -414,9 +414,8 @@ mod platform_impl {
     pub use crate::host::coreaudio::{
         Device as CoreAudioDevice,
         Devices as CoreAudioDevices,
-        EventLoop as CoreAudioEventLoop,
         Host as CoreAudioHost,
-        StreamId as CoreAudioStreamId,
+        Stream as CoreAudioStream,
         SupportedInputFormats as CoreAudioSupportedInputFormats,
         SupportedOutputFormats as CoreAudioSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -468,9 +468,8 @@ mod platform_impl {
     pub use crate::host::wasapi::{
         Device as WasapiDevice,
         Devices as WasapiDevices,
-        EventLoop as WasapiEventLoop,
+        Stream as WasapiStream,
         Host as WasapiHost,
-        StreamId as WasapiStreamId,
         SupportedInputFormats as WasapiSupportedInputFormats,
         SupportedOutputFormats as WasapiSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -250,22 +250,22 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn build_input_stream<F>(&self, format: &crate::Format, callback: F) -> Result<Self::Stream, crate::BuildStreamError>
-                where F: FnMut(crate::StreamDataResult) + Send + 'static {
+            fn build_input_stream<D, E>(&self, format: &crate::Format, data_callback: D, error_callback: E) -> Result<Self::Stream, crate::BuildStreamError>
+                where D: FnMut(crate::StreamData) + Send + 'static, E: FnMut(crate::StreamError) + Send + 'static {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_input_stream(format, callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_input_stream(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream),
                     )*
                 }
             }
 
-            fn build_output_stream<F>(&self, format: &crate::Format, callback: F) -> Result<Self::Stream, crate::BuildStreamError>
-                where F: FnMut(crate::StreamDataResult) + Send + 'static {
+            fn build_output_stream<D, E>(&self, format: &crate::Format, data_callback: D, error_callback: E) -> Result<Self::Stream, crate::BuildStreamError>
+                where D: FnMut(crate::StreamData) + Send + 'static, E: FnMut(crate::StreamError) + Send + 'static {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_output_stream(format, callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_output_stream(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream),
                     )*

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,8 @@ use {
     OutputDevices,
     PauseStreamError,
     PlayStreamError,
-    StreamDataResult,
+    StreamData,
+    StreamError,
     SupportedFormat,
     SupportedFormatsError,
 };
@@ -117,12 +118,12 @@ pub trait DeviceTrait {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError>;
 
     /// Create an input stream.
-    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static;
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static;
 
     /// Create an output stream.
-    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static;
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static;
 }
 
 /// A stream created from `Device`, with methods to control playback.


### PR DESCRIPTION
Close #278. I rushed for a buildable version so you can see it, there's still a lot of thing to do.

- [ ] Check for `can_pause` and optionally return an error
- [ ] Polymorphic struct versions of Traits will be explicitly `!Sync`, `!Send`
- [x] Take an additional error callback as described in https://github.com/tomaka/cpal/issues/268#issuecomment-508905225
- [ ] Update documentation
- [ ] Checkbox for ASIO backend so I don't miss it because it's without CI