### PR TITLE
Polymorphic streams

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), anyhow::Error> {
         cpal::SampleFormat::U16 => write_data::<u16>(data, channels, &mut next_value),
     };
 
-    let stream = device.build_output_stream(&format, data_fn, err_fn)?;
+    let stream = device.build_output_stream_raw(&format, data_fn, err_fn)?;
 
     stream.play()?;
 

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -21,13 +21,23 @@ fn main() -> Result<(), anyhow::Error> {
 
     let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
 
-    let data_fn = move |data: &mut cpal::Data| match data.sample_format() {
-        cpal::SampleFormat::F32 => write_data::<f32>(data, channels, &mut next_value),
-        cpal::SampleFormat::I16 => write_data::<i16>(data, channels, &mut next_value),
-        cpal::SampleFormat::U16 => write_data::<u16>(data, channels, &mut next_value),
+    let stream = match format.data_type {
+        cpal::SampleFormat::F32 => device.build_output_stream(
+            &format.shape(),
+            move |data: &mut [f32]| write_data(data, channels, &mut next_value),
+            err_fn,
+        )?,
+        cpal::SampleFormat::I16 => device.build_output_stream(
+            &format.shape(),
+            move |data: &mut [i16]| write_data(data, channels, &mut next_value),
+            err_fn,
+        )?,
+        cpal::SampleFormat::U16 => device.build_output_stream(
+            &format.shape(),
+            move |data: &mut [u16]| write_data(data, channels, &mut next_value),
+            err_fn,
+        )?,
     };
-
-    let stream = device.build_output_stream_raw(&format, data_fn, err_fn)?;
 
     stream.play()?;
 
@@ -36,11 +46,10 @@ fn main() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn write_data<T>(output: &mut cpal::Data, channels: usize, next_sample: &mut dyn FnMut() -> f32)
+fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
 where
     T: cpal::Sample,
 {
-    let output = output.as_slice_mut::<T>().expect("unexpected sample type");
     for frame in output.chunks_mut(channels) {
         let value: T = cpal::Sample::from::<f32>(&next_sample());
         for sample in frame.iter_mut() {

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -9,8 +9,22 @@ fn main() -> Result<(), anyhow::Error> {
         .default_output_device()
         .expect("failed to find a default output device");
     let format = device.default_output_format()?;
-    let sample_rate = format.sample_rate.0 as f32;
-    let channels = format.channels as usize;
+
+    match format.data_type {
+        cpal::SampleFormat::F32 => run::<f32>(&device, &format.shape())?,
+        cpal::SampleFormat::I16 => run::<i16>(&device, &format.shape())?,
+        cpal::SampleFormat::U16 => run::<u16>(&device, &format.shape())?,
+    }
+
+    Ok(())
+}
+
+fn run<T>(device: &cpal::Device, shape: &cpal::Shape) -> Result<(), anyhow::Error>
+where
+    T: cpal::Sample,
+{
+    let sample_rate = shape.sample_rate.0 as f32;
+    let channels = shape.channels as usize;
 
     // Produce a sinusoid of maximum amplitude.
     let mut sample_clock = 0f32;
@@ -21,24 +35,11 @@ fn main() -> Result<(), anyhow::Error> {
 
     let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
 
-    let stream = match format.data_type {
-        cpal::SampleFormat::F32 => device.build_output_stream(
-            &format.shape(),
-            move |data: &mut [f32]| write_data(data, channels, &mut next_value),
-            err_fn,
-        )?,
-        cpal::SampleFormat::I16 => device.build_output_stream(
-            &format.shape(),
-            move |data: &mut [i16]| write_data(data, channels, &mut next_value),
-            err_fn,
-        )?,
-        cpal::SampleFormat::U16 => device.build_output_stream(
-            &format.shape(),
-            move |data: &mut [u16]| write_data(data, channels, &mut next_value),
-            err_fn,
-        )?,
-    };
-
+    let stream = device.build_output_stream(
+        shape,
+        move |data: &mut [T]| write_data(data, channels, &mut next_value),
+        err_fn,
+    )?;
     stream.play()?;
 
     std::thread::sleep(std::time::Duration::from_millis(1000));

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -82,8 +82,8 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Build streams.
     println!("Attempting to build both streams with `{:?}`.", format);
-    let input_stream = input_device.build_input_stream(&format, input_data_fn, err_fn)?;
-    let output_stream = output_device.build_output_stream(&format, output_data_fn, err_fn)?;
+    let input_stream = input_device.build_input_stream_raw(&format, input_data_fn, err_fn)?;
+    let output_stream = output_device.build_output_stream_raw(&format, output_data_fn, err_fn)?;
     println!("Successfully built streams.");
 
     // Play the streams.

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), anyhow::Error> {
         cpal::SampleFormat::U16 => write_input_data::<u16, i16>(data, &writer_2),
     };
 
-    let stream = device.build_input_stream(&format, data_fn, err_fn)?;
+    let stream = device.build_input_stream_raw(&format, data_fn, err_fn)?;
 
     stream.play()?;
 

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -40,13 +40,23 @@ fn main() -> Result<(), anyhow::Error> {
         eprintln!("an error occurred on stream: {}", err);
     };
 
-    let data_fn = move |data: &cpal::Data| match data.sample_format() {
-        cpal::SampleFormat::F32 => write_input_data::<f32, f32>(data, &writer_2),
-        cpal::SampleFormat::I16 => write_input_data::<i16, i16>(data, &writer_2),
-        cpal::SampleFormat::U16 => write_input_data::<u16, i16>(data, &writer_2),
+    let stream = match format.data_type {
+        cpal::SampleFormat::F32 => device.build_input_stream(
+            &format.shape(),
+            move |data| write_input_data::<f32, f32>(data, &writer_2),
+            err_fn,
+        )?,
+        cpal::SampleFormat::I16 => device.build_input_stream(
+            &format.shape(),
+            move |data| write_input_data::<i16, i16>(data, &writer_2),
+            err_fn,
+        )?,
+        cpal::SampleFormat::U16 => device.build_input_stream(
+            &format.shape(),
+            move |data| write_input_data::<u16, i16>(data, &writer_2),
+            err_fn,
+        )?,
     };
-
-    let stream = device.build_input_stream_raw(&format, data_fn, err_fn)?;
 
     stream.play()?;
 
@@ -77,12 +87,11 @@ fn wav_spec_from_format(format: &cpal::Format) -> hound::WavSpec {
 
 type WavWriterHandle = Arc<Mutex<Option<hound::WavWriter<BufWriter<File>>>>>;
 
-fn write_input_data<T, U>(input: &cpal::Data, writer: &WavWriterHandle)
+fn write_input_data<T, U>(input: &[T], writer: &WavWriterHandle)
 where
     T: cpal::Sample,
     U: cpal::Sample + hound::Sample,
 {
-    let input = input.as_slice::<T>().expect("unexpected sample format");
     if let Ok(mut guard) = writer.try_lock() {
         if let Some(writer) = guard.as_mut() {
             for &sample in input.iter() {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -80,7 +80,7 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -95,7 +95,7 @@ impl DeviceTrait for Device {
         Ok(stream)
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -81,7 +81,7 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -91,10 +91,10 @@ impl DeviceTrait for Device {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream(self, format, data_callback, error_callback)
+        Device::build_input_stream_raw(self, format, data_callback, error_callback)
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -104,7 +104,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream(self, format, data_callback, error_callback)
+        Device::build_output_stream_raw(self, format, data_callback, error_callback)
     }
 }
 

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -57,7 +57,7 @@ impl Stream {
 }
 
 impl Device {
-    pub fn build_input_stream<D, E>(
+    pub fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         mut data_callback: D,
@@ -202,7 +202,7 @@ impl Device {
                 }
 
                 unsupported_format_pair => unreachable!(
-                    "`build_input_stream` should have returned with unsupported \
+                    "`build_input_stream_raw` should have returned with unsupported \
                      format {:?}",
                     unsupported_format_pair
                 ),
@@ -223,7 +223,7 @@ impl Device {
         })
     }
 
-    pub fn build_output_stream<D, E>(
+    pub fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         mut data_callback: D,
@@ -410,7 +410,7 @@ impl Device {
                 }
 
                 unsupported_format_pair => unreachable!(
-                    "`build_output_stream` should have returned with unsupported \
+                    "`build_output_stream_raw` should have returned with unsupported \
                      format {:?}",
                     unsupported_format_pair
                 ),

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -102,7 +102,7 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -112,10 +112,10 @@ impl DeviceTrait for Device {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream(self, format, data_callback, error_callback)
+        Device::build_input_stream_raw(self, format, data_callback, error_callback)
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -125,7 +125,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream(self, format, data_callback, error_callback)
+        Device::build_output_stream_raw(self, format, data_callback, error_callback)
     }
 }
 
@@ -467,7 +467,7 @@ fn audio_unit_from_device(device: &Device, input: bool) -> Result<AudioUnit, cor
 }
 
 impl Device {
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         mut data_callback: D,
@@ -655,7 +655,7 @@ impl Device {
         }))
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         mut data_callback: D,

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -148,7 +148,7 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         _format: &Format,
         _data_callback: D,
@@ -161,7 +161,7 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -61,7 +61,7 @@ impl DeviceTrait for Device {
         unimplemented!()
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         _format: &Format,
         _data_callback: D,
@@ -75,7 +75,7 @@ impl DeviceTrait for Device {
     }
 
     /// Create an output stream.
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         _format: &Format,
         _data_callback: D,

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -95,7 +95,7 @@ impl DeviceTrait for Device {
         Device::default_output_format(self)
     }
 
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -105,7 +105,7 @@ impl DeviceTrait for Device {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let stream_inner = self.build_input_stream_inner(format)?;
+        let stream_inner = self.build_input_stream_raw_inner(format)?;
         Ok(Stream::new_input(
             stream_inner,
             data_callback,
@@ -113,7 +113,7 @@ impl DeviceTrait for Device {
         ))
     }
 
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -123,7 +123,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let stream_inner = self.build_output_stream_inner(format)?;
+        let stream_inner = self.build_output_stream_raw_inner(format)?;
         Ok(Stream::new_output(
             stream_inner,
             data_callback,
@@ -610,7 +610,7 @@ impl Device {
         }
     }
 
-    pub(crate) fn build_input_stream_inner(
+    pub(crate) fn build_input_stream_raw_inner(
         &self,
         format: &Format,
     ) -> Result<StreamInner, BuildStreamError> {
@@ -754,7 +754,7 @@ impl Device {
         }
     }
 
-    pub(crate) fn build_output_stream_inner(
+    pub(crate) fn build_output_stream_raw_inner(
         &self,
         format: &Format,
     ) -> Result<StreamInner, BuildStreamError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
 //! # let format = device.default_output_format().unwrap();
-//! let stream = device.build_output_stream(
+//! let stream = device.build_output_stream_raw(
 //!     &format,
 //!     move |data: &mut Data| {
 //!         // react to stream events and read or write stream data here.
@@ -98,7 +98,7 @@
 //!     SampleFormat::I16 => write_silence::<i16>(data),
 //!     SampleFormat::U16 => write_silence::<u16>(data),
 //! };
-//! let stream = device.build_output_stream(&format, data_fn, err_fn).unwrap();
+//! let stream = device.build_output_stream_raw(&format, data_fn, err_fn).unwrap();
 //!
 //! fn write_silence<T: Sample>(data: &mut Data) {
 //!     let data = data.as_slice_mut::<T>().unwrap();
@@ -118,7 +118,7 @@
 //! # let format = device.default_output_format().unwrap();
 //! # let data_fn = move |_data: &mut cpal::Data| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream(&format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&format, data_fn, err_fn).unwrap();
 //! stream.play().unwrap();
 //! ```
 //!
@@ -132,7 +132,7 @@
 //! # let format = device.default_output_format().unwrap();
 //! # let data_fn = move |_data: &mut cpal::Data| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream(&format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&format, data_fn, err_fn).unwrap();
 //! stream.pause().unwrap();
 //! ```
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -255,7 +255,7 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn build_input_stream<D, E>(
+            fn build_input_stream_raw<D, E>(
                 &self,
                 format: &crate::Format,
                 data_callback: D,
@@ -267,14 +267,14 @@ macro_rules! impl_platform_host {
             {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_input_stream(format, data_callback, error_callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_input_stream_raw(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),
                     )*
                 }
             }
 
-            fn build_output_stream<D, E>(
+            fn build_output_stream_raw<D, E>(
                 &self,
                 format: &crate::Format,
                 data_callback: D,
@@ -286,7 +286,7 @@ macro_rules! impl_platform_host {
             {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.build_output_stream(format, data_callback, error_callback)
+                        DeviceInner::$HostVariant(ref d) => d.build_output_stream_raw(format, data_callback, error_callback)
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),
                     )*

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,8 +2,8 @@
 
 use {
     BuildStreamError, Data, DefaultFormatError, DeviceNameError, DevicesError, Format,
-    InputDevices, OutputDevices, PauseStreamError, PlayStreamError, StreamError, SupportedFormat,
-    SupportedFormatsError,
+    InputDevices, OutputDevices, PauseStreamError, PlayStreamError, Sample, Shape, StreamError,
+    SupportedFormat, SupportedFormatsError,
 };
 
 /// A **Host** provides access to the available audio devices on the system.
@@ -113,6 +113,54 @@ pub trait DeviceTrait {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError>;
 
     /// Create an input stream.
+    fn build_input_stream<T, D, E>(
+        &self,
+        shape: &Shape,
+        mut data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        T: Sample,
+        D: FnMut(&[T]) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        self.build_input_stream_raw(
+            &Format::with_shape(shape, T::FORMAT),
+            move |data| {
+                data_callback(
+                    data.as_slice()
+                        .expect("host supplied incorrect sample type"),
+                )
+            },
+            error_callback,
+        )
+    }
+
+    /// Create an output stream.
+    fn build_output_stream<T, D, E>(
+        &self,
+        shape: &Shape,
+        mut data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        T: Sample,
+        D: FnMut(&mut [T]) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        self.build_output_stream_raw(
+            &Format::with_shape(shape, T::FORMAT),
+            move |data| {
+                data_callback(
+                    data.as_slice_mut()
+                        .expect("host supplied incorrect sample type"),
+                )
+            },
+            error_callback,
+        )
+    }
+
+    /// Create a dynamically typed input stream.
     fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
@@ -123,7 +171,7 @@ pub trait DeviceTrait {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static;
 
-    /// Create an output stream.
+    /// Create a dynamically typed output stream.
     fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -87,7 +87,7 @@ pub trait DeviceTrait {
     type SupportedInputFormats: Iterator<Item = SupportedFormat>;
     /// The iterator type yielding supported output stream formats.
     type SupportedOutputFormats: Iterator<Item = SupportedFormat>;
-    /// The stream type created by `build_input_stream` and `build_output_stream`.
+    /// The stream type created by `build_input_stream_raw` and `build_output_stream_raw`.
     type Stream: StreamTrait;
 
     /// The human-readable name of the device.
@@ -113,7 +113,7 @@ pub trait DeviceTrait {
     fn default_output_format(&self) -> Result<Format, DefaultFormatError>;
 
     /// Create an input stream.
-    fn build_input_stream<D, E>(
+    fn build_input_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,
@@ -124,7 +124,7 @@ pub trait DeviceTrait {
         E: FnMut(StreamError) + Send + 'static;
 
     /// Create an output stream.
-    fn build_output_stream<D, E>(
+    fn build_output_stream_raw<D, E>(
         &self,
         format: &Format,
         data_callback: D,


### PR DESCRIPTION
Fixes #119. ~Seeking feedback before proceeding.~ As discussed in #359, this provides a statically-typed buffer to the user without incurring additional monomorphization cost.

TODO:
- [x] Consider a richer buffer type than a slice: leaving this for future work
- [x] Bundle channels and sample rate into a single argument
- [x] Input streams
- ~Privatize `Data`~
- [x] Update all backends
- [x] Update examples and docs