### PR TITLE
[WIP] Timestamp and `StreamInstant` APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2.65"
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 coreaudio-rs = { version = "0.9.1", default-features = false, features = ["audio_unit", "core_audio"] }
 core-foundation-sys = "0.6.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
+mach = "0.3" # For access to mach_timebase type.
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 stdweb = { version = "0.1.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hound = "3.4"
 ringbuf = "0.1.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "std", "synchapi", "winbase", "winuser"] }
+winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.1", path = "asio-sys", optional = true }
 parking_lot = "0.9"
 

--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -916,9 +916,7 @@ extern "C" fn buffer_switch_time_info(
 ) -> *mut ai::ASIOTime {
     // This lock is probably unavoidable, but locks in the audio stream are not great.
     let mut bcs = BUFFER_CALLBACK.lock().unwrap();
-    let asio_time: &mut AsioTime = unsafe {
-        &mut *(time as *mut AsioTime)
-    };
+    let asio_time: &mut AsioTime = unsafe { &mut *(time as *mut AsioTime) };
     let callback_info = CallbackInfo {
         buffer_index: double_buffer_index,
         system_time: asio_time.time_info.system_time,

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -483,7 +483,7 @@ impl Device {
         config: &StreamConfig,
         sample_format: SampleFormat,
         mut data_callback: D,
-        _error_callback: E,
+        mut error_callback: E,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -637,6 +637,7 @@ impl Device {
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
         let bytes_per_channel = sample_format.sample_size();
+        let sample_rate = config.sample_rate;
         type Args = render_callback::Args<data::Raw>;
         audio_unit.set_input_callback(move |args: Args| unsafe {
             let ptr = (*args.data.data).mBuffers.as_ptr() as *const AudioBuffer;
@@ -645,7 +646,7 @@ impl Device {
 
             // TODO: Perhaps loop over all buffers instead?
             let AudioBuffer {
-                mNumberChannels: _num_channels,
+                mNumberChannels: channels,
                 mDataByteSize: data_byte_size,
                 mData: data,
             } = buffers[0];
@@ -653,7 +654,23 @@ impl Device {
             let data = data as *mut ();
             let len = (data_byte_size as usize / bytes_per_channel) as usize;
             let data = Data::from_parts(data, len, sample_format);
-            let info = InputCallbackInfo {};
+
+            // TODO: Need a better way to get delay, for now we assume a double-buffer offset.
+            let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
+                Err(err) => {
+                    error_callback(err.into());
+                    return Err(());
+                }
+                Ok(cb) => cb,
+            };
+            let buffer_frames = len / channels as usize;
+            let delay = frames_to_duration(buffer_frames, sample_rate);
+            let capture = callback
+                .sub(delay)
+                .expect("`capture` occurs before origin of alsa `StreamInstant`");
+            let timestamp = crate::InputStreamTimestamp { callback, capture };
+
+            let info = InputCallbackInfo { timestamp };
             data_callback(&data, &info);
             Ok(())
         })?;
@@ -672,7 +689,7 @@ impl Device {
         config: &StreamConfig,
         sample_format: SampleFormat,
         mut data_callback: D,
-        _error_callback: E,
+        mut error_callback: E,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -691,13 +708,14 @@ impl Device {
         // Register the callback that is being called by coreaudio whenever it needs data to be
         // fed to the audio buffer.
         let bytes_per_channel = sample_format.sample_size();
+        let sample_rate = config.sample_rate;
         type Args = render_callback::Args<data::Raw>;
         audio_unit.set_render_callback(move |args: Args| unsafe {
             // If `run()` is currently running, then a callback will be available from this list.
             // Otherwise, we just fill the buffer with zeroes and return.
 
             let AudioBuffer {
-                mNumberChannels: _num_channels,
+                mNumberChannels: channels,
                 mDataByteSize: data_byte_size,
                 mData: data,
             } = (*args.data.data).mBuffers[0];
@@ -705,7 +723,23 @@ impl Device {
             let data = data as *mut ();
             let len = (data_byte_size as usize / bytes_per_channel) as usize;
             let mut data = Data::from_parts(data, len, sample_format);
-            let info = OutputCallbackInfo {};
+
+            let callback = match host_time_to_stream_instant(args.time_stamp.mHostTime) {
+                Err(err) => {
+                    error_callback(err.into());
+                    return Err(());
+                }
+                Ok(cb) => cb,
+            };
+            // TODO: Need a better way to get delay, for now we assume a double-buffer offset.
+            let buffer_frames = len / channels as usize;
+            let delay = frames_to_duration(buffer_frames, sample_rate);
+            let playback = callback
+                .add(delay)
+                .expect("`playback` occurs beyond representation supported by `StreamInstant`");
+            let timestamp = crate::OutputStreamTimestamp { callback, playback };
+
+            let info = OutputCallbackInfo { timestamp };
             data_callback(&mut data, &info);
             Ok(())
         })?;
@@ -718,6 +752,26 @@ impl Device {
             device_id: self.audio_device_id,
         }))
     }
+}
+
+fn host_time_to_stream_instant(
+    m_host_time: u64,
+) -> Result<crate::StreamInstant, BackendSpecificError> {
+    let mut info: mach::mach_time::mach_timebase_info = Default::default();
+    let res = unsafe { mach::mach_time::mach_timebase_info(&mut info) };
+    check_os_status(res)?;
+    let nanos = m_host_time * info.numer as u64 / info.denom as u64;
+    let secs = nanos / 1_000_000_000;
+    let subsec_nanos = nanos - secs * 1_000_000_000;
+    Ok(crate::StreamInstant::new(secs as i64, subsec_nanos as u32))
+}
+
+// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
+fn frames_to_duration(frames: usize, rate: crate::SampleRate) -> std::time::Duration {
+    let secsf = frames as f64 / rate.0 as f64;
+    let secs = secsf as u64;
+    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
+    std::time::Duration::new(secs, nanos)
 }
 
 pub struct Stream {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,5 +1,5 @@
 use super::check_result;
-use super::winapi::shared::basetsd::UINT32;
+use super::winapi::shared::basetsd::{UINT32, UINT64};
 use super::winapi::shared::minwindef::{BYTE, FALSE, WORD};
 use super::winapi::um::audioclient::{self, AUDCLNT_E_DEVICE_INVALIDATED, AUDCLNT_S_BUFFER_EMPTY};
 use super::winapi::um::handleapi;
@@ -64,6 +64,7 @@ pub enum AudioClientFlow {
 
 pub struct StreamInner {
     pub audio_client: *mut audioclient::IAudioClient,
+    pub audio_clock: *mut audioclient::IAudioClock,
     pub client_flow: AudioClientFlow,
     // Event that is signalled by WASAPI whenever audio data must be written.
     pub event: winnt::HANDLE,
@@ -73,6 +74,8 @@ pub struct StreamInner {
     pub max_frames_in_buffer: UINT32,
     // Number of bytes that each frame occupies.
     pub bytes_per_frame: WORD,
+    // The configuration with which the stream was created.
+    pub config: crate::StreamConfig,
     // The sample format with which the stream was created.
     pub sample_format: SampleFormat,
 }
@@ -185,6 +188,7 @@ impl Drop for StreamInner {
     fn drop(&mut self) {
         unsafe {
             (*self.audio_client).Release();
+            (*self.audio_clock).Release();
             handleapi::CloseHandle(self.event);
         }
     }
@@ -388,12 +392,13 @@ fn process_input(
             if frames_available == 0 {
                 return ControlFlow::Continue;
             }
+            let mut qpc_position: UINT64 = 0;
             let hresult = (*capture_client).GetBuffer(
                 &mut buffer,
                 &mut frames_available,
                 flags.as_mut_ptr(),
                 ptr::null_mut(),
-                ptr::null_mut(),
+                &mut qpc_position,
             );
 
             // TODO: Can this happen?
@@ -410,7 +415,16 @@ fn process_input(
             let len = frames_available as usize * stream.bytes_per_frame as usize
                 / stream.sample_format.sample_size();
             let data = Data::from_parts(data, len, stream.sample_format);
-            let info = InputCallbackInfo {};
+
+            // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
+            let timestamp = match input_timestamp(stream, qpc_position) {
+                Ok(ts) => ts,
+                Err(err) => {
+                    error_callback(err);
+                    return ControlFlow::Break;
+                }
+            };
+            let info = InputCallbackInfo { timestamp };
             data_callback(&data, &info);
 
             // Release the buffer.
@@ -455,7 +469,15 @@ fn process_output(
         let len = frames_available as usize * stream.bytes_per_frame as usize
             / stream.sample_format.sample_size();
         let mut data = Data::from_parts(data, len, stream.sample_format);
-        let info = OutputCallbackInfo {};
+        let sample_rate = stream.config.sample_rate;
+        let timestamp = match output_timestamp(stream, frames_available, sample_rate) {
+            Ok(ts) => ts,
+            Err(err) => {
+                error_callback(err);
+                return ControlFlow::Break;
+            }
+        };
+        let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
 
         let hresult = (*render_client).ReleaseBuffer(frames_available as u32, 0);
@@ -466,4 +488,67 @@ fn process_output(
     }
 
     ControlFlow::Continue
+}
+
+/// Convert the given duration in frames at the given sample rate to a `std::time::Duration`.
+fn frames_to_duration(frames: u32, rate: crate::SampleRate) -> std::time::Duration {
+    let secsf = frames as f64 / rate.0 as f64;
+    let secs = secsf as u64;
+    let nanos = ((secsf - secs as f64) * 1_000_000_000.0) as u32;
+    std::time::Duration::new(secs, nanos)
+}
+
+/// Use the stream's `IAudioClock` to produce the current stream instant.
+///
+/// Uses the QPC position produced via the `GetPosition` method.
+fn stream_instant(stream: &StreamInner) -> Result<crate::StreamInstant, StreamError> {
+    let mut position: UINT64 = 0;
+    let mut qpc_position: UINT64 = 0;
+    let res = unsafe { (*stream.audio_clock).GetPosition(&mut position, &mut qpc_position) };
+    stream_error_from_hresult(res)?;
+    // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
+    let qpc_nanos = qpc_position as i128 * 100;
+    let instant = crate::StreamInstant::from_nanos_i128(qpc_nanos)
+        .expect("performance counter out of range of `StreamInstant` representation");
+    Ok(instant)
+}
+
+/// Produce the input stream timestamp.
+///
+/// `buffer_qpc_position` is the `qpc_position` returned via the `GetBuffer` call on the capture
+/// client. It represents the instant at which the first sample of the retrieved buffer was
+/// captured.
+fn input_timestamp(
+    stream: &StreamInner,
+    buffer_qpc_position: UINT64,
+) -> Result<crate::InputStreamTimestamp, StreamError> {
+    // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.
+    let qpc_nanos = buffer_qpc_position as i128 * 100;
+    let capture = crate::StreamInstant::from_nanos_i128(qpc_nanos)
+        .expect("performance counter out of range of `StreamInstant` representation");
+    let callback = stream_instant(stream)?;
+    Ok(crate::InputStreamTimestamp { capture, callback })
+}
+
+/// Produce the output stream timestamp.
+///
+/// `frames_available` is the number of frames available for writing as reported by subtracting the
+/// result of `GetCurrentPadding` from the maximum buffer size.
+///
+/// `sample_rate` is the rate at which audio frames are processed by the device.
+///
+/// TODO: The returned `playback` is an estimate that assumes audio is delivered immediately after
+/// `frames_available` are consumed. The reality is that there is likely a tiny amount of latency
+/// after this, but not sure how to determine this.
+fn output_timestamp(
+    stream: &StreamInner,
+    frames_available: u32,
+    sample_rate: crate::SampleRate,
+) -> Result<crate::OutputStreamTimestamp, StreamError> {
+    let callback = stream_instant(stream)?;
+    let buffer_duration = frames_to_duration(frames_available, sample_rate);
+    let playback = callback
+        .add(buffer_duration)
+        .expect("`playback` occurs beyond representation supported by `StreamInstant`");
+    Ok(crate::OutputStreamTimestamp { callback, playback })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,6 +230,16 @@ pub struct Data {
 ///
 /// **StreamInstant** represents a duration since some unspecified origin occurring either before
 /// or equal to the moment the stream from which it was created begins.
+///
+/// ## Host `StreamInstant` Sources
+///
+/// | Host | Source |
+/// | ---- | ------ |
+/// | alsa | `snd_pcm_status_get_htstamp` |
+/// | coreaudio | `mach_absolute_time` |
+/// | wasapi | `QueryPerformanceCounter` |
+/// | asio | `timeGetTime` |
+/// | emscripten | `AudioContext.getOutputTimestamp` |
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
     secs: i64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,6 +158,7 @@ pub use platform::{
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
 pub use samples_formats::{Sample, SampleFormat};
+use std::time::Duration;
 
 mod error;
 mod host;
@@ -220,13 +221,53 @@ pub struct Data {
     sample_format: SampleFormat,
 }
 
-/// Information relevant to a single call to the user's output stream data callback.
-#[derive(Debug, Clone, PartialEq)]
-pub struct OutputCallbackInfo {}
+/// A monotonic time instance associated with a stream, retrieved from either:
+///
+/// 1. A timestamp provided to the stream's underlying audio data callback or
+/// 2. The same time source used to generate timestamps for a stream's underlying audio data
+///    callback.
+///
+/// **StreamInstant** represents a duration since some unspecified origin occurring either before
+/// or equal to the moment the stream from which it was created begins.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct StreamInstant {
+    secs: u64,
+    nanos: u32,
+}
+
+/// A timestamp associated with a call to an input stream's data callback.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct InputStreamTimestamp {
+    /// The instant the stream's data callback was invoked.
+    pub callback: StreamInstant,
+    /// The instant that data was captured from the device.
+    ///
+    /// E.g. The instant data was read from an ADC.
+    pub capture: StreamInstant,
+}
+
+/// A timestamp associated with a call to an output stream's data callback.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct OutputStreamTimestamp {
+    /// The instant the stream's data callback was invoked.
+    pub callback: StreamInstant,
+    /// The predicted instant that data written will be delivered to the device for playback.
+    ///
+    /// E.g. The instant data will be played by a DAC.
+    pub playback: StreamInstant,
+}
 
 /// Information relevant to a single call to the user's input stream data callback.
 #[derive(Debug, Clone, PartialEq)]
-pub struct InputCallbackInfo {}
+pub struct InputCallbackInfo {
+    timestamp: InputStreamTimestamp,
+}
+
+/// Information relevant to a single call to the user's output stream data callback.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputCallbackInfo {
+    timestamp: OutputStreamTimestamp,
+}
 
 impl SupportedStreamConfig {
     pub fn channels(&self) -> ChannelCount {
@@ -246,6 +287,66 @@ impl SupportedStreamConfig {
             channels: self.channels,
             sample_rate: self.sample_rate,
         }
+    }
+}
+
+impl StreamInstant {
+    /// The amount of time elapsed from another instant to this one.
+    ///
+    /// Returns `None` if `earlier` is later than self.
+    pub fn duration_since(&self, earlier: &Self) -> Option<Duration> {
+        if self < earlier {
+            None
+        } else {
+            Some(self.as_duration() - earlier.as_duration())
+        }
+    }
+
+    /// Returns the instant in time after the given duration has passed.
+    ///
+    /// Returns `None` if the resulting instant would exceed the bounds of the underlying data
+    /// structure.
+    pub fn add(&self, duration: Duration) -> Option<Self> {
+        self.as_duration()
+            .checked_add(duration)
+            .map(Self::from_duration)
+    }
+
+    /// Returns the instant in time one `duration` ago.
+    ///
+    /// Returns `None` if the resulting instant would underflow. As a result, it is important to
+    /// consider that on some platforms the `StreamInstant` may begin at `0` from the moment the
+    /// source stream is created.
+    pub fn sub(&self, duration: Duration) -> Option<Self> {
+        self.as_duration()
+            .checked_sub(duration)
+            .map(Self::from_duration)
+    }
+
+    fn new(secs: u64, nanos: u32) -> Self {
+        StreamInstant { secs, nanos }
+    }
+
+    fn as_duration(&self) -> Duration {
+        Duration::new(self.secs, self.nanos)
+    }
+
+    fn from_duration(d: Duration) -> Self {
+        Self::new(d.as_secs(), d.subsec_nanos())
+    }
+}
+
+impl InputCallbackInfo {
+    /// The timestamp associated with the call to an input stream's data callback.
+    pub fn timestamp(&self) -> InputStreamTimestamp {
+        self.timestamp
+    }
+}
+
+impl OutputCallbackInfo {
+    /// The timestamp associated with the call to an output stream's data callback.
+    pub fn timestamp(&self) -> OutputStreamTimestamp {
+        self.timestamp
     }
 }
 


### PR DESCRIPTION
This PR addresses #363. 

Currently, the PR only contains the top-level API but does not yet provide an implementation for each of the hosts. I'm posting this early in order to allow for feedback before diving too deeply into the implementation for each host.

- [x] API
- Platforms:
  - ~null~ N/A
  - [x] alsa - mitchmindtree/cpal#5
  - [x] coreaudio
  - [x] wasapi
  - [x] asio
  - [x] emscripten
- [x] Document `StreamInstant` source for each platform
- [ ] `stream.now()`? Possibly future PR.