### PR TITLE
Use apartment threading on Windows

### DIFF
--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -3,14 +3,14 @@
 use super::check_result;
 use std::ptr;
 
-use super::winapi::um::objbase::{COINIT_MULTITHREADED};
+use super::winapi::um::objbase::{COINIT_APARTMENTTHREADED};
 use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
         // this call can fail if another library initialized COM in single-threaded mode
         // handling this situation properly would make the API more annoying, so we just don't care
-        check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
+        check_result(CoInitializeEx(ptr::null_mut(), COINIT_APARTMENTTHREADED)).unwrap();
         ComInitialized(ptr::null_mut())
     }
 });


### PR DESCRIPTION
I'm trying to play back some music using rodio (and cpal) and create a window using winit.

I can choose to initialize rodio and winit in two ways:

### Initializing rodio first, then initializing winit
This gives me a panic in winit [here](https://github.com/rust-windowing/winit/blob/master/src/platform_impl/windows/window.rs#L85), because rodio/cpal already initialized COM.

### Initializing winit first, then initializing rodio
This gives me a panic in cpal [here](https://github.com/RustAudio/cpal/blob/master/src/host/wasapi/com.rs#L13), with the error `Os { code: -2147417850, kind: Other, message: "Cannot change thread mode after it is set." }`.

# Fix
The root cause seems to be that winit is initializing COM with `COINIT_APARTMENTTHREADED` whereas cpal initializes COM with `COINIT_MULTITHREADED`.

According to the [docs](https://docs.microsoft.com/en-us/windows/win32/learnwin32/initializing-the-com-library) apartment threading can work if multiple threads don't access the same COM object. I believe this is true in cpal? Using apartment threading effectively isolates the COM use from winit from the COM use in cpal, which seems to be what we want.

I can confirm that (in my tests, at least) after this change everything works correctly, regardless of the winit/rodio initialization order.