### PR TITLE
Move dependencies unused on non-windows platforms to the windows section in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,10 @@ license = "Apache-2.0"
 keywords = ["audio", "sound"]
 
 [features]
-asio = ["asio-sys"] # Only available on Windows. See README for setup instructions.
+asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
 
 [dependencies]
 thiserror = "1.0.2"
-lazy_static = "1.3"
-num-traits = "0.2.6"
 
 [dev-dependencies]
 anyhow = "1.0.12"
@@ -24,7 +22,9 @@ ringbuf = "0.1.6"
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.1", path = "asio-sys", optional = true }
+num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.9"
+lazy_static = "1.3"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 alsa = "0.4.1"


### PR DESCRIPTION
This should reduce the footprint of cpal on non-windows platforms.