### PR TITLE
Fix build error when cross compiling

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -783,7 +783,7 @@ fn stream_timestamp(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec
+    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
 }
 
 // Adapted from `timediff` here:


### PR DESCRIPTION
When I tried cross compiling the source on git to `armv7-unknown-linux-gnueabihf`, it errors with 
```
error[E0308]: mismatched types
   --> /home/user/cpal/src/host/alsa/mod.rs:786:40
    |
786 |     ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec
    |                                        ^^^^^^^^^^ expected `i64`, found `i32`

error[E0277]: cannot add `i32` to `i64`
   --> /home/user/cpal/src/host/alsa/mod.rs:786:38
    |
786 |     ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec
    |                                      ^ no implementation for `i64 + i32`
    |
    = help: the trait `std::ops::Add<i32>` is not implemented for `i64`
```
casting `ts.tv_nsec` to `i64` seems like the easiest fix.