### PR TITLE
Use snd_pcm_avail_update

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1054,9 +1054,8 @@ fn check_for_pollout_or_pollin(
 
 // Determine the number of samples that are available to read/write.
 fn get_available_samples(stream: &StreamInner) -> Result<usize, BackendSpecificError> {
-    // TODO: what about snd_pcm_avail_update?
     let available = unsafe {
-        alsa::snd_pcm_avail(stream.channel)
+        alsa::snd_pcm_avail_update(stream.channel)
     };
     if available == -32 {
         // buffer underrun


### PR DESCRIPTION
Tested on Linux, seems to working fine. The `snd_pcm_avail` function performs additional work for synchronization (device timestamps), which we don't use at the moment.