### PR TITLE
Reenable the publish github workflow

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         CPAL_TMP=$(mktemp /tmp/cpalXXX.txt) || echo "::error::mktemp error"
         echo "::set-env name=CPAL_TMP::$CPAL_TMP"
-        #cargo publish --token $CRATESIO_TOKEN 2> $CPAL_TMP
+        cargo publish --token $CRATESIO_TOKEN 2> $CPAL_TMP
     - name: Check if cpal is already published
       run: |
         empty=0


### PR DESCRIPTION
The manual release of 0.12.0 is done.
Hopefully the issue is now resolved and in the future the CI can do it automatically.

cc #428 and #444