### PR TITLE
Turn off std feature of failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ keywords = ["audio", "sound"]
 asio = ["asio-sys"] # Only available on Windows. See README for setup instructions.
 
 [dependencies]
-failure = "0.1.5"
+failure = { version = "0.1.5", default-features = false, features = ["derive"] }
 lazy_static = "1.3"
 num-traits = "0.2.6"
 
 [dev-dependencies]
 hound = "3.4"
+failure = "0.1.5"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winuser"] }


### PR DESCRIPTION
This saves us some dependencies and thus speeds up the build.