### PR TITLE
Uses ringbuffer in feedback example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ num-traits = "0.2.6"
 
 [dev-dependencies]
 hound = "3.4"
+ringbuf = "0.1.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winuser"] }

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -45,6 +45,8 @@ fn main() -> Result<(), failure::Error> {
 
     // Fill the samples with 0.0 equal to the length of the delay.
     for _ in 0..latency_samples {
+        // The ring buffer has twice as much space as necessary to add latency here,
+        // so this should never fail
         producer.push(0.0).unwrap();
     }
 


### PR DESCRIPTION
As mentioned on the Rust Audio discord, the `feedback` example should use a ringbuffer instead of mpsc channels