### PR TITLE
Disable cargo publish invocation

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         CPAL_TMP=$(mktemp /tmp/cpalXXX.txt) || echo "::error::mktemp error"
         echo "::set-env name=CPAL_TMP::$CPAL_TMP"
-        cargo publish --token $CRATESIO_TOKEN 2> $CPAL_TMP
+        #cargo publish --token $CRATESIO_TOKEN 2> $CPAL_TMP
     - name: Check if cpal is already published
       run: |
         empty=0


### PR DESCRIPTION
To allow pushing to master after the 0.12.0 release.

The 0.12.0 release will be uploaded manually.