### PR TITLE
Remove redundant 'static from &'static str

### DIFF
--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -6,11 +6,11 @@ use std::env;
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
-const CPAL_ASIO_DIR: &'static str = "CPAL_ASIO_DIR";
+const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
-const ASIO_HEADER: &'static str = "asio.h";
-const ASIO_SYS_HEADER: &'static str = "asiosys.h";
-const ASIO_DRIVERS_HEADER: &'static str = "asiodrivers.h";
+const ASIO_HEADER: &str = "asio.h";
+const ASIO_SYS_HEADER: &str = "asiosys.h";
+const ASIO_DRIVERS_HEADER: &str = "asiodrivers.h";
 
 fn main() {
     // If ASIO directory isn't set silently return early

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-const CPAL_ASIO_DIR: &'static str = "CPAL_ASIO_DIR";
+const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
 fn main() {
     // If ASIO directory isn't set silently return early

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), anyhow::Error> {
         .expect("Failed to get default input config");
     println!("Default input config: {:?}", config);
     // The WAV file we're recording to.
-    const PATH: &'static str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
+    const PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
     let spec = wav_spec_from_config(&config);
     let writer = hound::WavWriter::create(PATH, spec)?;
     let writer = Arc::new(Mutex::new(Some(writer)));


### PR DESCRIPTION
Specifying the static lifetime in constants and static variables
is redundant since Rust 1.17.0

https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1170-2017-04-27