### PR TITLE
Implement WASAPI loopback support

### DIFF
--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -552,7 +552,7 @@ impl Device {
         }
     }
 
-    fn data_flow(&self) -> EDataFlow {
+    pub(crate) fn data_flow(&self) -> EDataFlow {
         let endpoint = Endpoint::from(self.device as *const _);
         endpoint.data_flow()
     }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -21,6 +21,10 @@ mod device;
 mod stream;
 
 /// The WASAPI host, the default windows host type.
+///
+/// Note: If you use a WASAPI output device as an input device it will
+/// transparently enable loopback mode (see
+/// https://docs.microsoft.com/en-us/windows/win32/coreaudio/loopback-recording).
 #[derive(Debug)]
 pub struct Host;
 


### PR DESCRIPTION
This works by detecting output devices in build_input_stream() and
setting the AUDCLNT_STREAMFLAGS_LOOPBACK flag to enable loopback
recording.

closes #251