### PR TITLE
Fix type for armv6 platforms

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1,6 +1,7 @@
 extern crate alsa_sys as alsa;
 extern crate libc;
 
+use self::libc::c_long;
 use crate::{
     BackendSpecificError, BuildStreamError, ChannelCount, Data, DefaultStreamConfigError,
     DeviceNameError, DevicesError, PauseStreamError, PlayStreamError, SampleFormat, SampleRate,
@@ -763,7 +764,7 @@ fn process_output(
                 available_frames as alsa::snd_pcm_uframes_t,
             )
         };
-        if result == -libc::EPIPE as i64 {
+        if result == -libc::EPIPE as c_long {
             // buffer underrun
             // TODO: Notify the user of this.
             unsafe { alsa::snd_pcm_recover(stream.channel, result as i32, 0) };


### PR DESCRIPTION
I built a small audio app on the raspberry pi zero w, and got an error during the build:

```
error[E0308]: mismatched types
   --> /home/pi/.cargo/git/checkouts/cpal-c2179e82da06da7e/f3e7c46/src/host/alsa/mod.rs:766:22
    |
766 |         if result == -libc::EPIPE as i64 {
    |                      ^^^^^^^^^^^^^^^^^^^ expected `i32`, found `i64`
    |
help: you can convert an `i64` to `i32` and panic if the converted value wouldn't fit
    |
766 |         if result == (-libc::EPIPE as i64).try_into().unwrap() {
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: could not compile `cpal`.
```

Here, `result` comes from the `snd_pcm_writei()` function which returns a `long`. On the ARM architecture used on the pi zero, a `long` is 32 bits, but I think on most platforms it's 64 bits.

I just casted it to a u64 for the comparison, but if there's a different cast you'd prefer, let me know! I'm not sure if this triggers a redundant cast with clippy, it doesn't seem to on MacOS at least.