### PR TITLE
Add the ability to read inner values from input and output buffers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,6 +515,15 @@ impl<'a, T> Deref for InputBuffer<'a, T>
     }
 }
 
+impl<'a, T> InputBuffer<'a, T>
+    where T: Sample
+{
+    #[inline]
+    pub fn inner(&'a self) -> &'a [T] {
+        self.buffer
+    }
+}
+
 impl<'a, T> Deref for OutputBuffer<'a, T>
     where T: Sample
 {
@@ -534,6 +543,21 @@ impl<'a, T> DerefMut for OutputBuffer<'a, T>
         self.buffer
     }
 }
+
+impl<'a, T> OutputBuffer<'a, T>
+    where T: Sample
+{
+    #[inline]
+    pub fn inner(&'a self) -> &'a [T] {
+        self.buffer
+    }
+
+    #[inline]
+    pub fn inner_mut(&'a mut self) -> &'a mut [T] {
+        self.buffer
+    }
+}
+
 
 impl<'a> UnknownTypeInputBuffer<'a> {
     /// Returns the length of the buffer in number of samples.


### PR DESCRIPTION
I need the ability to get a slice with the proper lifespan (`'a`). In the next major release we'll be switching to plain slices instead of wrapper `InputBuffer`/`OutputBuffer` types, so it's not a problem.