### PR TITLE
[Alsa Host] Add a default period time

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -869,7 +869,7 @@ fn set_hw_params_from_format<'a>(
     config: &StreamConfig,
     sample_format: SampleFormat,
 ) -> Result<alsa::pcm::HwParams<'a>, BackendSpecificError> {
-    let mut hw_params = alsa::pcm::HwParams::any(pcm_handle)?;
+    let hw_params = alsa::pcm::HwParams::any(pcm_handle)?;
     hw_params.set_access(alsa::pcm::Access::RWInterleaved)?;
 
     let sample_format = if cfg!(target_endian = "big") {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -890,12 +890,10 @@ fn set_hw_params_from_format<'a>(
     hw_params.set_rate(config.sample_rate.0, alsa::ValueOr::Nearest)?;
     hw_params.set_channels(config.channels as u32)?;
 
-    // If this isn't set manually a overlarge buffer may be used causing audio delay
-    let mut hw_params_copy = hw_params.clone();
-    if let Err(_) = hw_params.set_buffer_time_near(100_000, alsa::ValueOr::Nearest) {
-        // Swap out the params with errors for a snapshot taken before the error was introduced.
-        mem::swap(&mut hw_params_copy, &mut hw_params);
-    }
+    // These values together represent a moderate latency and wakeup interval.
+    // Without them we are at the mercy of the device
+    hw_params.set_period_time_near(25_000, alsa::ValueOr::Nearest);
+    hw_params.set_buffer_time_near(100_000, alsa::ValueOr::Nearest);
 
     pcm_handle.hw_params(&hw_params)?;
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -892,8 +892,8 @@ fn set_hw_params_from_format<'a>(
 
     // These values together represent a moderate latency and wakeup interval.
     // Without them we are at the mercy of the device
-    hw_params.set_period_time_near(25_000, alsa::ValueOr::Nearest);
-    hw_params.set_buffer_time_near(100_000, alsa::ValueOr::Nearest);
+    hw_params.set_period_time_near(25_000, alsa::ValueOr::Nearest)?;
+    hw_params.set_buffer_time_near(100_000, alsa::ValueOr::Nearest)?;
 
     pcm_handle.hw_params(&hw_params)?;
 


### PR DESCRIPTION
This will accomplish two things, in addition to what the buffer
time already provides:
  - With a latency of 100ms it doesn't make sense to wake up the
    cpu for new audio data more often than this. Maintaining a lower
    period time will create unnecessary load. This is an effect
    that stacks if the alsa device is virtual (Like the pulse plugin,
    which happens to have a low default period time, which stands
    in stark contrast to its reportedly high buffer). Most of the
    time 50ms would also work, but its better to have some fallout
    protection in the default scenario
  - It prevents errors trying to set the buffer time.

I removed the workaround introduced earlier for the second issue. While it's still not entirely clear why it should actually raise an error there if you do not first set the period time, there is something to be said for first choosing the period time in general, since it does restrict the possible buffer sizes.

Fixes #369, Fixes #391 (probably)

Now I also strongly suspect a good period time will have a positive effect for #322, but that should be verified. Since pulse appears involved I am optimistic.

EDIT: I now think that period size first is a requirement that comes with devices that require buffer sizes to be multiples of the period size. If that period size is not defined it is not yet possible to set a buffer size even though the minimum and maximum are well defined. That is probably why `set_buffer_time_near` fails. 