### PR TITLE
Fix undeclared module errors on Mac.

### DIFF
--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -27,6 +27,8 @@ use std::cell::RefCell;
 use std::os::raw::c_char;
 use std::ptr::null;
 use std::slice;
+use std::thread;
+use std::time::Duration;
 
 use self::coreaudio::audio_unit::{AudioUnit, Scope, Element};
 use self::coreaudio::audio_unit::render_callback::{self, data};


### PR DESCRIPTION
Commit d8743b3 broke the coreaudio build by removing the module scopes for thread and Duration. This brings those references back into scope.