### PR TITLE
Publish version 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Unreleased
 
+# Version 0.11.0 (2019-12-11)
+
+- Fix some underruns that could occur in ALSA.
+- Add name to `HostId`.
+- Use `snd_pcm_hw_params_set_buffer_time_near` rather than `set_buffer_time_max`
+  in ALSA backend.
+- Remove many uses of `std::mem::uninitialized`.
+- Fix WASAPI capture logic.
+- Panic on stream ID overflow rather than returning an error.
+- Use `ringbuffer` crate in feedback example.
+- Move errors into a separate module.
+- Switch from `failure` to `thiserror` for error handling.
+- Add `winbase` winapi feature to solve windows compile error issues.
+- Lots of CI improvements.
+
 # Version 0.10.0 (2019-07-05)
 
 - core-foundation-sys and coreaudio-rs version bumps.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "cpal"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio I/O library in pure Rust."
-repository = "https://github.com/tomaka/cpal"
+repository = "https://github.com/rustaudio/cpal"
 documentation = "https://docs.rs/cpal"
 license = "Apache-2.0"
 keywords = ["audio", "sound"]


### PR DESCRIPTION
Please see the CHANGELOG diff for an overview of changes included in this
release.

You can find the full code diff [here](https://github.com/RustAudio/cpal/compare/391b32f5b2704141506eb4fcb827b8de76e77d54...master).

Thanks to all who have contributed! CPAL has come a long way thanks to
the combined effort of many different people!