### PR TITLE
Rename stream `Format` types to `StreamConfig` and other related renamings.

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -8,23 +8,23 @@ fn main() -> Result<(), anyhow::Error> {
     let device = host
         .default_output_device()
         .expect("failed to find a default output device");
-    let format = device.default_output_format()?;
+    let config = device.default_output_config()?;
 
-    match format.data_type {
-        cpal::SampleFormat::F32 => run::<f32>(&device, &format.shape())?,
-        cpal::SampleFormat::I16 => run::<i16>(&device, &format.shape())?,
-        cpal::SampleFormat::U16 => run::<u16>(&device, &format.shape())?,
+    match config.sample_format {
+        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into())?,
+        cpal::SampleFormat::I16 => run::<i16>(&device, &config.into())?,
+        cpal::SampleFormat::U16 => run::<u16>(&device, &config.into())?,
     }
 
     Ok(())
 }
 
-fn run<T>(device: &cpal::Device, shape: &cpal::Shape) -> Result<(), anyhow::Error>
+fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Result<(), anyhow::Error>
 where
     T: cpal::Sample,
 {
-    let sample_rate = shape.sample_rate.0 as f32;
-    let channels = shape.channels as usize;
+    let sample_rate = config.sample_rate.0 as f32;
+    let channels = config.channels as usize;
 
     // Produce a sinusoid of maximum amplitude.
     let mut sample_clock = 0f32;
@@ -36,7 +36,7 @@ where
     let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
 
     let stream = device.build_output_stream(
-        shape,
+        config,
         move |data: &mut [T]| write_data(data, channels, &mut next_value),
         err_fn,
     )?;

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -21,48 +21,48 @@ fn main() -> Result<(), anyhow::Error> {
         for (device_index, device) in devices.enumerate() {
             println!("  {}. \"{}\"", device_index + 1, device.name()?);
 
-            // Input formats
-            if let Ok(fmt) = device.default_input_format() {
-                println!("    Default input stream format:\n      {:?}", fmt);
+            // Input configs
+            if let Ok(fmt) = device.default_input_config() {
+                println!("    Default input stream config:\n      {:?}", fmt);
             }
-            let mut input_formats = match device.supported_input_formats() {
+            let mut input_configs = match device.supported_input_configs() {
                 Ok(f) => f.peekable(),
                 Err(e) => {
                     println!("Error: {:?}", e);
                     continue;
                 }
             };
-            if input_formats.peek().is_some() {
-                println!("    All supported input stream formats:");
-                for (format_index, format) in input_formats.enumerate() {
+            if input_configs.peek().is_some() {
+                println!("    All supported input stream configs:");
+                for (config_index, config) in input_configs.enumerate() {
                     println!(
                         "      {}.{}. {:?}",
                         device_index + 1,
-                        format_index + 1,
-                        format
+                        config_index + 1,
+                        config
                     );
                 }
             }
 
-            // Output formats
-            if let Ok(fmt) = device.default_output_format() {
-                println!("    Default output stream format:\n      {:?}", fmt);
+            // Output configs
+            if let Ok(fmt) = device.default_output_config() {
+                println!("    Default output stream config:\n      {:?}", fmt);
             }
-            let mut output_formats = match device.supported_output_formats() {
+            let mut output_configs = match device.supported_output_configs() {
                 Ok(f) => f.peekable(),
                 Err(e) => {
                     println!("Error: {:?}", e);
                     continue;
                 }
             };
-            if output_formats.peek().is_some() {
-                println!("    All supported output stream formats:");
-                for (format_index, format) in output_formats.enumerate() {
+            if output_configs.peek().is_some() {
+                println!("    All supported output stream configs:");
+                for (config_index, config) in output_configs.enumerate() {
                     println!(
                         "      {}.{}. {:?}",
                         device_index + 1,
-                        format_index + 1,
-                        format
+                        config_index + 1,
+                        config
                     );
                 }
             }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -1,4 +1,4 @@
-//! Records a WAV file (roughly 3 seconds long) using the default input device and format.
+//! Records a WAV file (roughly 3 seconds long) using the default input device and config.
 //!
 //! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
 
@@ -15,18 +15,18 @@ fn main() -> Result<(), anyhow::Error> {
     // Use the default host for working with audio devices.
     let host = cpal::default_host();
 
-    // Setup the default input device and stream with the default input format.
+    // Setup the default input device and stream with the default input config.
     let device = host
         .default_input_device()
         .expect("Failed to get default input device");
     println!("Default input device: {}", device.name()?);
-    let format = device
-        .default_input_format()
-        .expect("Failed to get default input format");
-    println!("Default input format: {:?}", format);
+    let config = device
+        .default_input_config()
+        .expect("Failed to get default input config");
+    println!("Default input config: {:?}", config);
     // The WAV file we're recording to.
     const PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
-    let spec = wav_spec_from_format(&format);
+    let spec = wav_spec_from_config(&config);
     let writer = hound::WavWriter::create(PATH, spec)?;
     let writer = Arc::new(Mutex::new(Some(writer)));
 
@@ -40,19 +40,19 @@ fn main() -> Result<(), anyhow::Error> {
         eprintln!("an error occurred on stream: {}", err);
     };
 
-    let stream = match format.data_type {
+    let stream = match config.sample_format {
         cpal::SampleFormat::F32 => device.build_input_stream(
-            &format.shape(),
+            &config.into(),
             move |data| write_input_data::<f32, f32>(data, &writer_2),
             err_fn,
         )?,
         cpal::SampleFormat::I16 => device.build_input_stream(
-            &format.shape(),
+            &config.into(),
             move |data| write_input_data::<i16, i16>(data, &writer_2),
             err_fn,
         )?,
         cpal::SampleFormat::U16 => device.build_input_stream(
-            &format.shape(),
+            &config.into(),
             move |data| write_input_data::<u16, i16>(data, &writer_2),
             err_fn,
         )?,
@@ -76,12 +76,12 @@ fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {
     }
 }
 
-fn wav_spec_from_format(format: &cpal::Format) -> hound::WavSpec {
+fn wav_spec_from_config(config: &cpal::SupportedStreamConfig) -> hound::WavSpec {
     hound::WavSpec {
-        channels: format.channels as _,
-        sample_rate: format.sample_rate.0 as _,
-        bits_per_sample: (format.data_type.sample_size() * 8) as _,
-        sample_format: sample_format(format.data_type),
+        channels: config.channels as _,
+        sample_rate: config.sample_rate.0 as _,
+        bits_per_sample: (config.sample_format.sample_size() * 8) as _,
+        sample_format: sample_format(config.sample_format),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,9 +90,9 @@ pub enum BuildStreamError {
     /// program is running.
     #[error("The requested device is no longer available. For example, it has been unplugged.")]
     DeviceNotAvailable,
-    /// The required format is not supported.
-    #[error("The requested stream format is not supported by the device.")]
-    FormatNotSupported,
+    /// The specified stream configuration is not supported.
+    #[error("The requested stream configuration is not supported by the device.")]
+    StreamConfigNotSupported,
     /// We called something the C-Layer did not understand
     ///
     /// On ALSA device functions called with a feature they do not support will yield this. E.g.

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,7 +47,7 @@ pub enum DeviceNameError {
 
 /// Error that can happen when enumerating the list of supported formats.
 #[derive(Debug, Error)]
-pub enum SupportedFormatsError {
+pub enum SupportedStreamConfigsError {
     /// The device no longer exists. This can happen if the device is disconnected while the
     /// program is running.
     #[error("The requested device is no longer available. For example, it has been unplugged.")]
@@ -67,7 +67,7 @@ pub enum SupportedFormatsError {
 
 /// May occur when attempting to request the default input or output stream format from a `Device`.
 #[derive(Debug, Error)]
-pub enum DefaultFormatError {
+pub enum DefaultStreamConfigError {
     /// The device no longer exists. This can happen if the device is disconnected while the
     /// program is running.
     #[error("The requested device is no longer available. For example, it has been unplugged.")]

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -2,12 +2,13 @@ extern crate asio_sys as sys;
 extern crate parking_lot;
 
 use crate::{
-    BuildStreamError, Data, DefaultFormatError, DeviceNameError, DevicesError, Format,
-    PauseStreamError, PlayStreamError, StreamError, SupportedFormatsError,
+    BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
+    PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfig,
+    SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
-pub use self::device::{Device, Devices, SupportedInputFormats, SupportedOutputFormats};
+pub use self::device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs};
 pub use self::stream::Stream;
 use std::sync::Arc;
 
@@ -53,37 +54,37 @@ impl HostTrait for Host {
 }
 
 impl DeviceTrait for Device {
-    type SupportedInputFormats = SupportedInputFormats;
-    type SupportedOutputFormats = SupportedOutputFormats;
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)
     }
 
-    fn supported_input_formats(
+    fn supported_input_configs(
         &self,
-    ) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
-        Device::supported_input_formats(self)
+    ) -> Result<Self::SupportedInputConfigs, SupportedStreamConfigsError> {
+        Device::supported_input_configs(self)
     }
 
-    fn supported_output_formats(
+    fn supported_output_configs(
         &self,
-    ) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
-        Device::supported_output_formats(self)
+    ) -> Result<Self::SupportedOutputConfigs, SupportedStreamConfigsError> {
+        Device::supported_output_configs(self)
     }
 
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_input_format(self)
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Device::default_input_config(self)
     }
 
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_output_format(self)
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Device::default_output_config(self)
     }
 
     fn build_input_stream_raw<D, E>(
         &self,
-        format: &Format,
+        config: &SupportedStreamConfig,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -91,12 +92,12 @@ impl DeviceTrait for Device {
         D: FnMut(&Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream_raw(self, format, data_callback, error_callback)
+        Device::build_input_stream_raw(self, config, data_callback, error_callback)
     }
 
     fn build_output_stream_raw<D, E>(
         &self,
-        format: &Format,
+        config: &SupportedStreamConfig,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -104,7 +105,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream_raw(self, format, data_callback, error_callback)
+        Device::build_output_stream_raw(self, config, data_callback, error_callback)
     }
 }
 

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 use BackendSpecificError;
 use BuildStreamError;
 use Data;
-use Format;
 use PauseStreamError;
 use PlayStreamError;
 use Sample;
 use SampleFormat;
 use StreamError;
+use SupportedStreamConfig;
 
 /// Sample types whose constant silent value is known.
 trait Silence {
@@ -59,7 +59,7 @@ impl Stream {
 impl Device {
     pub fn build_input_stream_raw<D, E>(
         &self,
-        format: &Format,
+        config: &SupportedStreamConfig,
         mut data_callback: D,
         _error_callback: E,
     ) -> Result<Stream, BuildStreamError>
@@ -70,18 +70,18 @@ impl Device {
         let stream_type = self.driver.input_data_type().map_err(build_stream_err)?;
 
         // Ensure that the desired sample type is supported.
-        let data_type = super::device::convert_data_type(&stream_type)
+        let sample_format = super::device::convert_data_type(&stream_type)
             .ok_or(BuildStreamError::FormatNotSupported)?;
-        if format.data_type != data_type {
+        if config.sample_format != sample_format {
             return Err(BuildStreamError::FormatNotSupported);
         }
 
-        let num_channels = format.channels.clone();
-        let buffer_size = self.get_or_create_input_stream(format)?;
+        let num_channels = config.channels.clone();
+        let buffer_size = self.get_or_create_input_stream(config)?;
         let cpal_num_samples = buffer_size * num_channels as usize;
 
         // Create the buffer depending on the size of the data type.
-        let len_bytes = cpal_num_samples * data_type.sample_size();
+        let len_bytes = cpal_num_samples * sample_format.sample_size();
         let mut interleaved = vec![0u8; len_bytes];
 
         let stream_playing = Arc::new(AtomicBool::new(false));
@@ -134,7 +134,7 @@ impl Device {
                 callback(&data);
             }
 
-            match (&stream_type, data_type) {
+            match (&stream_type, sample_format) {
                 (&sys::AsioSampleType::ASIOSTInt16LSB, SampleFormat::I16) => {
                     process_input_callback::<i16, i16, _, _>(
                         &mut data_callback,
@@ -225,7 +225,7 @@ impl Device {
 
     pub fn build_output_stream_raw<D, E>(
         &self,
-        format: &Format,
+        config: &SupportedStreamConfig,
         mut data_callback: D,
         _error_callback: E,
     ) -> Result<Stream, BuildStreamError>
@@ -236,18 +236,18 @@ impl Device {
         let stream_type = self.driver.output_data_type().map_err(build_stream_err)?;
 
         // Ensure that the desired sample type is supported.
-        let data_type = super::device::convert_data_type(&stream_type)
+        let sample_format = super::device::convert_data_type(&stream_type)
             .ok_or(BuildStreamError::FormatNotSupported)?;
-        if format.data_type != data_type {
+        if config.sample_format != sample_format {
             return Err(BuildStreamError::FormatNotSupported);
         }
 
-        let num_channels = format.channels.clone();
-        let buffer_size = self.get_or_create_output_stream(format)?;
+        let num_channels = config.channels.clone();
+        let buffer_size = self.get_or_create_output_stream(config)?;
         let cpal_num_samples = buffer_size * num_channels as usize;
 
         // Create buffers depending on data type.
-        let len_bytes = cpal_num_samples * data_type.sample_size();
+        let len_bytes = cpal_num_samples * sample_format.sample_size();
         let mut interleaved = vec![0u8; len_bytes];
         let mut silence_asio_buffer = SilenceAsioBuffer::default();
 
@@ -336,7 +336,7 @@ impl Device {
                 }
             }
 
-            match (data_type, &stream_type) {
+            match (sample_format, &stream_type) {
                 (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt16LSB) => {
                     process_output_callback::<i16, i16, _, _>(
                         &mut data_callback,
@@ -436,15 +436,18 @@ impl Device {
     /// If there is no existing ASIO Input Stream it will be created.
     ///
     /// On success, the buffer size of the stream is returned.
-    fn get_or_create_input_stream(&self, format: &Format) -> Result<usize, BuildStreamError> {
-        match self.default_input_format() {
+    fn get_or_create_input_stream(
+        &self,
+        config: &SupportedStreamConfig,
+    ) -> Result<usize, BuildStreamError> {
+        match self.default_input_config() {
             Ok(f) => {
                 let num_asio_channels = f.channels;
-                check_format(&self.driver, format, num_asio_channels)
+                check_config(&self.driver, config, num_asio_channels)
             }
             Err(_) => Err(BuildStreamError::FormatNotSupported),
         }?;
-        let num_channels = format.channels as usize;
+        let num_channels = config.channels as usize;
         let ref mut streams = *self.asio_streams.lock();
         // Either create a stream if thers none or had back the
         // size of the current one.
@@ -473,15 +476,18 @@ impl Device {
     /// Create a new CPAL Output Stream.
     ///
     /// If there is no existing ASIO Output Stream it will be created.
-    fn get_or_create_output_stream(&self, format: &Format) -> Result<usize, BuildStreamError> {
-        match self.default_output_format() {
+    fn get_or_create_output_stream(
+        &self,
+        config: &SupportedStreamConfig,
+    ) -> Result<usize, BuildStreamError> {
+        match self.default_output_config() {
             Ok(f) => {
                 let num_asio_channels = f.channels;
-                check_format(&self.driver, format, num_asio_channels)
+                check_config(&self.driver, config, num_asio_channels)
             }
             Err(_) => Err(BuildStreamError::FormatNotSupported),
         }?;
-        let num_channels = format.channels as usize;
+        let num_channels = config.channels as usize;
         let ref mut streams = *self.asio_streams.lock();
         // Either create a stream if thers none or had back the
         // size of the current one.
@@ -570,19 +576,19 @@ impl AsioSample for f64 {
     }
 }
 
-/// Check whether or not the desired format is supported by the stream.
+/// Check whether or not the desired config is supported by the stream.
 ///
 /// Checks sample rate, data type and then finally the number of channels.
-fn check_format(
+fn check_config(
     driver: &sys::Driver,
-    format: &Format,
+    config: &SupportedStreamConfig,
     num_asio_channels: u16,
 ) -> Result<(), BuildStreamError> {
-    let Format {
+    let SupportedStreamConfig {
         channels,
         sample_rate,
-        data_type,
-    } = format;
+        sample_format,
+    } = config;
     // Try and set the sample rate to what the user selected.
     let sample_rate = sample_rate.0.into();
     if sample_rate != driver.sample_rate().map_err(build_stream_err)? {
@@ -598,7 +604,7 @@ fn check_format(
         }
     }
     // unsigned formats are not supported by asio
-    match data_type {
+    match sample_format {
         SampleFormat::I16 | SampleFormat::F32 => (),
         SampleFormat::U16 => return Err(BuildStreamError::FormatNotSupported),
     }

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -71,9 +71,9 @@ impl Device {
 
         // Ensure that the desired sample type is supported.
         let sample_format = super::device::convert_data_type(&stream_type)
-            .ok_or(BuildStreamError::FormatNotSupported)?;
+            .ok_or(BuildStreamError::StreamConfigNotSupported)?;
         if config.sample_format != sample_format {
-            return Err(BuildStreamError::FormatNotSupported);
+            return Err(BuildStreamError::StreamConfigNotSupported);
         }
 
         let num_channels = config.channels.clone();
@@ -237,9 +237,9 @@ impl Device {
 
         // Ensure that the desired sample type is supported.
         let sample_format = super::device::convert_data_type(&stream_type)
-            .ok_or(BuildStreamError::FormatNotSupported)?;
+            .ok_or(BuildStreamError::StreamConfigNotSupported)?;
         if config.sample_format != sample_format {
-            return Err(BuildStreamError::FormatNotSupported);
+            return Err(BuildStreamError::StreamConfigNotSupported);
         }
 
         let num_channels = config.channels.clone();
@@ -445,7 +445,7 @@ impl Device {
                 let num_asio_channels = f.channels;
                 check_config(&self.driver, config, num_asio_channels)
             }
-            Err(_) => Err(BuildStreamError::FormatNotSupported),
+            Err(_) => Err(BuildStreamError::StreamConfigNotSupported),
         }?;
         let num_channels = config.channels as usize;
         let ref mut streams = *self.asio_streams.lock();
@@ -485,7 +485,7 @@ impl Device {
                 let num_asio_channels = f.channels;
                 check_config(&self.driver, config, num_asio_channels)
             }
-            Err(_) => Err(BuildStreamError::FormatNotSupported),
+            Err(_) => Err(BuildStreamError::StreamConfigNotSupported),
         }?;
         let num_channels = config.channels as usize;
         let ref mut streams = *self.asio_streams.lock();
@@ -600,16 +600,16 @@ fn check_config(
                 .set_sample_rate(sample_rate)
                 .map_err(build_stream_err)?;
         } else {
-            return Err(BuildStreamError::FormatNotSupported);
+            return Err(BuildStreamError::StreamConfigNotSupported);
         }
     }
     // unsigned formats are not supported by asio
     match sample_format {
         SampleFormat::I16 | SampleFormat::F32 => (),
-        SampleFormat::U16 => return Err(BuildStreamError::FormatNotSupported),
+        SampleFormat::U16 => return Err(BuildStreamError::StreamConfigNotSupported),
     }
     if *channels > num_asio_channels {
-        return Err(BuildStreamError::FormatNotSupported);
+        return Err(BuildStreamError::StreamConfigNotSupported);
     }
     Ok(())
 }

--- a/src/host/coreaudio/enumerate.rs
+++ b/src/host/coreaudio/enumerate.rs
@@ -9,7 +9,7 @@ use super::Device;
 use std::mem;
 use std::ptr::null;
 use std::vec::IntoIter as VecIntoIter;
-use {BackendSpecificError, DevicesError, SupportedFormat};
+use {BackendSpecificError, DevicesError, SupportedStreamConfigRange};
 
 unsafe fn audio_devices() -> Result<Vec<AudioDeviceID>, OSStatus> {
     let property_address = AudioObjectPropertyAddress {
@@ -143,5 +143,5 @@ pub fn default_output_device() -> Option<Device> {
     Some(device)
 }
 
-pub type SupportedInputFormats = VecIntoIter<SupportedFormat>;
-pub type SupportedOutputFormats = VecIntoIter<SupportedFormat>;
+pub type SupportedInputConfigs = VecIntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = VecIntoIter<SupportedStreamConfigRange>;

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -395,7 +395,7 @@ impl From<coreaudio::Error> for BuildStreamError {
             | coreaudio::Error::NoKnownSubtype
             | coreaudio::Error::AudioUnit(coreaudio::error::AudioUnitError::FormatNotSupported)
             | coreaudio::Error::AudioCodec(_)
-            | coreaudio::Error::AudioFormat(_) => BuildStreamError::FormatNotSupported,
+            | coreaudio::Error::AudioFormat(_) => BuildStreamError::StreamConfigNotSupported,
             _ => BuildStreamError::DeviceNotAvailable,
         }
     }
@@ -541,7 +541,7 @@ impl Device {
                     r.mMinimum as u32 == sample_rate && r.mMaximum as u32 == sample_rate
                 });
                 let range_index = match maybe_index {
-                    None => return Err(BuildStreamError::FormatNotSupported),
+                    None => return Err(BuildStreamError::StreamConfigNotSupported),
                     Some(i) => i,
                 };
 

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -8,9 +8,9 @@ use stdweb::web::TypedArray;
 use stdweb::Reference;
 
 use crate::{
-    BuildStreamError, Data, DefaultFormatError, DeviceNameError, DevicesError, Format,
-    PauseStreamError, PlayStreamError, SampleFormat, StreamError, SupportedFormat,
-    SupportedFormatsError,
+    BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
+    PauseStreamError, PlayStreamError, SampleFormat, StreamError, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -37,8 +37,8 @@ pub struct Stream {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamId(usize);
 
-pub type SupportedInputFormats = ::std::vec::IntoIter<SupportedFormat>;
-pub type SupportedOutputFormats = ::std::vec::IntoIter<SupportedFormat>;
+pub type SupportedInputConfigs = ::std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = ::std::vec::IntoIter<SupportedStreamConfigRange>;
 
 impl Host {
     pub fn new() -> Result<Self, crate::HostUnavailable> {
@@ -60,12 +60,16 @@ impl Device {
     }
 
     #[inline]
-    fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
+    fn supported_input_configs(
+        &self,
+    ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
         unimplemented!();
     }
 
     #[inline]
-    fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
+    fn supported_output_configs(
+        &self,
+    ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
         // TODO: right now cpal's API doesn't allow flexibility here
         //       "44100" and "2" (channels) have also been hard-coded in the rest of the code ; if
         //       this ever becomes more flexible, don't forget to change that
@@ -74,25 +78,25 @@ impl Device {
         //
         //       UPDATE: We can do this now. Might be best to use `crate::COMMON_SAMPLE_RATES` and
         //       filter out those that lay outside the range specified above.
-        Ok(vec![SupportedFormat {
+        Ok(vec![SupportedStreamConfigRange {
             channels: 2,
             min_sample_rate: ::SampleRate(44100),
             max_sample_rate: ::SampleRate(44100),
-            data_type: ::SampleFormat::F32,
+            sample_format: ::SampleFormat::F32,
         }]
         .into_iter())
     }
 
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         unimplemented!();
     }
 
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        // TODO: because it is hard coded, see supported_output_formats.
-        Ok(Format {
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        // TODO: because it is hard coded, see supported_output_configs.
+        Ok(SupportedStreamConfig {
             channels: 2,
             sample_rate: ::SampleRate(44100),
-            data_type: ::SampleFormat::F32,
+            sample_format: ::SampleFormat::F32,
         })
     }
 }
@@ -120,37 +124,37 @@ impl HostTrait for Host {
 }
 
 impl DeviceTrait for Device {
-    type SupportedInputFormats = SupportedInputFormats;
-    type SupportedOutputFormats = SupportedOutputFormats;
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
         Device::name(self)
     }
 
-    fn supported_input_formats(
+    fn supported_input_configs(
         &self,
-    ) -> Result<Self::SupportedInputFormats, SupportedFormatsError> {
-        Device::supported_input_formats(self)
+    ) -> Result<Self::SupportedInputConfigs, SupportedStreamConfigsError> {
+        Device::supported_input_configs(self)
     }
 
-    fn supported_output_formats(
+    fn supported_output_configs(
         &self,
-    ) -> Result<Self::SupportedOutputFormats, SupportedFormatsError> {
-        Device::supported_output_formats(self)
+    ) -> Result<Self::SupportedOutputConfigs, SupportedStreamConfigsError> {
+        Device::supported_output_configs(self)
     }
 
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_input_format(self)
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Device::default_input_config(self)
     }
 
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
-        Device::default_output_format(self)
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Device::default_output_config(self)
     }
 
     fn build_input_stream_raw<D, E>(
         &self,
-        _format: &Format,
+        _config: &SupportedStreamConfig,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -163,7 +167,7 @@ impl DeviceTrait for Device {
 
     fn build_output_stream_raw<D, E>(
         &self,
-        format: &Format,
+        config: &SupportedStreamConfig,
         data_callback: D,
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -172,7 +176,7 @@ impl DeviceTrait for Device {
         E: FnMut(StreamError) + Send + 'static,
     {
         assert_eq!(
-            format.data_type,
+            config.sample_format,
             SampleFormat::F32,
             "emscripten backend currently only supports `f32` data",
         );

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
-    BuildStreamError, Data, DefaultFormatError, DeviceNameError, DevicesError, Format,
-    PauseStreamError, PlayStreamError, StreamError, SupportedFormat, SupportedFormatsError,
+    BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
+    PauseStreamError, PlayStreamError, StreamError, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -15,8 +16,8 @@ pub struct Host;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Stream;
 
-pub struct SupportedInputFormats;
-pub struct SupportedOutputFormats;
+pub struct SupportedInputConfigs;
+pub struct SupportedOutputConfigs;
 
 impl Host {
     #[allow(dead_code)]
@@ -32,8 +33,8 @@ impl Devices {
 }
 
 impl DeviceTrait for Device {
-    type SupportedInputFormats = SupportedInputFormats;
-    type SupportedOutputFormats = SupportedOutputFormats;
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
     type Stream = Stream;
 
     #[inline]
@@ -42,28 +43,32 @@ impl DeviceTrait for Device {
     }
 
     #[inline]
-    fn supported_input_formats(&self) -> Result<SupportedInputFormats, SupportedFormatsError> {
+    fn supported_input_configs(
+        &self,
+    ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
         unimplemented!()
     }
 
     #[inline]
-    fn supported_output_formats(&self) -> Result<SupportedOutputFormats, SupportedFormatsError> {
+    fn supported_output_configs(
+        &self,
+    ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
         unimplemented!()
     }
 
     #[inline]
-    fn default_input_format(&self) -> Result<Format, DefaultFormatError> {
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         unimplemented!()
     }
 
     #[inline]
-    fn default_output_format(&self) -> Result<Format, DefaultFormatError> {
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         unimplemented!()
     }
 
     fn build_input_stream_raw<D, E>(
         &self,
-        _format: &Format,
+        _format: &SupportedStreamConfig,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -77,7 +82,7 @@ impl DeviceTrait for Device {
     /// Create an output stream.
     fn build_output_stream_raw<D, E>(
         &self,
-        _format: &Format,
+        _format: &SupportedStreamConfig,
         _data_callback: D,
         _error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
@@ -129,20 +134,20 @@ impl Iterator for Devices {
     }
 }
 
-impl Iterator for SupportedInputFormats {
-    type Item = SupportedFormat;
+impl Iterator for SupportedInputConfigs {
+    type Item = SupportedStreamConfigRange;
 
     #[inline]
-    fn next(&mut self) -> Option<SupportedFormat> {
+    fn next(&mut self) -> Option<SupportedStreamConfigRange> {
         None
     }
 }
 
-impl Iterator for SupportedOutputFormats {
-    type Item = SupportedFormat;
+impl Iterator for SupportedOutputConfigs {
+    type Item = SupportedStreamConfigRange;
 
     #[inline]
-    fn next(&mut self) -> Option<SupportedFormat> {
+    fn next(&mut self) -> Option<SupportedStreamConfigRange> {
         None
     }
 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -242,7 +242,7 @@ pub unsafe fn is_format_supported(
         },
         (winerror::S_FALSE, _) => {
             (*audio_client).Release();
-            return Err(BuildStreamError::FormatNotSupported);
+            return Err(BuildStreamError::StreamConfigNotSupported);
         },
         (_, Ok(())) => (),
     };
@@ -639,12 +639,12 @@ impl Device {
             // Computing the format and initializing the device.
             let waveformatex = {
                 let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                    .ok_or(BuildStreamError::StreamConfigNotSupported)?;
                 let share_mode = AUDCLNT_SHAREMODE_SHARED;
 
                 // Ensure the format is supported.
                 match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Ok(false) => return Err(BuildStreamError::StreamConfigNotSupported),
                     Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
                     _ => (),
                 }
@@ -783,12 +783,12 @@ impl Device {
             // Computing the format and initializing the device.
             let waveformatex = {
                 let format_attempt = format_to_waveformatextensible(format)
-                    .ok_or(BuildStreamError::FormatNotSupported)?;
+                    .ok_or(BuildStreamError::StreamConfigNotSupported)?;
                 let share_mode = AUDCLNT_SHAREMODE_SHARED;
 
                 // Ensure the format is supported.
                 match super::device::is_format_supported(audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::FormatNotSupported),
+                    Ok(false) => return Err(BuildStreamError::StreamConfigNotSupported),
                     Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
                     _ => (),
                 }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,8 +1,8 @@
 extern crate winapi;
 
 pub use self::device::{
-    default_input_device, default_output_device, Device, Devices, SupportedInputFormats,
-    SupportedOutputFormats,
+    default_input_device, default_output_device, Device, Devices, SupportedInputConfigs,
+    SupportedOutputConfigs,
 };
 pub use self::stream::Stream;
 use self::winapi::um::winnt::HRESULT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,24 +31,25 @@
 //! let device = host.default_output_device().expect("no output device available");
 //! ```
 //!
-//! Before we can create a stream, we must decide what the format of the audio samples is going to
-//! be. You can query all the supported formats with the `supported_input_formats()` and
-//! `supported_output_formats()` methods. These produce a list of `SupportedFormat` structs which
-//! can later be turned into actual `Format` structs. If you don't want to query the list of
-//! formats, you can also build your own `Format` manually, but doing so could lead to an error
-//! when building the stream if the format is not supported by the device.
+//! Before we can create a stream, we must decide what the configuration of the audio stream is
+//! going to be. You can query all the supported configurations with the
+//! `supported_input_configs()` and `supported_output_configs()` methods. These produce a list of
+//! `SupportedStreamConfigRange` structs which can later be turned into actual
+//! `SupportedStreamConfig` structs. If you don't want to query the list of configs, you can also
+//! build your own `StreamConfig` manually, but doing so could lead to an error when building the
+//! stream if the config is not supported by the device.
 //!
-//! > **Note**: the `supported_formats()` method could return an error for example if the device
-//! > has been disconnected.
+//! > **Note**: the `supported_input/output_configs()` methods could return an error for example if
+//! > the device has been disconnected.
 //!
 //! ```no_run
 //! use cpal::traits::{DeviceTrait, HostTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! let mut supported_formats_range = device.supported_output_formats()
-//!     .expect("error while querying formats");
-//! let format = supported_formats_range.next()
-//!     .expect("no supported format?!")
+//! let mut supported_configs_range = device.supported_output_configs()
+//!     .expect("error while querying configs");
+//! let supported_config = supported_configs_range.next()
+//!     .expect("no supported config?!")
 //!     .with_max_sample_rate();
 //! ```
 //!
@@ -59,9 +60,9 @@
 //! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! # let shape = device.default_output_format().unwrap().shape();
+//! # let config = device.default_output_config().unwrap().into();
 //! let stream = device.build_output_stream(
-//!     &shape,
+//!     &config,
 //!     move |data: &mut [f32]| {
 //!         // react to stream events and read or write stream data here.
 //!     },
@@ -91,13 +92,14 @@
 //! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! # let format = device.default_output_format().unwrap();
+//! # let supported_config = device.default_output_config().unwrap();
 //! let err_fn = |err| eprintln!("an error occurred on the output audio stream: {}", err);
-//! let shape = format.shape();
-//! let stream = match format.data_type {
-//!     SampleFormat::F32 => device.build_output_stream(&shape, write_silence::<f32>, err_fn),
-//!     SampleFormat::I16 => device.build_output_stream(&shape, write_silence::<i16>, err_fn),
-//!     SampleFormat::U16 => device.build_output_stream(&shape, write_silence::<u16>, err_fn),
+//! let sample_format = supported_config.sample_format;
+//! let config = supported_config.into();
+//! let stream = match sample_format {
+//!     SampleFormat::F32 => device.build_output_stream(&config, write_silence::<f32>, err_fn),
+//!     SampleFormat::I16 => device.build_output_stream(&config, write_silence::<i16>, err_fn),
+//!     SampleFormat::U16 => device.build_output_stream(&config, write_silence::<u16>, err_fn),
 //! }.unwrap();
 //!
 //! fn write_silence<T: Sample>(data: &mut [T]) {
@@ -114,10 +116,11 @@
 //! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! # let format = device.default_output_format().unwrap();
+//! # let supported_config = device.default_output_config().unwrap();
+//! # let config = supported_config.into();
 //! # let data_fn = move |_data: &mut cpal::Data| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream_raw(&format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&config, data_fn, err_fn).unwrap();
 //! stream.play().unwrap();
 //! ```
 //!
@@ -128,10 +131,11 @@
 //! # use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! # let format = device.default_output_format().unwrap();
+//! # let supported_config = device.default_output_config().unwrap();
+//! # let config = supported_config.into();
 //! # let data_fn = move |_data: &mut cpal::Data| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream_raw(&format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&config, data_fn, err_fn).unwrap();
 //! stream.pause().unwrap();
 //! ```
 
@@ -149,7 +153,7 @@ extern crate thiserror;
 pub use error::*;
 pub use platform::{
     available_hosts, default_host, host_from_id, Device, Devices, Host, HostId, Stream,
-    SupportedInputFormats, SupportedOutputFormats, ALL_HOSTS,
+    SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
 pub use samples_formats::{Sample, SampleFormat};
 
@@ -172,56 +176,35 @@ pub type ChannelCount = u16;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SampleRate(pub u32);
 
-/// The format of an input or output audio stream.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Format {
-    pub channels: ChannelCount,
-    pub sample_rate: SampleRate,
-    pub data_type: SampleFormat,
-}
-
-impl Format {
-    /// Construct a format having a particular `shape` and `data_type`.
-    pub fn with_shape(shape: &Shape, data_type: SampleFormat) -> Self {
-        Self {
-            channels: shape.channels,
-            sample_rate: shape.sample_rate,
-            data_type,
-        }
-    }
-
-    /// Extract aspects of the format independent of the data type.
-    pub fn shape(&self) -> Shape {
-        self.clone().into()
-    }
-}
-
-/// The properties of an input or output audio stream excluding its data type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Shape {
+/// The set of parameters used to describe how to open a stream.
+///
+/// The sample format is omitted in favour of using a sample type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamConfig {
     pub channels: ChannelCount,
     pub sample_rate: SampleRate,
 }
 
-impl From<Format> for Shape {
-    fn from(x: Format) -> Self {
-        Self {
-            channels: x.channels,
-            sample_rate: x.sample_rate,
-        }
-    }
-}
-
-/// Describes a range of supported stream formats.
+/// Describes a range of supported stream configurations, retrieved via the
+/// `Device::supported_input/output_configs` method.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SupportedFormat {
+pub struct SupportedStreamConfigRange {
     pub channels: ChannelCount,
     /// Minimum value for the samples rate of the supported formats.
     pub min_sample_rate: SampleRate,
     /// Maximum value for the samples rate of the supported formats.
     pub max_sample_rate: SampleRate,
     /// Type of data expected by the device.
-    pub data_type: SampleFormat,
+    pub sample_format: SampleFormat,
+}
+
+/// Describes a single supported stream configuration, retrieved via either a
+/// `SupportedStreamConfigRange` instance or one of the `Device::default_input/output_config` methods.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupportedStreamConfig {
+    pub channels: ChannelCount,
+    pub sample_rate: SampleRate,
+    pub sample_format: SampleFormat,
 }
 
 /// A buffer of dynamically typed audio data, passed to raw stream callbacks.
@@ -233,6 +216,17 @@ pub struct Data {
     data: *mut (),
     len: usize,
     sample_format: SampleFormat,
+}
+
+impl SupportedStreamConfig {
+    /// Construct a `SupportedStreamConfig` from an existing `StreamConfig`.
+    pub fn from_config(conf: &StreamConfig, fmt: SampleFormat) -> Self {
+        Self {
+            channels: conf.channels,
+            sample_rate: conf.sample_rate,
+            sample_format: fmt,
+        }
+    }
 }
 
 impl Data {
@@ -328,25 +322,25 @@ impl Data {
     }
 }
 
-impl SupportedFormat {
-    /// Turns this `SupportedFormat` into a `Format` corresponding to the maximum samples rate.
+impl SupportedStreamConfigRange {
+    /// Turns this `SupportedStreamConfigRange` into a `SupportedStreamConfig` corresponding to the maximum samples rate.
     #[inline]
-    pub fn with_max_sample_rate(self) -> Format {
-        Format {
+    pub fn with_max_sample_rate(self) -> SupportedStreamConfig {
+        SupportedStreamConfig {
             channels: self.channels,
             sample_rate: self.max_sample_rate,
-            data_type: self.data_type,
+            sample_format: self.sample_format,
         }
     }
 
-    /// A comparison function which compares two `SupportedFormat`s in terms of their priority of
+    /// A comparison function which compares two `SupportedStreamConfigRange`s in terms of their priority of
     /// use as a default stream format.
     ///
     /// Some backends do not provide a default stream format for their audio devices. In these
     /// cases, CPAL attempts to decide on a reasonable default format for the user. To do this we
     /// use the "greatest" of all supported stream formats when compared with this method.
     ///
-    /// Formats are prioritised by the following heuristics:
+    /// SupportedStreamConfigs are prioritised by the following heuristics:
     ///
     /// **Channels**:
     ///
@@ -382,17 +376,17 @@ impl SupportedFormat {
             return cmp_channels;
         }
 
-        let cmp_f32 = (self.data_type == F32).cmp(&(other.data_type == F32));
+        let cmp_f32 = (self.sample_format == F32).cmp(&(other.sample_format == F32));
         if cmp_f32 != Equal {
             return cmp_f32;
         }
 
-        let cmp_i16 = (self.data_type == I16).cmp(&(other.data_type == I16));
+        let cmp_i16 = (self.sample_format == I16).cmp(&(other.sample_format == I16));
         if cmp_i16 != Equal {
             return cmp_i16;
         }
 
-        let cmp_u16 = (self.data_type == U16).cmp(&(other.data_type == U16));
+        let cmp_u16 = (self.sample_format == U16).cmp(&(other.sample_format == U16));
         if cmp_u16 != Equal {
             return cmp_u16;
         }
@@ -410,14 +404,25 @@ impl SupportedFormat {
     }
 }
 
-impl From<Format> for SupportedFormat {
+impl From<SupportedStreamConfig> for StreamConfig {
+    fn from(conf: SupportedStreamConfig) -> Self {
+        let channels = conf.channels;
+        let sample_rate = conf.sample_rate;
+        StreamConfig {
+            channels,
+            sample_rate,
+        }
+    }
+}
+
+impl From<SupportedStreamConfig> for SupportedStreamConfigRange {
     #[inline]
-    fn from(format: Format) -> SupportedFormat {
-        SupportedFormat {
+    fn from(format: SupportedStreamConfig) -> SupportedStreamConfigRange {
+        SupportedStreamConfigRange {
             channels: format.channels,
             min_sample_rate: format.sample_rate,
             max_sample_rate: format.sample_rate,
-            data_type: format.data_type,
+            sample_format: format.sample_format,
         }
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -27,8 +27,8 @@ pub use self::platform_impl::*;
 // }
 // ```
 //
-// And so on for Device, Devices, EventLoop, Host, StreamId, SupportedInputFormats,
-// SupportedOutputFormats and all their necessary trait implementations.
+// And so on for Device, Devices, EventLoop, Host, StreamId, SupportedInputConfigs,
+// SupportedOutputConfigs and all their necessary trait implementations.
 // ```
 macro_rules! impl_platform_host {
     ($($HostVariant:ident $host_mod:ident $host_name:literal),*) => {
@@ -67,13 +67,13 @@ macro_rules! impl_platform_host {
         // TODO: Confirm this and add more specific detail and references.
         pub struct Stream(StreamInner, crate::platform::NotSendSyncAcrossAllPlatforms);
 
-        /// The **SupportedInputFormats** iterator associated with the platform's dynamically
+        /// The **SupportedInputConfigs** iterator associated with the platform's dynamically
         /// dispatched **Host** type.
-        pub struct SupportedInputFormats(SupportedInputFormatsInner);
+        pub struct SupportedInputConfigs(SupportedInputConfigsInner);
 
-        /// The **SupportedOutputFormats** iterator associated with the platform's dynamically
+        /// The **SupportedOutputConfigs** iterator associated with the platform's dynamically
         /// dispatched **Host** type.
-        pub struct SupportedOutputFormats(SupportedOutputFormatsInner);
+        pub struct SupportedOutputConfigs(SupportedOutputConfigsInner);
 
         /// Unique identifier for available hosts on the platform.
         #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -107,15 +107,15 @@ macro_rules! impl_platform_host {
             )*
         }
 
-        enum SupportedInputFormatsInner {
+        enum SupportedInputConfigsInner {
             $(
-                $HostVariant(crate::host::$host_mod::SupportedInputFormats),
+                $HostVariant(crate::host::$host_mod::SupportedInputConfigs),
             )*
         }
 
-        enum SupportedOutputFormatsInner {
+        enum SupportedOutputConfigsInner {
             $(
-                $HostVariant(crate::host::$host_mod::SupportedOutputFormats),
+                $HostVariant(crate::host::$host_mod::SupportedOutputConfigs),
             )*
         }
 
@@ -162,13 +162,13 @@ macro_rules! impl_platform_host {
             }
         }
 
-        impl Iterator for SupportedInputFormats {
-            type Item = crate::SupportedFormat;
+        impl Iterator for SupportedInputConfigs {
+            type Item = crate::SupportedStreamConfigRange;
 
             fn next(&mut self) -> Option<Self::Item> {
                 match self.0 {
                     $(
-                        SupportedInputFormatsInner::$HostVariant(ref mut s) => s.next(),
+                        SupportedInputConfigsInner::$HostVariant(ref mut s) => s.next(),
                     )*
                 }
             }
@@ -176,19 +176,19 @@ macro_rules! impl_platform_host {
             fn size_hint(&self) -> (usize, Option<usize>) {
                 match self.0 {
                     $(
-                        SupportedInputFormatsInner::$HostVariant(ref d) => d.size_hint(),
+                        SupportedInputConfigsInner::$HostVariant(ref d) => d.size_hint(),
                     )*
                 }
             }
         }
 
-        impl Iterator for SupportedOutputFormats {
-            type Item = crate::SupportedFormat;
+        impl Iterator for SupportedOutputConfigs {
+            type Item = crate::SupportedStreamConfigRange;
 
             fn next(&mut self) -> Option<Self::Item> {
                 match self.0 {
                     $(
-                        SupportedOutputFormatsInner::$HostVariant(ref mut s) => s.next(),
+                        SupportedOutputConfigsInner::$HostVariant(ref mut s) => s.next(),
                     )*
                 }
             }
@@ -196,15 +196,15 @@ macro_rules! impl_platform_host {
             fn size_hint(&self) -> (usize, Option<usize>) {
                 match self.0 {
                     $(
-                        SupportedOutputFormatsInner::$HostVariant(ref d) => d.size_hint(),
+                        SupportedOutputConfigsInner::$HostVariant(ref d) => d.size_hint(),
                     )*
                 }
             }
         }
 
         impl crate::traits::DeviceTrait for Device {
-            type SupportedInputFormats = SupportedInputFormats;
-            type SupportedOutputFormats = SupportedOutputFormats;
+            type SupportedInputConfigs = SupportedInputConfigs;
+            type SupportedOutputConfigs = SupportedOutputConfigs;
             type Stream = Stream;
 
             fn name(&self) -> Result<String, crate::DeviceNameError> {
@@ -215,49 +215,49 @@ macro_rules! impl_platform_host {
                 }
             }
 
-            fn supported_input_formats(&self) -> Result<Self::SupportedInputFormats, crate::SupportedFormatsError> {
+            fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, crate::SupportedStreamConfigsError> {
                 match self.0 {
                     $(
                         DeviceInner::$HostVariant(ref d) => {
-                            d.supported_input_formats()
-                                .map(SupportedInputFormatsInner::$HostVariant)
-                                .map(SupportedInputFormats)
+                            d.supported_input_configs()
+                                .map(SupportedInputConfigsInner::$HostVariant)
+                                .map(SupportedInputConfigs)
                         }
                     )*
                 }
             }
 
-            fn supported_output_formats(&self) -> Result<Self::SupportedOutputFormats, crate::SupportedFormatsError> {
+            fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, crate::SupportedStreamConfigsError> {
                 match self.0 {
                     $(
                         DeviceInner::$HostVariant(ref d) => {
-                            d.supported_output_formats()
-                                .map(SupportedOutputFormatsInner::$HostVariant)
-                                .map(SupportedOutputFormats)
+                            d.supported_output_configs()
+                                .map(SupportedOutputConfigsInner::$HostVariant)
+                                .map(SupportedOutputConfigs)
                         }
                     )*
                 }
             }
 
-            fn default_input_format(&self) -> Result<crate::Format, crate::DefaultFormatError> {
+            fn default_input_config(&self) -> Result<crate::SupportedStreamConfig, crate::DefaultStreamConfigError> {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.default_input_format(),
+                        DeviceInner::$HostVariant(ref d) => d.default_input_config(),
                     )*
                 }
             }
 
-            fn default_output_format(&self) -> Result<crate::Format, crate::DefaultFormatError> {
+            fn default_output_config(&self) -> Result<crate::SupportedStreamConfig, crate::DefaultStreamConfigError> {
                 match self.0 {
                     $(
-                        DeviceInner::$HostVariant(ref d) => d.default_output_format(),
+                        DeviceInner::$HostVariant(ref d) => d.default_output_config(),
                     )*
                 }
             }
 
             fn build_input_stream_raw<D, E>(
                 &self,
-                format: &crate::Format,
+                format: &crate::SupportedStreamConfig,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
@@ -276,7 +276,7 @@ macro_rules! impl_platform_host {
 
             fn build_output_stream_raw<D, E>(
                 &self,
-                format: &crate::Format,
+                format: &crate::SupportedStreamConfig,
                 data_callback: D,
                 error_callback: E,
             ) -> Result<Self::Stream, crate::BuildStreamError>
@@ -436,8 +436,8 @@ macro_rules! impl_platform_host {
 mod platform_impl {
     pub use crate::host::alsa::{
         Device as AlsaDevice, Devices as AlsaDevices, Host as AlsaHost, Stream as AlsaStream,
-        SupportedInputFormats as AlsaSupportedInputFormats,
-        SupportedOutputFormats as AlsaSupportedOutputFormats,
+        SupportedInputConfigs as AlsaSupportedInputConfigs,
+        SupportedOutputConfigs as AlsaSupportedOutputConfigs,
     };
 
     impl_platform_host!(Alsa alsa "ALSA");
@@ -454,8 +454,8 @@ mod platform_impl {
 mod platform_impl {
     pub use crate::host::coreaudio::{
         Device as CoreAudioDevice, Devices as CoreAudioDevices, Host as CoreAudioHost,
-        Stream as CoreAudioStream, SupportedInputFormats as CoreAudioSupportedInputFormats,
-        SupportedOutputFormats as CoreAudioSupportedOutputFormats,
+        Stream as CoreAudioStream, SupportedInputConfigs as CoreAudioSupportedInputConfigs,
+        SupportedOutputConfigs as CoreAudioSupportedOutputConfigs,
     };
 
     impl_platform_host!(CoreAudio coreaudio "CoreAudio");
@@ -472,8 +472,8 @@ mod platform_impl {
 mod platform_impl {
     pub use crate::host::emscripten::{
         Device as EmscriptenDevice, Devices as EmscriptenDevices, Host as EmscriptenHost,
-        Stream as EmscriptenStream, SupportedInputFormats as EmscriptenSupportedInputFormats,
-        SupportedOutputFormats as EmscriptenSupportedOutputFormats,
+        Stream as EmscriptenStream, SupportedInputConfigs as EmscriptenSupportedInputConfigs,
+        SupportedOutputConfigs as EmscriptenSupportedOutputConfigs,
     };
 
     impl_platform_host!(Emscripten emscripten "Emscripten");
@@ -491,13 +491,13 @@ mod platform_impl {
     #[cfg(feature = "asio")]
     pub use crate::host::asio::{
         Device as AsioDevice, Devices as AsioDevices, Host as AsioHost, Stream as AsioStream,
-        SupportedInputFormats as AsioSupportedInputFormats,
-        SupportedOutputFormats as AsioSupportedOutputFormats,
+        SupportedInputConfigs as AsioSupportedInputConfigs,
+        SupportedOutputConfigs as AsioSupportedOutputConfigs,
     };
     pub use crate::host::wasapi::{
         Device as WasapiDevice, Devices as WasapiDevices, Host as WasapiHost,
-        Stream as WasapiStream, SupportedInputFormats as WasapiSupportedInputFormats,
-        SupportedOutputFormats as WasapiSupportedOutputFormats,
+        Stream as WasapiStream, SupportedInputConfigs as WasapiSupportedInputConfigs,
+        SupportedOutputConfigs as WasapiSupportedOutputConfigs,
     };
 
     #[cfg(feature = "asio")]
@@ -526,8 +526,8 @@ mod platform_impl {
 mod platform_impl {
     pub use crate::host::null::{
         Device as NullDevice, Devices as NullDevices, EventLoop as NullEventLoop, Host as NullHost,
-        StreamId as NullStreamId, SupportedInputFormats as NullSupportedInputFormats,
-        SupportedOutputFormats as NullSupportedOutputFormats,
+        StreamId as NullStreamId, SupportedInputConfigs as NullSupportedInputConfigs,
+        SupportedOutputConfigs as NullSupportedOutputConfigs,
     };
 
     impl_platform_host!(Null null "Null");


### PR DESCRIPTION
This implements the changes described at #370.

Closes #370.

Backends implemented:

- [x] null
- [x] emscripten
- [x] asio
- [x] wasapi
- [x] alsa
- [x] coreaudio
- [x] docs updated
- [x] examples updated

Edit: here is the full list of renamings to make it easier for downstream crates to adapt:

- `Format` type's `data_type` field renamed to `sample_format`.
- `Shape` -> `StreamConfig` - The configuration input required to build a stream.
- `Format` -> `SupportedStreamConfig` - Describes a single supported stream configuration.
- `SupportedFormat` -> `SupportedStreamConfigRange` - Describes a range of supported configurations.
- `Device::default_input/output_format` -> `Device::default_input/output_config`.
- `Device::supported_input/output_formats` -> `Device::supported_input/output_configs`.
- `Device::SupportedInput/OutputFormats` -> `Device::SupportedInput/OutputConfigs`.
- `SupportedFormatsError` -> `SupportedStreamConfigsError`
- `DefaultFormatError` -> `DefaultStreamConfigError`
- `BuildStreamError::FormatNotSupported` -> `BuildStreamError::StreamConfigNotSupported`