### PR TITLE
Removing the `EventLoop` - rebased

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cargo/
 .DS_Store
 recorded.wav
+rls*.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ringbuf = "0.1.6"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.1", path = "asio-sys", optional = true }
+parking_lot = "0.9"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 alsa-sys = { version = "0.1", path = "alsa-sys" }

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -17,15 +17,7 @@ fn main() -> Result<(), anyhow::Error> {
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    let stream = device.build_output_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on stream: {}", err);
-                return;
-            }
-        };
-
+    let stream = device.build_output_stream(&format, move |data| {
         match data {
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer) } => {
                 for sample in buffer.chunks_mut(channels as usize) {
@@ -53,6 +45,8 @@ fn main() -> Result<(), anyhow::Error> {
             },
             _ => (),
         }
+    }, move |err| {
+        eprintln!("an error occurred on stream: {}", err);
     })?;
     stream.play()?;
     

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -49,7 +49,7 @@ fn main() -> Result<(), anyhow::Error> {
         eprintln!("an error occurred on stream: {}", err);
     })?;
     stream.play()?;
-    
+
     std::thread::sleep(std::time::Duration::from_millis(1000));
 
     Ok(())

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,37 +1,34 @@
 extern crate anyhow;
 extern crate cpal;
 
-use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+use cpal::traits::{DeviceTrait, StreamTrait, HostTrait};
 
 fn main() -> Result<(), anyhow::Error> {
     let host = cpal::default_host();
     let device = host.default_output_device().expect("failed to find a default output device");
     let format = device.default_output_format()?;
-    let event_loop = host.event_loop();
-    let stream_id = event_loop.build_output_stream(&device, &format)?;
-    event_loop.play_stream(stream_id.clone())?;
-
     let sample_rate = format.sample_rate.0 as f32;
+    let channels = format.channels;
     let mut sample_clock = 0f32;
 
     // Produce a sinusoid of maximum amplitude.
-    let mut next_value = || {
+    let mut next_value = move || {
         sample_clock = (sample_clock + 1.0) % sample_rate;
         (sample_clock * 440.0 * 2.0 * 3.141592 / sample_rate).sin()
     };
 
-    event_loop.run(move |id, result| {
+    let stream = device.build_output_stream(&format, move |result| {
         let data = match result {
             Ok(data) => data,
             Err(err) => {
-                eprintln!("an error occurred on stream {:?}: {}", id, err);
+                eprintln!("an error occurred on stream: {}", err);
                 return;
             }
         };
 
         match data {
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::U16(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = ((next_value() * 0.5 + 0.5) * std::u16::MAX as f32) as u16;
                     for out in sample.iter_mut() {
                         *out = value;
@@ -39,7 +36,7 @@ fn main() -> Result<(), anyhow::Error> {
                 }
             },
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::I16(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = (next_value() * std::i16::MAX as f32) as i16;
                     for out in sample.iter_mut() {
                         *out = value;
@@ -47,7 +44,7 @@ fn main() -> Result<(), anyhow::Error> {
                 }
             },
             cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer) } => {
-                for sample in buffer.chunks_mut(format.channels as usize) {
+                for sample in buffer.chunks_mut(channels as usize) {
                     let value = next_value();
                     for out in sample.iter_mut() {
                         *out = value;
@@ -56,5 +53,10 @@ fn main() -> Result<(), anyhow::Error> {
             },
             _ => (),
         }
-    });
+    })?;
+    stream.play()?;
+    
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    Ok(())
 }

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -49,15 +49,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Build streams.
     println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream = input_device.build_input_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on input stream: {}", err);
-                return;
-            },
-        };
-
+    let input_stream = input_device.build_input_stream(&format, move |data| {
         match data {
             cpal::StreamData::Input {
                 buffer: cpal::UnknownTypeInputBuffer::F32(buffer),
@@ -74,15 +66,10 @@ fn main() -> Result<(), anyhow::Error> {
             },
             _ => panic!("Expected input with f32 data"),
         }
+    }, move |err| {
+        eprintln!("an error occurred on input stream: {}", err);
     })?;
-    let output_stream = output_device.build_output_stream(&format, move |result| {
-        let data = match result {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on output stream: {}", err);
-                return;
-            },
-        };
+    let output_stream = output_device.build_output_stream(&format, move |data| {
         match data {
             cpal::StreamData::Output {
                 buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer),
@@ -103,6 +90,8 @@ fn main() -> Result<(), anyhow::Error> {
             },
             _ => panic!("Expected output with f32 data"),
         }
+    }, move |err| {
+        eprintln!("an error occurred on output stream: {}", err);
     })?;
     println!("Successfully built streams.");
 

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -10,30 +10,27 @@ extern crate anyhow;
 extern crate cpal;
 extern crate ringbuf;
 
-use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use ringbuf::RingBuffer;
 
 const LATENCY_MS: f32 = 150.0;
 
 fn main() -> Result<(), anyhow::Error> {
     let host = cpal::default_host();
-    let event_loop = host.event_loop();
 
     // Default devices.
-    let input_device = host.default_input_device().expect("failed to get default input device");
-    let output_device = host.default_output_device().expect("failed to get default output device");
+    let input_device = host
+        .default_input_device()
+        .expect("failed to get default input device");
+    let output_device = host
+        .default_output_device()
+        .expect("failed to get default output device");
     println!("Using default input device: \"{}\"", input_device.name()?);
     println!("Using default output device: \"{}\"", output_device.name()?);
 
     // We'll try and use the same format between streams to keep it simple
     let mut format = input_device.default_input_format()?;
     format.data_type = cpal::SampleFormat::F32;
-
-    // Build streams.
-    println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream_id = event_loop.build_input_stream(&input_device, &format)?;
-    let output_stream_id = event_loop.build_output_stream(&output_device, &format)?;
-    println!("Successfully built streams.");
 
     // Create a delay in case the input and output devices aren't synced.
     let latency_frames = (LATENCY_MS / 1_000.0) * format.sample_rate.0 as f32;
@@ -50,59 +47,78 @@ fn main() -> Result<(), anyhow::Error> {
         producer.push(0.0).unwrap();
     }
 
-    // Play the streams.
-    println!("Starting the input and output streams with `{}` milliseconds of latency.", LATENCY_MS);
-    event_loop.play_stream(input_stream_id.clone())?;
-    event_loop.play_stream(output_stream_id.clone())?;
+    // Build streams.
+    println!("Attempting to build both streams with `{:?}`.", format);
+    let input_stream = input_device.build_input_stream(&format, move |result| {
+        let data = match result {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("an error occurred on input stream: {}", err);
+                return;
+            },
+        };
 
-    // Run the event loop on a separate thread.
-    std::thread::spawn(move || {
-        event_loop.run(move |id, result| {
-            let data = match result {
-                Ok(data) => data,
-                Err(err) => {
-                    eprintln!("an error occurred on stream {:?}: {}", id, err);
-                    return;
+        match data {
+            cpal::StreamData::Input {
+                buffer: cpal::UnknownTypeInputBuffer::F32(buffer),
+            } => {
+                let mut output_fell_behind = false;
+                for &sample in buffer.iter() {
+                    if producer.push(sample).is_err() {
+                        output_fell_behind = true;
+                    }
                 }
-            };
+                if output_fell_behind {
+                    eprintln!("output stream fell behind: try increasing latency");
+                }
+            },
+            _ => panic!("Expected input with f32 data"),
+        }
+    })?;
+    let output_stream = output_device.build_output_stream(&format, move |result| {
+        let data = match result {
+            Ok(data) => data,
+            Err(err) => {
+                eprintln!("an error occurred on output stream: {}", err);
+                return;
+            },
+        };
+        match data {
+            cpal::StreamData::Output {
+                buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer),
+            } => {
+                let mut input_fell_behind = None;
+                for sample in buffer.iter_mut() {
+                    *sample = match consumer.pop() {
+                        Ok(s) => s,
+                        Err(err) => {
+                            input_fell_behind = Some(err);
+                            0.0
+                        },
+                    };
+                }
+                if let Some(err) = input_fell_behind {
+                    eprintln!("input stream fell behind: {:?}: try increasing latency", err);
+                }
+            },
+            _ => panic!("Expected output with f32 data"),
+        }
+    })?;
+    println!("Successfully built streams.");
 
-            match data {
-                cpal::StreamData::Input { buffer: cpal::UnknownTypeInputBuffer::F32(buffer) } => {
-                    assert_eq!(id, input_stream_id);
-                    let mut output_fell_behind = false;
-                    for &sample in buffer.iter() {
-                        if producer.push(sample).is_err() {
-                            output_fell_behind = true;
-                        }
-                    }
-                    if output_fell_behind {
-                        eprintln!("output stream fell behind: try increasing latency");
-                    }
-                },
-                cpal::StreamData::Output { buffer: cpal::UnknownTypeOutputBuffer::F32(mut buffer) } => {
-                    assert_eq!(id, output_stream_id);
-                    let mut input_fell_behind = None;
-                    for sample in buffer.iter_mut() {
-                        *sample = match consumer.pop() {
-                            Ok(s) => s,
-                            Err(err) => {
-                                input_fell_behind = Some(err);
-                                0.0
-                            },
-                        };
-                    }
-                    if let Some(_) = input_fell_behind {
-                        eprintln!("input stream fell behind: try increasing latency");
-                    }
-                },
-                _ => panic!("we're expecting f32 data"),
-            }
-        });
-    });
+    // Play the streams.
+    println!(
+        "Starting the input and output streams with `{}` milliseconds of latency.",
+        LATENCY_MS
+    );
+    input_stream.play()?;
+    output_stream.play()?;
 
     // Run for 3 seconds before closing.
     println!("Playing for 3 seconds... ");
     std::thread::sleep(std::time::Duration::from_secs(3));
+    drop(input_stream);
+    drop(output_stream);
     println!("Done!");
     Ok(())
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -32,15 +32,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Run the input stream on a separate thread.
     let writer_2 = writer.clone();
-    let stream = device.build_input_stream(&format, move |event| {
-        let data = match event {
-            Ok(data) => data,
-            Err(err) => {
-                eprintln!("an error occurred on stream: {}", err);
-                return;
-            },
-        };
-
+    let stream = device.build_input_stream(&format, move |data| {
         // Otherwise write to the wav writer.
         match data {
             cpal::StreamData::Input {
@@ -79,6 +71,8 @@ fn main() -> Result<(), anyhow::Error> {
             },
             _ => (),
         }
+    }, move |err| {
+        eprintln!("an error occurred on stream: {}", err);
     })?;
     stream.play()?;
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -583,7 +583,7 @@ fn stream_worker(rx: TriggerReceiver,
                 continue;
             },
             Err(err) => {
-                // TODO: signal errors
+                error_callback(err.into());
                 continue;
             }
         };

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -1,4 +1,5 @@
 extern crate asio_sys as sys;
+extern crate parking_lot;
 
 use {
     BuildStreamError,

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -14,20 +14,18 @@ use SupportedFormatsError;
 use SampleFormat;
 use SampleRate;
 use StreamData;
-use StreamDataResult;
+use StreamError;
 use SupportedFormat;
 use UnknownTypeInputBuffer;
 use UnknownTypeOutputBuffer;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 use std::ffi::CStr;
 use std::fmt;
 use std::mem;
+use std::cell::RefCell;
 use std::os::raw::c_char;
 use std::ptr::null;
-use std::sync::{Arc, Condvar, Mutex};
-use std::thread;
-use std::time::Duration;
 use std::slice;
 
 use self::coreaudio::audio_unit::{AudioUnit, Scope, Element};
@@ -87,7 +85,6 @@ impl Host {
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         // Assume coreaudio is always available on macOS and iOS.
@@ -105,15 +102,12 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
 
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+	type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)
@@ -134,49 +128,15 @@ impl DeviceTrait for Device {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         Device::default_output_format(self)
     }
-}
 
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    fn build_input_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_input_stream(self, device, format)
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Device::build_input_stream(self, format, data_callback, error_callback)
     }
 
-    fn build_output_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_output_stream(self, device, format)
-    }
-
-    fn play_stream(&self, stream: Self::StreamId) -> Result<(), PlayStreamError> {
-        EventLoop::play_stream(self, stream)
-    }
-
-    fn pause_stream(&self, stream: Self::StreamId) -> Result<(), PauseStreamError> {
-        EventLoop::pause_stream(self, stream)
-    }
-
-    fn destroy_stream(&self, stream: Self::StreamId) {
-        EventLoop::destroy_stream(self, stream)
-    }
-
-    fn run<F>(&self, callback: F) -> !
-    where
-        F: FnMut(Self::StreamId, StreamDataResult) + Send,
-    {
-        EventLoop::run(self, callback)
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Device::build_output_stream(self, format, data_callback, error_callback)
     }
 }
-
-impl StreamIdTrait for StreamId {}
 
 #[derive(Clone, PartialEq, Eq)]
 pub struct Device {
@@ -420,31 +380,6 @@ impl fmt::Debug for Device {
     }
 }
 
-// The ID of a stream is its index within the `streams` array of the events loop.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamId(usize);
-
-pub struct EventLoop {
-    // This `Arc` is shared with all the callbacks of coreaudio.
-    //
-    // TODO: Eventually, CPAL's API should be changed to allow for submitting a unique callback per
-    // stream to avoid streams blocking one another.
-    user_callback: Arc<Mutex<UserCallback>>,
-    streams: Mutex<Vec<Option<StreamInner>>>,
-    loop_cond: Arc<(Mutex<bool>, Condvar)>,
-}
-
-enum UserCallback {
-    // When `run` is called with a callback, that callback will be stored here.
-    //
-    // It is essential for the safety of the program that this callback is removed before `run`
-    // returns (not possible with the current CPAL API).
-    Active(&'static mut (dyn FnMut(StreamId, StreamDataResult) + Send)),
-    // A queue of events that have occurred but that have not yet been emitted to the user as we
-    // don't yet have a callback to do so.
-    Inactive,
-}
-
 struct StreamInner {
     playing: bool,
     audio_unit: AudioUnit,
@@ -540,75 +475,8 @@ fn audio_unit_from_device(device: &Device, input: bool) -> Result<AudioUnit, cor
     Ok(audio_unit)
 }
 
-impl EventLoop {
-    #[inline]
-    fn new() -> EventLoop {
-        EventLoop {
-            user_callback: Arc::new(Mutex::new(UserCallback::Inactive)),
-            streams: Mutex::new(Vec::new()),
-            loop_cond: Arc::new((Mutex::new(false), Condvar::new())),
-        }
-    }
-
-    #[inline]
-    fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult) + Send
-    {
-        {
-            let mut guard = self.user_callback.lock().unwrap();
-            if let UserCallback::Active(_) = *guard {
-                panic!("`EventLoop::run` was called when the event loop was already running");
-            }
-            let callback: &mut (dyn FnMut(StreamId, StreamDataResult) + Send) = &mut callback;
-            *guard = UserCallback::Active(unsafe { mem::transmute(callback) });
-        }
-
-        // Wait on a condvar to notify, which should never happen.
-        let &(ref lock, ref cvar) = &*self.loop_cond;
-        let mut running = lock.lock().unwrap();
-        *running = true;
-        while *running {
-            running = cvar.wait(running).unwrap();
-        }
-
-        unreachable!("current `EventLoop` API requires that `run` may not return");
-
-        // It is critical that we remove the callback before returning (currently not possible).
-        // *self.user_callback.lock().unwrap() = UserCallback::Inactive;
-    }
-
-    fn next_stream_id(&self) -> usize {
-        let streams_lock = self.streams.lock().unwrap();
-        let stream_id = streams_lock
-            .iter()
-            .position(|n| n.is_none())
-            .unwrap_or(streams_lock.len());
-        stream_id
-    }
-
-    // Add the stream to the list of streams within `self`.
-    fn add_stream(&self, stream_id: usize, au: AudioUnit, device_id: AudioDeviceID) {
-        let inner = StreamInner {
-            playing: true,
-            audio_unit: au,
-            device_id: device_id,
-        };
-
-        let mut streams_lock = self.streams.lock().unwrap();
-        if stream_id == streams_lock.len() {
-            streams_lock.push(Some(inner));
-        } else {
-            streams_lock[stream_id] = Some(inner);
-        }
-    }
-
-    #[inline]
-    fn build_input_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
+impl Device {
+    fn build_input_stream<D, E>(&self, format: &Format, mut data_callback: D, _error_callback: E) -> Result<Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         // The scope and element for working with a device's input stream.
         let scope = Scope::Output;
         let element = Element::Input;
@@ -624,7 +492,7 @@ impl EventLoop {
             let sample_rate: f64 = 0.0;
             let data_size = mem::size_of::<f64>() as u32;
             let status = AudioObjectGetPropertyData(
-                device.audio_device_id,
+                self.audio_device_id,
                 &property_address as *const _,
                 0,
                 null(),
@@ -635,26 +503,11 @@ impl EventLoop {
 
             // If the requested sample rate is different to the device sample rate, update the device.
             if sample_rate as u32 != format.sample_rate.0 {
-
-                // In order to avoid breaking existing input streams we return an error if there is
-                // already an active input stream for this device with the actual sample rate.
-                for stream in &*self.streams.lock().unwrap() {
-                    if let Some(stream) = stream.as_ref() {
-                        if stream.device_id == device.audio_device_id {
-                            let description = "cannot change device sample rate for stream as an \
-                                existing stream is already running at the current sample rate"
-                                .into();
-                            let err = BackendSpecificError { description };
-                            return Err(err.into());
-                        }
-                    }
-                }
-
                 // Get available sample rate ranges.
                 property_address.mSelector = kAudioDevicePropertyAvailableNominalSampleRates;
                 let data_size = 0u32;
                 let status = AudioObjectGetPropertyDataSize(
-                    device.audio_device_id,
+                    self.audio_device_id,
                     &property_address as *const _,
                     0,
                     null(),
@@ -665,7 +518,7 @@ impl EventLoop {
                 let mut ranges: Vec<u8> = vec![];
                 ranges.reserve_exact(data_size as usize);
                 let status = AudioObjectGetPropertyData(
-                    device.audio_device_id,
+                    self.audio_device_id,
                     &property_address as *const _,
                     0,
                     null(),
@@ -719,7 +572,7 @@ impl EventLoop {
                 // Add our sample rate change listener callback.
                 let reported_rate: f64 = 0.0;
                 let status = AudioObjectAddPropertyListener(
-                    device.audio_device_id,
+                    self.audio_device_id,
                     &property_address as *const _,
                     Some(rate_listener),
                     &reported_rate as *const _ as *mut _,
@@ -729,7 +582,7 @@ impl EventLoop {
                 // Finally, set the sample rate.
                 let sample_rate = sample_rate as f64;
                 let status = AudioObjectSetPropertyData(
-                    device.audio_device_id,
+                    self.audio_device_id,
                     &property_address as *const _,
                     0,
                     null(),
@@ -753,7 +606,7 @@ impl EventLoop {
 
                 // Remove the `rate_listener` callback.
                 let status = AudioObjectRemovePropertyListener(
-                    device.audio_device_id,
+                    self.audio_device_id,
                     &property_address as *const _,
                     Some(rate_listener),
                     &reported_rate as *const _ as *mut _,
@@ -762,18 +615,14 @@ impl EventLoop {
             }
         }
 
-        let mut audio_unit = audio_unit_from_device(device, true)?;
+        let mut audio_unit = audio_unit_from_device(self, true)?;
 
         // Set the stream in interleaved mode.
         let asbd = asbd_from_format(format);
         audio_unit.set_property(kAudioUnitProperty_StreamFormat, scope, element, Some(&asbd))?;
 
-        // Determine the future ID of the stream.
-        let stream_id = self.next_stream_id();
-
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
-        let user_callback = self.user_callback.clone();
         let sample_format = format.data_type;
         let bytes_per_channel = format.data_type.sample_size();
         type Args = render_callback::Args<data::Raw>;
@@ -789,20 +638,14 @@ impl EventLoop {
                 mData: data
             } = buffers[0];
 
-            let mut user_callback = user_callback.lock().unwrap();
-
             // A small macro to simplify handling the callback for different sample types.
             macro_rules! try_callback {
                 ($SampleFormat:ident, $SampleType:ty) => {{
                     let data_len = (data_byte_size as usize / bytes_per_channel) as usize;
                     let data_slice = slice::from_raw_parts(data as *const $SampleType, data_len);
-                    let callback = match *user_callback {
-                        UserCallback::Active(ref mut cb) => cb,
-                        UserCallback::Inactive => return Ok(()),
-                    };
                     let unknown_type_buffer = UnknownTypeInputBuffer::$SampleFormat(::InputBuffer { buffer: data_slice });
                     let stream_data = StreamData::Input { buffer: unknown_type_buffer };
-                    callback(StreamId(stream_id), Ok(stream_data));
+                    data_callback(stream_data);
                 }};
             }
 
@@ -815,23 +658,17 @@ impl EventLoop {
             Ok(())
         })?;
 
-        // TODO: start playing now? is that consistent with the other backends?
         audio_unit.start()?;
 
-        // Add the stream to the list of streams within `self`.
-        self.add_stream(stream_id, audio_unit, device.audio_device_id);
-
-        Ok(StreamId(stream_id))
+        Ok(Stream::new(StreamInner {
+            playing: true,
+            audio_unit,
+            device_id: self.audio_device_id,
+        }))
     }
 
-    #[inline]
-    fn build_output_stream(
-        &self,
-        device: &Device,
-        format: &Format,
-    ) -> Result<StreamId, BuildStreamError>
-    {
-        let mut audio_unit = audio_unit_from_device(device, false)?;
+    fn build_output_stream<D, E>(&self, format: &Format, mut data_callback: D, _error_callback: E) -> Result<Stream, BuildStreamError> where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        let mut audio_unit = audio_unit_from_device(self, false)?;
 
         // The scope and element for working with a device's output stream.
         let scope = Scope::Input;
@@ -841,12 +678,8 @@ impl EventLoop {
         let asbd = asbd_from_format(format);
         audio_unit.set_property(kAudioUnitProperty_StreamFormat, scope, element, Some(&asbd))?;
 
-        // Determine the future ID of the stream.
-        let stream_id = self.next_stream_id();
-
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
-        let user_callback = self.user_callback.clone();
         let sample_format = format.data_type;
         let bytes_per_channel = format.data_type.sample_size();
         type Args = render_callback::Args<data::Raw>;
@@ -860,25 +693,14 @@ impl EventLoop {
                 mData: data
             } = (*args.data.data).mBuffers[0];
 
-            let mut user_callback = user_callback.lock().unwrap();
-
             // A small macro to simplify handling the callback for different sample types.
             macro_rules! try_callback {
                 ($SampleFormat:ident, $SampleType:ty, $equilibrium:expr) => {{
                     let data_len = (data_byte_size as usize / bytes_per_channel) as usize;
                     let data_slice = slice::from_raw_parts_mut(data as *mut $SampleType, data_len);
-                    let callback = match *user_callback {
-                        UserCallback::Active(ref mut cb) => cb,
-                        UserCallback::Inactive => {
-                            for sample in data_slice.iter_mut() {
-                                *sample = $equilibrium;
-                            }
-                            return Ok(());
-                        }
-                    };
                     let unknown_type_buffer = UnknownTypeOutputBuffer::$SampleFormat(::OutputBuffer { buffer: data_slice });
                     let stream_data = StreamData::Output { buffer: unknown_type_buffer };
-                    callback(StreamId(stream_id), Ok(stream_data));
+                    data_callback(stream_data);
                 }};
             }
 
@@ -891,25 +713,31 @@ impl EventLoop {
             Ok(())
         })?;
 
-        // TODO: start playing now? is that consistent with the other backends?
         audio_unit.start()?;
 
-        // Add the stream to the list of streams within `self`.
-        self.add_stream(stream_id, audio_unit, device.audio_device_id);
-
-        Ok(StreamId(stream_id))
+        Ok(Stream::new(StreamInner {
+            playing: true,
+            audio_unit,
+            device_id: self.audio_device_id,
+        }))
     }
+}
 
-    fn destroy_stream(&self, stream_id: StreamId) {
-        {
-            let mut streams = self.streams.lock().unwrap();
-            streams[stream_id.0] = None;
+pub struct Stream {
+    inner: RefCell<StreamInner>,
+}
+
+impl Stream {
+    fn new(inner: StreamInner) -> Self {
+        Self {
+            inner: RefCell::new(inner),
         }
     }
+}
 
-    fn play_stream(&self, stream_id: StreamId) -> Result<(), PlayStreamError> {
-        let mut streams = self.streams.lock().unwrap();
-        let stream = streams[stream_id.0].as_mut().unwrap();
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        let mut stream = self.inner.borrow_mut();
 
         if !stream.playing {
             if let Err(e) = stream.audio_unit.start() {
@@ -922,9 +750,8 @@ impl EventLoop {
         Ok(())
     }
 
-    fn pause_stream(&self, stream_id: StreamId) -> Result<(), PauseStreamError> {
-        let mut streams = self.streams.lock().unwrap();
-        let stream = streams[stream_id.0].as_mut().unwrap();
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        let mut stream = self.inner.borrow_mut();
 
         if stream.playing {
             if let Err(e) = stream.audio_unit.stop() {

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -1,7 +1,6 @@
 use std::mem;
 use std::os::raw::c_void;
 use std::slice::from_raw_parts;
-use std::sync::Mutex;
 use stdweb;
 use stdweb::Reference;
 use stdweb::unstable::TryInto;
@@ -17,25 +16,102 @@ use PauseStreamError;
 use PlayStreamError;
 use SupportedFormatsError;
 use StreamData;
-use StreamDataResult;
+use StreamError;
 use SupportedFormat;
 use UnknownTypeOutputBuffer;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{DeviceTrait, HostTrait, StreamTrait};
+
+// The emscripten backend currently works by instantiating an `AudioContext` object per `Stream`.
+// Creating a stream creates a new `AudioContext`. Destroying a stream destroys it. Creation of a
+// `Host` instance initializes the `stdweb` context.
 
 /// The default emscripten host type.
 #[derive(Debug)]
 pub struct Host;
 
+/// Content is false if the iterator is empty.
+pub struct Devices(bool);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Device;
+
+pub struct Stream {
+    // A reference to an `AudioContext` object.
+    audio_ctxt_ref: Reference,
+}
+
+// Index within the `streams` array of the events loop.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StreamId(usize);
+
+pub type SupportedInputFormats = ::std::vec::IntoIter<SupportedFormat>;
+pub type SupportedOutputFormats = ::std::vec::IntoIter<SupportedFormat>;
+
 impl Host {
     pub fn new() -> Result<Self, crate::HostUnavailable> {
+        stdweb::initialize();
         Ok(Host)
+    }
+}
+
+impl Devices {
+    fn new() -> Result<Self, DevicesError> {
+        Ok(Self::default())
+    }
+}
+
+impl Device {
+    #[inline]
+    fn name(&self) -> Result<String, DeviceNameError> {
+        Ok("Default Device".to_owned())
+    }
+
+    #[inline]
+    fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
+        unimplemented!();
+    }
+
+    #[inline]
+    fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
+        // TODO: right now cpal's API doesn't allow flexibility here
+        //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
+        //       this ever becomes more flexible, don't forget to change that
+        //       According to https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createBuffer
+        //       browsers must support 1 to 32 channels at leats and 8,000 Hz to 96,000 Hz.
+        //
+        //       UPDATE: We can do this now. Might be best to use `crate::COMMON_SAMPLE_RATES` and
+        //       filter out those that lay outside the range specified above.
+        Ok(
+            vec![
+                SupportedFormat {
+                    channels: 2,
+                    min_sample_rate: ::SampleRate(44100),
+                    max_sample_rate: ::SampleRate(44100),
+                    data_type: ::SampleFormat::F32,
+                },
+            ].into_iter(),
+        )
+    }
+
+    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+        unimplemented!();
+    }
+
+    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+        // TODO: because it is hard coded, see supported_output_formats.
+        Ok(
+            Format {
+                channels: 2,
+                sample_rate: ::SampleRate(44100),
+                data_type: ::SampleFormat::F32,
+            },
+        )
     }
 }
 
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         // Assume this host is always available on emscripten.
@@ -53,15 +129,12 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
 
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)
@@ -82,224 +155,124 @@ impl DeviceTrait for Device {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         Device::default_output_format(self)
     }
-}
 
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    fn build_input_stream(
+    fn build_input_stream<D, E>(
         &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_input_stream(self, device, format)
-    }
-
-    fn build_output_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_output_stream(self, device, format)
-    }
-
-    fn play_stream(&self, stream: Self::StreamId) -> Result<(), PlayStreamError> {
-        EventLoop::play_stream(self, stream)
-    }
-
-    fn pause_stream(&self, stream: Self::StreamId) -> Result<(), PauseStreamError> {
-        EventLoop::pause_stream(self, stream)
-    }
-
-    fn destroy_stream(&self, stream: Self::StreamId) {
-        EventLoop::destroy_stream(self, stream)
-    }
-
-    fn run<F>(&self, callback: F) -> !
+        _format: &Format,
+        _data_callback: D,
+        _error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
     where
-        F: FnMut(Self::StreamId, StreamDataResult) + Send,
+        D: FnMut(StreamData) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
     {
-        EventLoop::run(self, callback)
+        unimplemented!()
+    }
+
+    fn build_output_stream<D, E>(
+        &self,
+        _format: &Format,
+        data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(StreamData) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        // Create the stream.
+        let audio_ctxt_ref = js!(return new AudioContext()).into_reference().unwrap();
+        let stream = Stream { audio_ctxt_ref };
+
+        // Specify the callback.
+        let mut user_data = (self, data_callback, error_callback);
+        let user_data_ptr = &mut user_data as *mut (_, _, _);
+
+        // Use `set_timeout` to invoke a Rust callback repeatedly.
+        //
+        // The job of this callback is to fill the content of the audio buffers.
+        //
+        // See also: The call to `set_timeout` at the end of the `audio_callback_fn` which creates
+        // the loop.
+        set_timeout(|| audio_callback_fn::<D, E>(user_data_ptr as *mut c_void), 10);
+
+        Ok(stream)
     }
 }
 
-impl StreamIdTrait for StreamId {}
-
-// The emscripten backend works by having a global variable named `_cpal_audio_contexts`, which
-// is an array of `AudioContext` objects. A stream ID corresponds to an entry in this array.
-//
-// Creating a stream creates a new `AudioContext`. Destroying a stream destroys it.
-
-// TODO: handle latency better ; right now we just use setInterval with the amount of sound data
-// that is in each buffer ; this is obviously bad, and also the schedule is too tight and there may
-// be underflows
-
-pub struct EventLoop {
-    streams: Mutex<Vec<Option<Reference>>>,
-}
-
-impl EventLoop {
-    #[inline]
-    pub fn new() -> EventLoop {
-        stdweb::initialize();
-        EventLoop {
-            streams: Mutex::new(Vec::new()),
-        }
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        let audio_ctxt = &self.audio_ctxt_ref;
+        js!(@{audio_ctxt}.resume());
+        Ok(())
     }
 
-    #[inline]
-    fn run<F>(&self, callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult),
-    {
-        // The `run` function uses `set_timeout` to invoke a Rust callback repeatidely. The job
-        // of this callback is to fill the content of the audio buffers.
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        let audio_ctxt = &self.audio_ctxt_ref;
+        js!(@{audio_ctxt}.suspend());
+        Ok(())
+    }
+}
 
-        // The first argument of the callback function (a `void*`) is a casted pointer to `self`
-        // and to the `callback` parameter that was passed to `run`.
+// The first argument of the callback function (a `void*`) is a casted pointer to `self`
+// and to the `callback` parameter that was passed to `run`.
+fn audio_callback_fn<D, E>(user_data_ptr: *mut c_void)
+where
+    D: FnMut(StreamData) + Send + 'static,
+    E: FnMut(StreamError) + Send + 'static,
+{
+    unsafe {
+        let user_data_ptr2 = user_data_ptr as *mut (&Stream, D, E);
+        let user_data = &mut *user_data_ptr2;
+        let (ref stream, ref mut data_cb, ref mut _err_cb) = user_data;
+        let audio_ctxt = &stream.audio_ctxt_ref;
 
-        fn callback_fn<F>(user_data_ptr: *mut c_void)
-            where F: FnMut(StreamId, StreamDataResult)
+        // TODO: We should be re-using a buffer.
+        let mut temporary_buffer = vec![0.0; 44100 * 2 / 3];
+
         {
-            unsafe {
-                let user_data_ptr2 = user_data_ptr as *mut (&EventLoop, F);
-                let user_data = &mut *user_data_ptr2;
-                let user_cb = &mut user_data.1;
-
-                let streams = user_data.0.streams.lock().unwrap().clone();
-                for (stream_id, stream) in streams.iter().enumerate() {
-                    let stream = match stream.as_ref() {
-                        Some(v) => v,
-                        None => continue,
-                    };
-
-                    let mut temporary_buffer = vec![0.0; 44100 * 2 / 3];
-
-                    {
-                        let buffer = UnknownTypeOutputBuffer::F32(::OutputBuffer { buffer: &mut temporary_buffer });
-                        let data = StreamData::Output { buffer: buffer };
-                        user_cb(StreamId(stream_id), Ok(data));
-                        // TODO: directly use a TypedArray<f32> once this is supported by stdweb
-                    }
-
-                    let typed_array = {
-                        let f32_slice = temporary_buffer.as_slice();
-                        let u8_slice: &[u8] = from_raw_parts(
-                            f32_slice.as_ptr() as *const _,
-                            f32_slice.len() * mem::size_of::<f32>(),
-                        );
-                        let typed_array: TypedArray<u8> = u8_slice.into();
-                        typed_array
-                    };
-
-                    let num_channels = 2u32; // TODO: correct value
-                    debug_assert_eq!(temporary_buffer.len() % num_channels as usize, 0);
-
-                    js!(
-                        var src_buffer = new Float32Array(@{typed_array}.buffer);
-                        var context = @{stream};
-                        var buf_len = @{temporary_buffer.len() as u32};
-                        var num_channels = @{num_channels};
-
-                        var buffer = context.createBuffer(num_channels, buf_len / num_channels, 44100);
-                        for (var channel = 0; channel < num_channels; ++channel) {
-                            var buffer_content = buffer.getChannelData(channel);
-                            for (var i = 0; i < buf_len / num_channels; ++i) {
-                                buffer_content[i] = src_buffer[i * num_channels + channel];
-                            }
-                        }
-
-                        var node = context.createBufferSource();
-                        node.buffer = buffer;
-                        node.connect(context.destination);
-                        node.start();
-                    );
-                }
-
-                set_timeout(|| callback_fn::<F>(user_data_ptr), 330);
-            }
+            let buffer = UnknownTypeOutputBuffer::F32(::OutputBuffer { buffer: &mut temporary_buffer });
+            let data = StreamData::Output { buffer: buffer };
+            data_cb(data);
         }
 
-        let mut user_data = (self, callback);
-        let user_data_ptr = &mut user_data as *mut (_, _);
-
-        set_timeout(|| callback_fn::<F>(user_data_ptr as *mut _), 10);
-
-        stdweb::event_loop();
-    }
-
-    #[inline]
-    fn build_input_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, BuildStreamError> {
-        unimplemented!();
-    }
-
-    #[inline]
-    fn build_output_stream(&self, _: &Device, _format: &Format) -> Result<StreamId, BuildStreamError> {
-        let stream = js!(return new AudioContext()).into_reference().unwrap();
-
-        let mut streams = self.streams.lock().unwrap();
-        let stream_id = if let Some(pos) = streams.iter().position(|v| v.is_none()) {
-            streams[pos] = Some(stream);
-            pos
-        } else {
-            let l = streams.len();
-            streams.push(Some(stream));
-            l
+        // TODO: directly use a TypedArray<f32> once this is supported by stdweb
+        let typed_array = {
+            let f32_slice = temporary_buffer.as_slice();
+            let u8_slice: &[u8] = from_raw_parts(
+                f32_slice.as_ptr() as *const _,
+                f32_slice.len() * mem::size_of::<f32>(),
+            );
+            let typed_array: TypedArray<u8> = u8_slice.into();
+            typed_array
         };
 
-        Ok(StreamId(stream_id))
-    }
+        let num_channels = 2u32; // TODO: correct value
+        debug_assert_eq!(temporary_buffer.len() % num_channels as usize, 0);
 
-    #[inline]
-    fn destroy_stream(&self, stream_id: StreamId) {
-        self.streams.lock().unwrap()[stream_id.0] = None;
-    }
+        js!(
+            var src_buffer = new Float32Array(@{typed_array}.buffer);
+            var context = @{audio_ctxt};
+            var buf_len = @{temporary_buffer.len() as u32};
+            var num_channels = @{num_channels};
 
-    #[inline]
-    fn play_stream(&self, stream_id: StreamId) -> Result<(), PlayStreamError> {
-        let streams = self.streams.lock().unwrap();
-        let stream = streams
-            .get(stream_id.0)
-            .and_then(|v| v.as_ref())
-            .expect("invalid stream ID");
-        js!(@{stream}.resume());
-        Ok(())
-    }
+            var buffer = context.createBuffer(num_channels, buf_len / num_channels, 44100);
+            for (var channel = 0; channel < num_channels; ++channel) {
+                var buffer_content = buffer.getChannelData(channel);
+                for (var i = 0; i < buf_len / num_channels; ++i) {
+                    buffer_content[i] = src_buffer[i * num_channels + channel];
+                }
+            }
 
-    #[inline]
-    fn pause_stream(&self, stream_id: StreamId) -> Result<(), PauseStreamError> {
-        let streams = self.streams.lock().unwrap();
-        let stream = streams
-            .get(stream_id.0)
-            .and_then(|v| v.as_ref())
-            .expect("invalid stream ID");
-        js!(@{stream}.suspend());
-        Ok(())
-    }
-}
+            var node = context.createBufferSource();
+            node.buffer = buffer;
+            node.connect(context.destination);
+            node.start();
+        );
 
-// Index within the `streams` array of the events loop.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamId(usize);
-
-// Detects whether the `AudioContext` global variable is available.
-fn is_webaudio_available() -> bool {
-    stdweb::initialize();
-
-    js!(if (!AudioContext) {
-            return false;
-        } else {
-            return true;
-        }).try_into()
-        .unwrap()
-}
-
-// Content is false if the iterator is empty.
-pub struct Devices(bool);
-
-impl Devices {
-    fn new() -> Result<Self, DevicesError> {
-        Ok(Self::default())
+        // TODO: handle latency better ; right now we just use setInterval with the amount of sound
+        // data that is in each buffer ; this is obviously bad, and also the schedule is too tight
+        // and there may be underflows
+        set_timeout(|| audio_callback_fn::<D, E>(user_data_ptr), 330);
     }
 }
 
@@ -336,54 +309,13 @@ fn default_output_device() -> Option<Device> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Device;
-
-impl Device {
-    #[inline]
-    fn name(&self) -> Result<String, DeviceNameError> {
-        Ok("Default Device".to_owned())
-    }
-
-    #[inline]
-    fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
-        unimplemented!();
-    }
-
-    #[inline]
-    fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
-        // TODO: right now cpal's API doesn't allow flexibility here
-        //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
-        //       this ever becomes more flexible, don't forget to change that
-        //       According to https://developer.mozilla.org/en-US/docs/Web/API/BaseAudioContext/createBuffer
-        //       browsers must support 1 to 32 channels at leats and 8,000 Hz to 96,000 Hz.
-        Ok(
-            vec![
-                SupportedFormat {
-                    channels: 2,
-                    min_sample_rate: ::SampleRate(44100),
-                    max_sample_rate: ::SampleRate(44100),
-                    data_type: ::SampleFormat::F32,
-                },
-            ].into_iter(),
-        )
-    }
-
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        unimplemented!();
-    }
-
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        // TODO: because it is hard coded, see supported_output_formats.
-        Ok(
-            Format {
-                channels: 2,
-                sample_rate: ::SampleRate(44100),
-                data_type: ::SampleFormat::F32,
-            },
-        )
-    }
+// Detects whether the `AudioContext` global variable is available.
+fn is_webaudio_available() -> bool {
+    stdweb::initialize();
+    js!(if (!AudioContext) {
+            return false;
+        } else {
+            return true;
+        }).try_into()
+        .unwrap()
 }
-
-pub type SupportedInputFormats = ::std::vec::IntoIter<SupportedFormat>;
-pub type SupportedOutputFormats = ::std::vec::IntoIter<SupportedFormat>;

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -77,13 +77,13 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    fn build_input_stream<D, E>(&self, _format: &Format, _data_callback: D, _error_callback: E) -> Result<Self::Stream, BuildStreamError>
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         unimplemented!()
     }
 
     /// Create an output stream.
-    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    fn build_output_stream<D, E>(&self, _format: &Format, _data_callback: D, _error_callback: E) -> Result<Self::Stream, BuildStreamError>
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static{
         unimplemented!()
     }

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -10,7 +10,7 @@ use PlayStreamError;
 use StreamDataResult;
 use SupportedFormatsError;
 use SupportedFormat;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 #[derive(Default)]
 pub struct Devices;
@@ -23,7 +23,7 @@ pub struct EventLoop;
 pub struct Host;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StreamId;
+pub struct Stream;
 
 pub struct SupportedInputFormats;
 pub struct SupportedOutputFormats;
@@ -49,6 +49,7 @@ impl EventLoop {
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     #[inline]
     fn name(&self) -> Result<String, DeviceNameError> {
@@ -74,49 +75,22 @@ impl DeviceTrait for Device {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         unimplemented!()
     }
-}
 
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    #[inline]
-    fn run<F>(&self, _callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult)
-    {
-        loop { /* TODO: don't spin */ }
-    }
-
-    #[inline]
-    fn build_input_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
-        Err(BuildStreamError::DeviceNotAvailable)
-    }
-
-    #[inline]
-    fn build_output_stream(&self, _: &Device, _: &Format) -> Result<StreamId, BuildStreamError> {
-        Err(BuildStreamError::DeviceNotAvailable)
-    }
-
-    #[inline]
-    fn destroy_stream(&self, _: StreamId) {
+    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
+        where F: FnMut(StreamDataResult) + Send + 'static {
         unimplemented!()
     }
 
-    #[inline]
-    fn play_stream(&self, _: StreamId) -> Result<(), PlayStreamError> {
-        panic!()
-    }
-
-    #[inline]
-    fn pause_stream(&self, _: StreamId) -> Result<(), PauseStreamError> {
-        panic!()
+    /// Create an output stream.
+    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
+        where F: FnMut(StreamDataResult) + Send + 'static{
+        unimplemented!()
     }
 }
 
 impl HostTrait for Host {
     type Device = Device;
     type Devices = Devices;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         false
@@ -133,13 +107,17 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Device> {
         None
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
 
-impl StreamIdTrait for StreamId {}
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        unimplemented!()
+    }
+
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        unimplemented!()
+    }
+}
 
 impl Iterator for Devices {
     type Item = Device;

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use BuildStreamError;
 use DefaultFormatError;
 use DevicesError;
@@ -19,8 +17,6 @@ pub struct Devices;
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Device;
 
-pub struct EventLoop;
-
 pub struct Host;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -30,6 +26,7 @@ pub struct SupportedInputFormats;
 pub struct SupportedOutputFormats;
 
 impl Host {
+    #[allow(dead_code)]
     pub fn new() -> Result<Self, crate::HostUnavailable> {
         Ok(Host)
     }
@@ -38,12 +35,6 @@ impl Host {
 impl Devices {
     pub fn new() -> Result<Self, DevicesError> {
         Ok(Devices)
-    }
-}
-
-impl EventLoop {
-    pub fn new() -> EventLoop {
-        EventLoop
     }
 }
 

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -7,7 +7,8 @@ use DeviceNameError;
 use Format;
 use PauseStreamError;
 use PlayStreamError;
-use StreamDataResult;
+use StreamData;
+use StreamError;
 use SupportedFormatsError;
 use SupportedFormat;
 use traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -76,14 +77,14 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static {
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         unimplemented!()
     }
 
     /// Create an output stream.
-    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static{
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static{
         unimplemented!()
     }
 }

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -3,8 +3,8 @@
 use super::check_result;
 use std::ptr;
 
-use super::winapi::um::objbase::{COINIT_MULTITHREADED};
 use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
+use super::winapi::um::objbase::COINIT_MULTITHREADED;
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -336,7 +336,7 @@ unsafe fn format_from_waveformatex_ptr(
     let format = Format {
         channels: (*waveformatex_ptr).nChannels as _,
         sample_rate: SampleRate((*waveformatex_ptr).nSamplesPerSec),
-        data_type: data_type,
+        data_type,
     };
     Some(format)
 }
@@ -400,7 +400,7 @@ impl Device {
     #[inline]
     fn from_immdevice(device: *mut IMMDevice) -> Self {
         Device {
-            device: device,
+            device,
             future_audio_client: Arc::new(Mutex::new(None)),
         }
     }
@@ -763,15 +763,15 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             {
                 let client_flow = AudioClientFlow::Capture {
-                    capture_client: capture_client,
+                    capture_client,
                 };
                 let inner = StreamInner {
                     id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
+                    audio_client,
+                    client_flow,
+                    event,
                     playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
+                    max_frames_in_buffer,
                     bytes_per_frame: waveformatex.nBlockAlign,
                     sample_format: format.data_type,
                 };
@@ -924,15 +924,15 @@ impl Device {
             // `run()` method and added to the `RunContext`.
             {
                 let client_flow = AudioClientFlow::Render {
-                    render_client: render_client,
+                    render_client,
                 };
                 let inner = StreamInner {
                     id: new_stream_id.clone(),
-                    audio_client: audio_client,
-                    client_flow: client_flow,
-                    event: event,
+                    audio_client,
+                    client_flow,
+                    event,
                     playing: false,
-                    max_frames_in_buffer: max_frames_in_buffer,
+                    max_frames_in_buffer,
                     bytes_per_frame: waveformatex.nBlockAlign,
                     sample_format: format.data_type,
                 };
@@ -1039,7 +1039,7 @@ impl From<*const IMMDevice> for Endpoint {
     fn from(device: *const IMMDevice) -> Self {
         unsafe {
             let endpoint = immendpoint_from_immdevice(device);
-            Endpoint { endpoint: endpoint }
+            Endpoint { endpoint }
         }
     }
 }
@@ -1118,7 +1118,7 @@ impl Devices {
             check_result_backend_specific((*collection).GetCount(&mut count))?;
 
             Ok(Devices {
-                collection: collection,
+                collection,
                 total_count: count,
                 next_item: 0,
             })

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::ffi::OsStringExt;
 use std::ptr;
 use std::slice;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, atomic::Ordering};
 
 use BackendSpecificError;
 use DefaultFormatError;
@@ -33,6 +33,7 @@ use super::winapi::shared::guiddef::{
 use super::winapi::shared::winerror;
 use super::winapi::shared::minwindef::{
     DWORD,
+    WORD,
 };
 use super::winapi::shared::mmreg;
 use super::winapi::shared::wtypes;
@@ -41,12 +42,14 @@ use super::winapi::um::winnt::LPWSTR;
 use super::winapi::um::winnt::WCHAR;
 use super::winapi::um::coml2api;
 use super::winapi::um::audioclient::{
+    self,
     IAudioClient,
     IID_IAudioClient,
     AUDCLNT_E_DEVICE_INVALIDATED,
 };
 use super::winapi::um::audiosessiontypes::{
     AUDCLNT_SHAREMODE_SHARED,
+    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
 };
 use super::winapi::um::combaseapi::{
     CoCreateInstance,
@@ -68,7 +71,8 @@ use super::winapi::um::mmdeviceapi::{
     IMMEndpoint,
 };
 
-use crate::traits::DeviceTrait;
+use crate::{traits::DeviceTrait, BuildStreamError, StreamData, StreamError};
+use super::{stream::{Stream, AudioClientFlow, StreamInner, Command}, winapi::um::synchapi};
 
 pub type SupportedInputFormats = std::vec::IntoIter<SupportedFormat>;
 pub type SupportedOutputFormats = std::vec::IntoIter<SupportedFormat>;
@@ -111,6 +115,24 @@ impl DeviceTrait for Device {
 
     fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
         Device::default_output_format(self)
+    }
+
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(
+            Arc::new(self.build_input_stream_inner(format)?),
+            data_callback,
+            error_callback,
+        ))
+    }
+
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+    where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
+        Ok(Stream::new(
+            Arc::new(self.build_output_stream_inner(format)?),
+            data_callback,
+            error_callback,
+        ))
     }
 }
 
@@ -600,6 +622,327 @@ impl Device {
             Err(DefaultFormatError::StreamTypeNotSupported)
         }
     }
+    
+    pub(crate) fn build_input_stream_inner(
+        &self,
+        format: &Format,
+    ) -> Result<Stream, BuildStreamError>
+    {
+        unsafe {
+            // Making sure that COM is initialized.
+            // It's not actually sure that this is required, but when in doubt do it.
+            com::com_initialized();
+
+            // Obtaining a `IAudioClient`.
+            let audio_client = match self.build_audioclient() {
+                Ok(client) => client,
+                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
+                    return Err(BuildStreamError::DeviceNotAvailable),
+                Err(e) => {
+                    let description = format!("{}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+            };
+
+            // Computing the format and initializing the device.
+            let waveformatex = {
+                let format_attempt = format_to_waveformatextensible(format)
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                let share_mode = AUDCLNT_SHAREMODE_SHARED;
+
+                // Ensure the format is supported.
+                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
+                    _ => (),
+                }
+
+                // finally initializing the audio client
+                let hresult = (*audio_client).Initialize(
+                    share_mode,
+                    AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                    0,
+                    0,
+                    &format_attempt.Format,
+                    ptr::null(),
+                );
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                format_attempt.Format
+            };
+
+            // obtaining the size of the samples buffer in number of frames
+            let max_frames_in_buffer = {
+                let mut max_frames_in_buffer = mem::uninitialized();
+                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                max_frames_in_buffer
+            };
+
+            // Creating the event that will be signalled whenever we need to submit some samples.
+            let event = {
+                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
+                if event == ptr::null_mut() {
+                    (*audio_client).Release();
+                    let description = format!("failed to create event");
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                if let Err(e) = check_result((*audio_client).SetEventHandle(event)) {
+                    (*audio_client).Release();
+                    let description = format!("failed to call SetEventHandle: {}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                event
+            };
+
+            // Building a `IAudioCaptureClient` that will be used to read captured samples.
+            let capture_client = {
+                let mut capture_client: *mut audioclient::IAudioCaptureClient = mem::uninitialized();
+                let hresult = (*audio_client).GetService(
+                    &audioclient::IID_IAudioCaptureClient,
+                    &mut capture_client as *mut *mut audioclient::IAudioCaptureClient as *mut _,
+                );
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to build capture client: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                &mut *capture_client
+            };
+
+            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
+            if new_stream_id.0 == usize::max_value() {
+                return Err(BuildStreamError::StreamIdOverflow);
+            }
+
+            // Once we built the `StreamInner`, we add a command that will be picked up by the
+            // `run()` method and added to the `RunContext`.
+            {
+                let client_flow = AudioClientFlow::Capture {
+                    capture_client: capture_client,
+                };
+                let inner = StreamInner {
+                    id: new_stream_id.clone(),
+                    audio_client: audio_client,
+                    client_flow: client_flow,
+                    event: event,
+                    playing: false,
+                    max_frames_in_buffer: max_frames_in_buffer,
+                    bytes_per_frame: waveformatex.nBlockAlign,
+                    sample_format: format.data_type,
+                };
+
+                self.push_command(Command::NewStream(inner));
+            };
+
+            Ok(new_stream_id)
+        }
+    }
+
+    pub(crate) fn build_output_stream_inner(
+        &self,
+        format: &Format,
+    ) -> Result<Stream, BuildStreamError>
+    {
+        unsafe {
+            // Making sure that COM is initialized.
+            // It's not actually sure that this is required, but when in doubt do it.
+            com::com_initialized();
+
+            // Obtaining a `IAudioClient`.
+            let audio_client = match self.build_audioclient() {
+                Ok(client) => client,
+                Err(ref e) if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) =>
+                    return Err(BuildStreamError::DeviceNotAvailable),
+                Err(e) => {
+                    let description = format!("{}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+            };
+
+            // Computing the format and initializing the device.
+            let waveformatex = {
+                let format_attempt = format_to_waveformatextensible(format)
+                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                let share_mode = AUDCLNT_SHAREMODE_SHARED;
+
+                // Ensure the format is supported.
+                match super::device::is_format_supported(audio_client, &format_attempt.Format) {
+                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
+                    _ => (),
+                }
+
+                // finally initializing the audio client
+                let hresult = (*audio_client).Initialize(share_mode,
+                                                         AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+                                                         0,
+                                                         0,
+                                                         &format_attempt.Format,
+                                                         ptr::null());
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("{}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                format_attempt.Format
+            };
+
+            // Creating the event that will be signalled whenever we need to submit some samples.
+            let event = {
+                let event = synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null());
+                if event == ptr::null_mut() {
+                    (*audio_client).Release();
+                    let description = format!("failed to create event");
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                match check_result((*audio_client).SetEventHandle(event)) {
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to call SetEventHandle: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(_) => (),
+                };
+
+                event
+            };
+
+            // obtaining the size of the samples buffer in number of frames
+            let max_frames_in_buffer = {
+                let mut max_frames_in_buffer = mem::uninitialized();
+                let hresult = (*audio_client).GetBufferSize(&mut max_frames_in_buffer);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to obtain buffer size: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                max_frames_in_buffer
+            };
+
+            // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
+            let render_client = {
+                let mut render_client: *mut audioclient::IAudioRenderClient = mem::uninitialized();
+                let hresult = (*audio_client).GetService(&audioclient::IID_IAudioRenderClient,
+                                                         &mut render_client as
+                                                             *mut *mut audioclient::IAudioRenderClient as
+                                                             *mut _);
+
+                match check_result(hresult) {
+                    Err(ref e)
+                        if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
+                        (*audio_client).Release();
+                        return Err(BuildStreamError::DeviceNotAvailable);
+                    },
+                    Err(e) => {
+                        (*audio_client).Release();
+                        let description = format!("failed to build render client: {}", e);
+                        let err = BackendSpecificError { description };
+                        return Err(err.into());
+                    },
+                    Ok(()) => (),
+                };
+
+                &mut *render_client
+            };
+
+            let new_stream_id = StreamId(self.next_stream_id.fetch_add(1, Ordering::Relaxed));
+            if new_stream_id.0 == usize::max_value() {
+                return Err(BuildStreamError::StreamIdOverflow);
+            }
+
+            // Once we built the `StreamInner`, we add a command that will be picked up by the
+            // `run()` method and added to the `RunContext`.
+            {
+                let client_flow = AudioClientFlow::Render {
+                    render_client: render_client,
+                };
+                let inner = StreamInner {
+                    id: new_stream_id.clone(),
+                    audio_client: audio_client,
+                    client_flow: client_flow,
+                    event: event,
+                    playing: false,
+                    max_frames_in_buffer: max_frames_in_buffer,
+                    bytes_per_frame: waveformatex.nBlockAlign,
+                    sample_format: format.data_type,
+                };
+
+                self.push_command(Command::NewStream(inner));
+            };
+
+            Ok(new_stream_id)
+        }
+    }
 }
 
 impl PartialEq for Device {
@@ -841,4 +1184,59 @@ pub fn default_input_device() -> Option<Device> {
 
 pub fn default_output_device() -> Option<Device> {
     default_device(eRender)
+}
+
+
+// Turns a `Format` into a `WAVEFORMATEXTENSIBLE`.
+//
+// Returns `None` if the WAVEFORMATEXTENSIBLE does not support the given format.
+fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEXTENSIBLE> {
+    let format_tag = match format.data_type {
+        SampleFormat::I16 => mmreg::WAVE_FORMAT_PCM,
+        SampleFormat::F32 => mmreg::WAVE_FORMAT_EXTENSIBLE,
+        SampleFormat::U16 => return None,
+    };
+    let channels = format.channels as WORD;
+    let sample_rate = format.sample_rate.0 as DWORD;
+    let sample_bytes = format.data_type.sample_size() as WORD;
+    let avg_bytes_per_sec = channels as DWORD * sample_rate * sample_bytes as DWORD;
+    let block_align = channels * sample_bytes;
+    let bits_per_sample = 8 * sample_bytes;
+    let cb_size = match format.data_type {
+        SampleFormat::I16 => 0,
+        SampleFormat::F32 => {
+            let extensible_size = mem::size_of::<mmreg::WAVEFORMATEXTENSIBLE>();
+            let ex_size = mem::size_of::<mmreg::WAVEFORMATEX>();
+            (extensible_size - ex_size) as WORD
+        },
+        SampleFormat::U16 => return None,
+    };
+    let waveformatex = mmreg::WAVEFORMATEX {
+        wFormatTag: format_tag,
+        nChannels: channels,
+        nSamplesPerSec: sample_rate,
+        nAvgBytesPerSec: avg_bytes_per_sec,
+        nBlockAlign: block_align,
+        wBitsPerSample: bits_per_sample,
+        cbSize: cb_size,
+    };
+
+    // CPAL does not care about speaker positions, so pass audio straight through.
+    // TODO: This constant should be defined in winapi but is missing.
+    const KSAUDIO_SPEAKER_DIRECTOUT: DWORD = 0;
+    let channel_mask = KSAUDIO_SPEAKER_DIRECTOUT;
+
+    let sub_format = match format.data_type {
+        SampleFormat::I16 => ksmedia::KSDATAFORMAT_SUBTYPE_PCM,
+        SampleFormat::F32 => ksmedia::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT,
+        SampleFormat::U16 => return None,
+    };
+    let waveformatextensible = mmreg::WAVEFORMATEXTENSIBLE {
+        Format: waveformatex,
+        Samples: bits_per_sample as WORD,
+        dwChannelMask: channel_mask,
+        SubFormat: sub_format,
+    };
+
+    Some(waveformatextensible)
 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -358,8 +358,7 @@ impl Device {
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }
-            let ptr_usize: usize = *(&property_value.data as *const _ as *const usize);
-            let ptr_utf16 = ptr_usize as *const u16;
+            let ptr_utf16 = *(&property_value.data as *const _ as *const (*const u16));
 
             // Find the length of the friendly name.
             let mut len = 0;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -7,7 +7,7 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::ffi::OsStringExt;
 use std::ptr;
 use std::slice;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, atomic::Ordering};
 
 use BackendSpecificError;
 use DefaultFormatError;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -113,7 +113,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         Ok(Stream::new(
-            Arc::new(self.build_input_stream_inner(format)?),
+            self.build_input_stream_inner(format)?,
             data_callback,
             error_callback,
         ))
@@ -130,7 +130,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         Ok(Stream::new(
-            Arc::new(self.build_output_stream_inner(format)?),
+            self.build_output_stream_inner(format)?,
             data_callback,
             error_callback,
         ))

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -68,6 +68,8 @@ use super::winapi::um::mmdeviceapi::{
     IMMEndpoint,
 };
 
+use crate::traits::DeviceTrait;
+
 pub type SupportedInputFormats = std::vec::IntoIter<SupportedFormat>;
 pub type SupportedOutputFormats = std::vec::IntoIter<SupportedFormat>;
 
@@ -85,6 +87,31 @@ pub struct Device {
     /// We cache an uninitialized `IAudioClient` so that we can call functions from it without
     /// having to create/destroy audio clients all the time.
     future_audio_client: Arc<Mutex<Option<IAudioClientWrapper>>>, // TODO: add NonZero around the ptr
+}
+
+impl DeviceTrait for Device {
+    type SupportedInputFormats = SupportedInputFormats;
+    type SupportedOutputFormats = SupportedOutputFormats;
+
+    fn name(&self) -> Result<String, DeviceNameError> {
+        Device::name(self)
+    }
+
+    fn supported_input_formats(&self) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
+        Device::supported_input_formats(self)
+    }
+
+    fn supported_output_formats(&self) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
+        Device::supported_output_formats(self)
+    }
+
+    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+        Device::default_input_format(self)
+    }
+
+    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+        Device::default_output_format(self)
+    }
 }
 
 struct Endpoint {

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -96,6 +96,7 @@ pub struct Device {
 impl DeviceTrait for Device {
     type SupportedInputFormats = SupportedInputFormats;
     type SupportedOutputFormats = SupportedOutputFormats;
+    type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -61,8 +61,9 @@ fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificE
     match check_result(result) {
         Ok(()) => Ok(()),
         Err(err) => {
-            let description = format!("{}", err);
-            return Err(BackendSpecificError { description });
+            Err(BackendSpecificError { 
+                description: format!("{}", err),
+            })
         }
     }
 }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -12,7 +12,7 @@ use StreamDataResult;
 use SupportedFormatsError;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{DeviceTrait, EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{EventLoopTrait, HostTrait, StreamIdTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
 pub use self::stream::{EventLoop, StreamId};
 
@@ -58,31 +58,6 @@ impl HostTrait for Host {
 
     fn event_loop(&self) -> Self::EventLoop {
         EventLoop::new()
-    }
-}
-
-impl DeviceTrait for Device {
-    type SupportedInputFormats = SupportedInputFormats;
-    type SupportedOutputFormats = SupportedOutputFormats;
-
-    fn name(&self) -> Result<String, DeviceNameError> {
-        Device::name(self)
-    }
-
-    fn supported_input_formats(&self) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
-        Device::supported_input_formats(self)
-    }
-
-    fn supported_output_formats(&self) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
-        Device::supported_output_formats(self)
-    }
-
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_input_format(self)
-    }
-
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_output_format(self)
     }
 }
 

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -6,7 +6,7 @@ use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
 use traits::{HostTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::{StreamId};
+pub use self::stream::Stream;
 
 mod com;
 mod device;

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,12 +1,15 @@
 extern crate winapi;
 
-use BackendSpecificError;
-use DevicesError;
+pub use self::device::{
+    default_input_device, default_output_device, Device, Devices, SupportedInputFormats,
+    SupportedOutputFormats,
+};
+pub use self::stream::Stream;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{HostTrait};
-pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::Stream;
+use traits::HostTrait;
+use BackendSpecificError;
+use DevicesError;
 
 mod com;
 mod device;
@@ -60,10 +63,8 @@ fn check_result(result: HRESULT) -> Result<(), IoError> {
 fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificError> {
     match check_result(result) {
         Ok(()) => Ok(()),
-        Err(err) => {
-            Err(BackendSpecificError { 
-                description: format!("{}", err),
-            })
-        }
+        Err(err) => Err(BackendSpecificError {
+            description: format!("{}", err),
+        }),
     }
 }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,20 +1,12 @@
 extern crate winapi;
 
 use BackendSpecificError;
-use BuildStreamError;
-use DefaultFormatError;
-use DeviceNameError;
 use DevicesError;
-use Format;
-use PlayStreamError;
-use PauseStreamError;
-use StreamDataResult;
-use SupportedFormatsError;
 use self::winapi::um::winnt::HRESULT;
 use std::io::Error as IoError;
-use traits::{EventLoopTrait, HostTrait, StreamIdTrait};
+use traits::{HostTrait};
 pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats, default_input_device, default_output_device};
-pub use self::stream::{EventLoop, StreamId};
+pub use self::stream::{StreamId};
 
 mod com;
 mod device;
@@ -37,7 +29,6 @@ impl Host {
 impl HostTrait for Host {
     type Devices = Devices;
     type Device = Device;
-    type EventLoop = EventLoop;
 
     fn is_available() -> bool {
         // Assume WASAPI is always available on windows.
@@ -55,53 +46,7 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
-
-    fn event_loop(&self) -> Self::EventLoop {
-        EventLoop::new()
-    }
 }
-
-impl EventLoopTrait for EventLoop {
-    type Device = Device;
-    type StreamId = StreamId;
-
-    fn build_input_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_input_stream(self, device, format)
-    }
-
-    fn build_output_stream(
-        &self,
-        device: &Self::Device,
-        format: &Format,
-    ) -> Result<Self::StreamId, BuildStreamError> {
-        EventLoop::build_output_stream(self, device, format)
-    }
-
-    fn play_stream(&self, stream: Self::StreamId) -> Result<(), PlayStreamError> {
-        EventLoop::play_stream(self, stream)
-    }
-
-    fn pause_stream(&self, stream: Self::StreamId) -> Result<(), PauseStreamError> {
-        EventLoop::pause_stream(self, stream)
-    }
-
-    fn destroy_stream(&self, stream: Self::StreamId) {
-        EventLoop::destroy_stream(self, stream)
-    }
-
-    fn run<F>(&self, callback: F) -> !
-    where
-        F: FnMut(Self::StreamId, StreamDataResult) + Send,
-    {
-        EventLoop::run(self, callback)
-    }
-}
-
-impl StreamIdTrait for StreamId {}
 
 #[inline]
 fn check_result(result: HRESULT) -> Result<(), IoError> {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -148,12 +148,17 @@ impl EventLoop {
     }
 }
 
-impl Drop for EventLoop {
+impl Drop for Stream {
     #[inline]
     fn drop(&mut self) {
         unsafe {
             handleapi::CloseHandle(self.pending_scheduled_event);
         }
+        unsafe { 
+            let result = synchapi::SetEvent(self.pending_scheduled_event); 
+            assert!(result != 0); 
+        }
+        self.thread.take().unwrap().join().unwrap();
     }
 }
 

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -224,7 +224,6 @@ fn wait_for_handle_signal(handles: &[winnt::HANDLE]) -> Result<usize, BackendSpe
         return Err(err);
     }
     // Notifying the corresponding task handler.
-    debug_assert!(result >= winbase::WAIT_OBJECT_0);
     let handle_idx = (result - winbase::WAIT_OBJECT_0) as usize;
     Ok(handle_idx)
 }

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,9 +1,6 @@
 use super::check_result;
-use super::com;
 use super::winapi::shared::basetsd::UINT32;
-use super::winapi::shared::ksmedia;
-use super::winapi::shared::minwindef::{BYTE, DWORD, FALSE, WORD};
-use super::winapi::shared::mmreg;
+use super::winapi::shared::minwindef::{BYTE, FALSE, WORD};
 use super::winapi::um::audioclient::{self, AUDCLNT_E_DEVICE_INVALIDATED, AUDCLNT_S_BUFFER_EMPTY};
 use super::winapi::um::handleapi;
 use super::winapi::um::synchapi;
@@ -13,17 +10,13 @@ use super::winapi::um::winnt;
 use std::mem;
 use std::ptr;
 use std::slice;
-use std::sync::Mutex;
 use std::sync::mpsc::{channel, Sender, Receiver};
-use std::sync::atomic::AtomicUsize;
 
 use std::{sync::{Arc},
 thread::{self, JoinHandle}};
 use crate::traits::StreamTrait;
 
 use BackendSpecificError;
-use BuildStreamError;
-use Format;
 use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
@@ -257,7 +250,7 @@ fn stream_error_from_hresult(hresult: winnt::HRESULT) -> Result<(), StreamError>
     Ok(())
 }
 
-fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) -> () {
+fn run_inner(run_context: RunContext, data_callback: &mut dyn FnMut(StreamData), error_callback: &mut dyn FnMut(StreamError)) {
     unsafe {
         'stream_loop: loop {
             // Process queued commands.

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -28,7 +28,6 @@ use PauseStreamError;
 use PlayStreamError;
 use SampleFormat;
 use StreamData;
-use StreamDataResult;
 use StreamError;
 use UnknownTypeOutputBuffer;
 use UnknownTypeInputBuffer;
@@ -452,12 +451,12 @@ impl EventLoop {
 
     #[inline]
     pub(crate) fn run<F>(&self, mut callback: F) -> !
-        where F: FnMut(StreamId, StreamDataResult)
+        where F: FnMut(StreamId, StreamData)
     {
         self.run_inner(&mut callback);
     }
 
-    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamDataResult)) -> ! {
+    fn run_inner(&self, callback: &mut dyn FnMut(StreamId, StreamData)) -> ! {
         unsafe {
             // We keep `run_context` locked forever, which guarantees that two invocations of
             // `run()` cannot run simultaneously.
@@ -753,7 +752,7 @@ fn format_to_waveformatextensible(format: &Format) -> Option<mmreg::WAVEFORMATEX
 // Process any pending commands that are queued within the `RunContext`.
 fn process_commands(
     run_context: &mut RunContext,
-    callback: &mut dyn FnMut(StreamId, StreamDataResult),
+    callback: &mut dyn FnMut(StreamId, StreamData),
 ) {
     // Process the pending commands.
     for command in run_context.commands.try_iter() {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -87,14 +87,14 @@ pub (crate) struct StreamInner {
 }
 
 impl Stream {
-    fn new<D, E>(stream_inner: Arc<StreamInner>, mut data_callback: D, mut error_callback: E) -> Stream
+    pub (crate) fn new<D, E>(stream_inner: Arc<StreamInner>, mut data_callback: D, mut error_callback: E) -> Stream
         where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static {
         let pending_scheduled_event =
             unsafe { synchapi::CreateEventA(ptr::null_mut(), 0, 0, ptr::null()) };
         let (tx, rx) = channel();
 
         let run_context = RunContext {
-            stream: Arc::new(stream_inner),
+            stream: stream_inner,
             handles: vec![pending_scheduled_event],
             commands: rx,
         };

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -27,6 +27,8 @@ use UnknownTypeOutputBuffer;
 pub struct Stream {
     /// The high-priority audio processing thread calling callbacks.
     /// Option used for moving out in destructor.
+    ///
+    /// TODO: Actually set the thread priority.
     thread: Option<JoinHandle<()>>,
 
     // Commands processed by the `run()` method that is currently running.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,10 +206,6 @@ pub enum StreamData<'a> {
     },
 }
 
-/// Stream data passed to the `EventLoop::run` callback, or an error in the case that the device
-/// was invalidated or some backend-specific error occurred.
-pub type StreamDataResult<'a> = Result<StreamData<'a>, StreamError>;
-
 /// Represents a buffer containing audio data that may be read.
 ///
 /// This struct implements the `Deref` trait targeting `[T]`. Therefore this buffer can be read the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,11 +151,10 @@ extern crate thiserror;
 
 pub use error::*;
 pub use platform::{
-    ALL_HOSTS, Device, Devices, EventLoop, Host, HostId, SupportedInputFormats,
-    SupportedOutputFormats, StreamId, available_hosts, default_host, host_from_id,
+    ALL_HOSTS, available_hosts, default_host, Device, Devices, Host, host_from_id,
+    HostId, Stream, SupportedInputFormats, SupportedOutputFormats,
 };
 pub use samples_formats::{Sample, SampleFormat};
-
 use std::ops::{Deref, DerefMut};
 
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,7 @@ pub struct SupportedFormat {
 }
 
 /// Stream data passed to the `EventLoop::run` callback.
+#[derive(Debug)]
 pub enum StreamData<'a> {
     Input {
         buffer: UnknownTypeInputBuffer<'a>,
@@ -217,6 +218,7 @@ pub enum StreamData<'a> {
 /// same way as reading from a `Vec` or any other kind of Rust array.
 // TODO: explain audio stuff in general
 // TODO: remove the wrapper and just use slices in next major version
+#[derive(Debug)]
 pub struct InputBuffer<'a, T: 'a>
 where
     T: Sample,
@@ -232,6 +234,7 @@ where
 // TODO: explain audio stuff in general
 // TODO: remove the wrapper and just use slices
 #[must_use]
+#[derive(Debug)]
 pub struct OutputBuffer<'a, T: 'a>
 where
     T: Sample,
@@ -242,6 +245,7 @@ where
 /// This is the struct that is provided to you by cpal when you want to read samples from a buffer.
 ///
 /// Since the type of data is only known at runtime, you have to read the right buffer.
+#[derive(Debug)]
 pub enum UnknownTypeInputBuffer<'a> {
     /// Samples whose format is `u16`.
     U16(InputBuffer<'a, u16>),
@@ -254,6 +258,7 @@ pub enum UnknownTypeInputBuffer<'a> {
 /// This is the struct that is provided to you by cpal when you want to write samples to a buffer.
 ///
 /// Since the type of data is only known at runtime, you have to fill the right buffer.
+#[derive(Debug)]
 pub enum UnknownTypeOutputBuffer<'a> {
     /// Samples whose format is `u16`.
     U16(OutputBuffer<'a, u16>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,9 @@
 //! > given callback is called by a dedicated, high-priority thread responsible for delivering
 //! > audio data to the system's audio device in a timely manner. On older platforms that only
 //! > provide a blocking API (e.g. ALSA), CPAL will create a thread in order to consistently
-//! > provide non-blocking behaviour. *If this is an issue for your platform or design, please
-//! > share your issue and use-case with the CPAL team on the github issue tracker for
+//! > provide non-blocking behaviour (currently this is a thread per stream, but this may change to
+//! > use a single thread for all streams). *If this is an issue for your platform or design,
+//! > please share your issue and use-case with the CPAL team on the github issue tracker for
 //! > consideration.*
 //!
 //! In this example, we simply fill the given output buffer with zeroes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,25 +7,21 @@
 //!   least one [**DefaultHost**](./struct.Host.html) that is guaranteed to be available.
 //! - A [**Device**](./struct.Device.html) is an audio device that may have any number of input and
 //!   output streams.
-//! - A stream is an open flow of audio data. Input streams allow you to receive audio data, output
-//!   streams allow you to play audio data. You must choose which **Device** will run your stream
-//!   before you can create one. Often, a default device can be retrieved via the **Host**.
-//! - An [**EventLoop**](./struct.EventLoop.html) is a collection of streams being run by one or
-//!   more **Device**s under a single **Host**. Each stream must belong to an **EventLoop**, and
-//!   all the streams that belong to an **EventLoop** are managed together.
+//! - A [**Stream**](./trait.Stream.html) is an open flow of audio data. Input streams allow you to
+//!   receive audio data, output streams allow you to play audio data. You must choose which
+//!   **Device** will run your stream before you can create one. Often, a default device can be
+//!   retrieved via the **Host**.
 //!
-//! The first step is to initialise the `Host` (for accessing audio devices) and create an
-//! `EventLoop`:
+//! The first step is to initialise the `Host`:
 //!
 //! ```
 //! use cpal::traits::HostTrait;
 //! let host = cpal::default_host();
-//! let event_loop = host.event_loop();
 //! ```
 //!
-//! Then choose a `Device`. The easiest way is to use the default input or output `Device` via the
-//! `default_input_device()` or `default_output_device()` functions. Alternatively you can
-//! enumerate all the available devices with the `devices()` function. Beware that the
+//! Then choose an available `Device`. The easiest way is to use the default input or output
+//! `Device` via the `default_input_device()` or `default_output_device()` functions. Alternatively
+//! you can enumerate all the available devices with the `devices()` function. Beware that the
 //! `default_*_device()` functions return an `Option` in case no device is available for that
 //! stream type on the system.
 //!
@@ -56,87 +52,96 @@
 //!     .with_max_sample_rate();
 //! ```
 //!
-//! Now that we have everything for the stream, we can create it from our event loop:
+//! Now that we have everything for the stream, we are ready to create it from our selected device:
 //!
 //! ```no_run
-//! use cpal::traits::{DeviceTrait, EventLoopTrait, HostTrait};
+//! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
-//! # let event_loop = host.event_loop();
 //! # let device = host.default_output_device().unwrap();
-//! # let format = device.supported_output_formats().unwrap().next().unwrap().with_max_sample_rate();
-//! let stream_id = event_loop.build_output_stream(&device, &format).unwrap();
+//! # let format = device.default_output_format().unwrap();
+//! let stream = device.build_output_stream(
+//!     &format,
+//!     move |data| {
+//!         // react to stream events and read or write stream data here.
+//!     },
+//!     move |err| {
+//!         // react to errors here.
+//!     },
+//! );
 //! ```
 //!
-//! The value returned by `build_output_stream()` is of type `StreamId` and is an identifier that
-//! will allow you to control the stream.
+//! While the stream is running, the selected audio device will periodically call the data callback
+//! that was passed to the function. The callback is passed an instance of type `StreamData` that
+//! represents the data that must be read from or written to. The inner `UnknownTypeOutputBuffer`
+//! can be one of `I16`, `U16` or `F32` depending on the format that was passed to
+//! `build_output_stream`.
 //!
-//! Now we must start the stream. This is done with the `play_stream()` method on the event loop.
-//!
-//! ```no_run
-//! # use cpal::traits::{EventLoopTrait, HostTrait};
-//! # let host = cpal::default_host();
-//! # let event_loop = host.event_loop();
-//! # let stream_id = unimplemented!();
-//! event_loop.play_stream(stream_id).expect("failed to play_stream");
-//! ```
-//!
-//! Now everything is ready! We call `run()` on the `event_loop` to begin processing.
-//!
-//! ```no_run
-//! # use cpal::traits::{EventLoopTrait, HostTrait};
-//! # let host = cpal::default_host();
-//! # let event_loop = host.event_loop();
-//! event_loop.run(move |_stream_id, _stream_result| {
-//!     // react to stream events and read or write stream data here
-//! });
-//! ```
-//!
-//! > **Note**: Calling `run()` will block the thread forever, so it's usually best done in a
-//! > separate thread.
-//!
-//! While `run()` is running, the audio device of the user will from time to time call the callback
-//! that you passed to this function. The callback gets passed the stream ID and an instance of type
-//! `StreamData` that represents the data that must be read from or written to. The inner
-//! `UnknownTypeOutputBuffer` can be one of `I16`, `U16` or `F32` depending on the format that was
-//! passed to `build_output_stream`.
+//! > **Note**: Creating and running a stream will *not* block the thread. On modern platforms, the
+//! > given callback is called by a dedicated, high-priority thread responsible for delivering
+//! > audio data to the system's audio device in a timely manner. On older platforms that only
+//! > provide a blocking API (e.g. ALSA), CPAL will create a thread in order to consistently
+//! > provide non-blocking behaviour. *If this is an issue for your platform or design, please
+//! > share your issue and use-case with the CPAL team on the github issue tracker for
+//! > consideration.*
 //!
 //! In this example, we simply fill the given output buffer with zeroes.
 //!
 //! ```no_run
 //! use cpal::{StreamData, UnknownTypeOutputBuffer};
-//! use cpal::traits::{EventLoopTrait, HostTrait};
+//! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
-//! # let event_loop = host.event_loop();
-//! event_loop.run(move |stream_id, stream_result| {
-//!     let stream_data = match stream_result {
-//!         Ok(data) => data,
-//!         Err(err) => {
-//!             eprintln!("an error occurred on stream {:?}: {}", stream_id, err);
-//!             return;
+//! # let device = host.default_output_device().unwrap();
+//! # let format = device.default_output_format().unwrap();
+//! let stream = device.build_output_stream(
+//!     &format,
+//!     move |data| {
+//!         match data {
+//!             StreamData::Output { buffer: UnknownTypeOutputBuffer::U16(mut buffer) } => {
+//!                 for elem in buffer.iter_mut() {
+//!                     *elem = u16::max_value() / 2;
+//!                 }
+//!             },
+//!             StreamData::Output { buffer: UnknownTypeOutputBuffer::I16(mut buffer) } => {
+//!                 for elem in buffer.iter_mut() {
+//!                     *elem = 0;
+//!                 }
+//!             },
+//!             StreamData::Output { buffer: UnknownTypeOutputBuffer::F32(mut buffer) } => {
+//!                 for elem in buffer.iter_mut() {
+//!                     *elem = 0.0;
+//!                 }
+//!             },
+//!             _ => (),
 //!         }
-//!         _ => return,
-//!     };
-//!
-//!     match stream_data {
-//!         StreamData::Output { buffer: UnknownTypeOutputBuffer::U16(mut buffer) } => {
-//!             for elem in buffer.iter_mut() {
-//!                 *elem = u16::max_value() / 2;
-//!             }
-//!         },
-//!         StreamData::Output { buffer: UnknownTypeOutputBuffer::I16(mut buffer) } => {
-//!             for elem in buffer.iter_mut() {
-//!                 *elem = 0;
-//!             }
-//!         },
-//!         StreamData::Output { buffer: UnknownTypeOutputBuffer::F32(mut buffer) } => {
-//!             for elem in buffer.iter_mut() {
-//!                 *elem = 0.0;
-//!             }
-//!         },
-//!         _ => (),
-//!     }
-//! });
+//!     },
+//!     move |err| {
+//!         eprintln!("an error occurred on the output audio stream: {}", err);
+//!     },
+//! );
 //! ```
+//!
+//! Not all platforms automatically run the stream upon creation. To ensure the stream has started,
+//! we can use `Stream::play`.
+//!
+//! ```no_run
+//! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+//! # let host = cpal::default_host();
+//! # let device = host.default_output_device().unwrap();
+//! # let format = device.default_output_format().unwrap();
+//! # let stream = device.build_output_stream(&format, move |_data| {}, move |_err| {}).unwrap();
+//! stream.play().unwrap();
+//! ```
+//!
+//! Some devices support pausing the audio stream. This can be useful for saving energy in moments
+//! of silence.
+//!
+//! ```no_run
+//! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+//! # let host = cpal::default_host();
+//! # let device = host.default_output_device().unwrap();
+//! # let format = device.default_output_format().unwrap();
+//! # let stream = device.build_output_stream(&format, move |_data| {}, move |_err| {}).unwrap();
+//! stream.pause().unwrap();
 
 #![recursion_limit = "512"]
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -457,9 +457,8 @@ mod platform_impl {
     pub use crate::host::asio::{
         Device as AsioDevice,
         Devices as AsioDevices,
-        EventLoop as AsioEventLoop,
+        Stream as AsioStream,
         Host as AsioHost,
-        StreamId as AsioStreamId,
         SupportedInputFormats as AsioSupportedInputFormats,
         SupportedOutputFormats as AsioSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -414,9 +414,8 @@ mod platform_impl {
     pub use crate::host::coreaudio::{
         Device as CoreAudioDevice,
         Devices as CoreAudioDevices,
-        EventLoop as CoreAudioEventLoop,
         Host as CoreAudioHost,
-        StreamId as CoreAudioStreamId,
+        Stream as CoreAudioStream,
         SupportedInputFormats as CoreAudioSupportedInputFormats,
         SupportedOutputFormats as CoreAudioSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -435,9 +435,8 @@ mod platform_impl {
     pub use crate::host::emscripten::{
         Device as EmscriptenDevice,
         Devices as EmscriptenDevices,
-        EventLoop as EmscriptenEventLoop,
         Host as EmscriptenHost,
-        StreamId as EmscriptenStreamId,
+        Stream as EmscriptenStream,
         SupportedInputFormats as EmscriptenSupportedInputFormats,
         SupportedOutputFormats as EmscriptenSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -468,9 +468,8 @@ mod platform_impl {
     pub use crate::host::wasapi::{
         Device as WasapiDevice,
         Devices as WasapiDevices,
-        EventLoop as WasapiEventLoop,
+        Stream as WasapiStream,
         Host as WasapiHost,
-        StreamId as WasapiStreamId,
         SupportedInputFormats as WasapiSupportedInputFormats,
         SupportedOutputFormats as WasapiSupportedOutputFormats,
     };

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -250,22 +250,22 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn build_input_stream<F>(&self, format: &crate::Format, callback: F) -> Result<Self::Stream, crate::BuildStreamError>
-                where F: FnMut(crate::StreamDataResult) + Send + 'static {
+            fn build_input_stream<D, E>(&self, format: &crate::Format, data_callback: D, error_callback: E) -> Result<Self::Stream, crate::BuildStreamError>
+                where D: FnMut(crate::StreamData) + Send + 'static, E: FnMut(crate::StreamError) + Send + 'static {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_input_stream(format, callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_input_stream(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream),
                     )*
                 }
             }
 
-            fn build_output_stream<F>(&self, format: &crate::Format, callback: F) -> Result<Self::Stream, crate::BuildStreamError>
-                where F: FnMut(crate::StreamDataResult) + Send + 'static {
+            fn build_output_stream<D, E>(&self, format: &crate::Format, data_callback: D, error_callback: E) -> Result<Self::Stream, crate::BuildStreamError>
+                where D: FnMut(crate::StreamData) + Send + 'static, E: FnMut(crate::StreamError) + Send + 'static {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_output_stream(format, callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_output_stream(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream),
                     )*

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -10,7 +10,8 @@ use {
     OutputDevices,
     PauseStreamError,
     PlayStreamError,
-    StreamDataResult,
+    StreamData,
+    StreamError,
     SupportedFormat,
     SupportedFormatsError,
 };
@@ -117,12 +118,12 @@ pub trait DeviceTrait {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError>;
 
     /// Create an input stream.
-    fn build_input_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static;
+    fn build_input_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static;
 
     /// Create an output stream.
-    fn build_output_stream<F>(&self, format: &Format, callback: F) -> Result<Self::Stream, BuildStreamError>
-        where F: FnMut(StreamDataResult) + Send + 'static;
+    fn build_output_stream<D, E>(&self, format: &Format, data_callback: D, error_callback: E) -> Result<Self::Stream, BuildStreamError>
+        where D: FnMut(StreamData) + Send + 'static, E: FnMut(StreamError) + Send + 'static;
 }
 
 /// A stream created from `Device`, with methods to control playback.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -128,7 +128,16 @@ pub trait DeviceTrait {
 
 /// A stream created from `Device`, with methods to control playback.
 pub trait StreamTrait {
+    /// Run the stream.
+    ///
+    /// Note: Not all platforms automatically run the stream upon creation, so it is important to
+    /// call `play` after creation if it is expected that the stream should run immediately.
     fn play(&self) -> Result<(), PlayStreamError>;
 
+    /// Some devices support pausing the audio stream. This can be useful for saving energy in
+    /// moments of silence.
+    ///
+    /// Note: Not all devices support suspending the stream at the hardware level. This method may
+    /// fail in these cases.
     fn pause(&self) -> Result<(), PauseStreamError>;
 }


### PR DESCRIPTION
This PR is a rebase of @ishitatsuyuki's work in #301. Originally opened at ishitatsuyuki/cpal#3 but closed in favour opening a new PR here.

### Backends

- [x] null
- [x] ALSA
- [x] CoreAudio
- [x] WASAPI
- [x] Emscripten
- [x] ASIO

### Other TODO

- [x] Polymorphic struct versions of Traits will be explicitly !Sync, !Send
- [x] Docs

### ALSA multiple streams bug

*Edit: This bug seems to have been addressed in the rebase*.

After testing each of the examples with the ALSA backend on my Arch Linux system, I noticed that the `feedback.rs` example no longer works. No audio output was occurring and after some investigation it seems the output stream callback only seems to get called once. `beep.rs` and `record_wav.rs` both work fine, which leads me to wonder if there's an issue with the way multiple streams are being handled. `feedback.rs` also works fine on `master`, so this has likely been introduced in this PR.

@ishitatsuyuki does anything come to mind as a potential cause for this? I did notice that we're now spawning a whole OS thread per stream. I wonder if there's some kind of race going on in the stream loop? I might see if I can find anything about thread safety in the ALSA docs. I also wonder if we can reduce the number of threads necessary by just using a single thread on which all of the streams run, similar to the old `EventLoop::run` impl. If there is some race going on, maybe using a single thread for all streams would help to avoid this.

Also, I was reading through PortAudio's non-blocking ALSA code and noticed that, when spinning up a thread for a new stream, they also attempt to set the thread's priority to the highest possible. It might be worth seeing if there is some way we can do this too, though this work can probably wait for a follow-up PR.