### PR TITLE
Don't fail if CoInitializeEx returns RPC_E_CHANGED_MODE. It's OK.

### DIFF
--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -1,30 +1,40 @@
 //! Handles COM initialization and cleanup.
 
-use super::check_result;
 use std::ptr;
 
 use super::winapi::um::objbase::{COINIT_MULTITHREADED};
 use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
+use super::winapi::shared::winerror::{SUCCEEDED, HRESULT, RPC_E_CHANGED_MODE};
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
-        // this call can fail if another library initialized COM in single-threaded mode
-        // handling this situation properly would make the API more annoying, so we just don't care
-        check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
-        ComInitialized(ptr::null_mut())
+        // this call can fail with RPC_E_CHANGED_MODE if another library initialized COM
+        // in apartment-threaded mode. That's OK though, we don't care.
+        let result = CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED);
+        if SUCCEEDED(result) || result == RPC_E_CHANGED_MODE {
+            ComInitialized {
+                result
+            }
+        } else {
+            // COM initialization failed in another way, something is really wrong.
+            panic!("Failed to initialize COM.");
+        }
     }
 });
 
 /// RAII object that guards the fact that COM is initialized.
-///
-// We store a raw pointer because it's the only way at the moment to remove `Send`/`Sync` from the
-// object.
-struct ComInitialized(*mut ());
+struct ComInitialized {
+    result: HRESULT,
+}
 
 impl Drop for ComInitialized {
     #[inline]
     fn drop(&mut self) {
-        unsafe { CoUninitialize() };
+        // Need to avoid calling CoUninitialize() if CoInitializeEx failed since it may have returned
+        // RPC_E_MODE_CHANGED - which is OK, see above.
+        if SUCCEEDED(self.result) {
+            unsafe { CoUninitialize() };
+        }
     }
 }
 


### PR DESCRIPTION
As far as I can tell, cpal relies on no way on the COM mode being COINIT_MULTITHREADED.

So let's survive even if COM was already initialized in apartment-threaded mode (there is no such thing as single-threaded mode).