### PR TITLE
Retry COM initialization

### DIFF
--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -10,7 +10,11 @@ thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
         // this call can fail if another library initialized COM in single-threaded mode
         // handling this situation properly would make the API more annoying, so we just don't care
-        check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
+        if check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).is_err() {
+            // Uninitialize and try again
+            CoUninitialize();
+            check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
+        }
         ComInitialized(ptr::null_mut())
     }
 });


### PR DESCRIPTION
I noticed that running the enumerate example with ASIO enabled listed ASIO devices fine, and then panic:ed on Wasapi. Reversing the order to do Wasapi first made it work fine.
I'm thinking that the same situation could happen in an application that supports switching between different hosts.
This PR adds a second try to initialize COM if the first try fails. This fixes the enumerate example, but I guess there could be side effects I'm not aware of. 