### PR TITLE
adding in a link to the CPAL WASM guide into the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Note that on Linux, the ALSA development files are required. These are provided
 as part of the `libasound2-dev` package on Debian and Ubuntu distributions and
 `alsa-lib-devel` on Fedora.
 
+## Compiling for Web Assembly
+
+If you are interested in using CPAL with WASM, please see [this guide](https://github.com/RustAudio/cpal/wiki/Setting-up-a-new-CPAL-WASM-project) in our Wiki which walks through setting up a new project from scratch. 
+
 ## ASIO on Windows
 
 [ASIO](https://en.wikipedia.org/wiki/Audio_Stream_Input/Output) is an audio


### PR DESCRIPTION
I wrote a simple getting started guide for creating a CPAL WASM project that I published to the Wiki. It was adopted from the existing work of @ishitatsuyuki . [See this link](https://github.com/RustAudio/cpal/wiki/Setting-up-a-new-CPAL-WASM-project)

I didn't see a way to create PR for a post in the Wiki so if anyone has any issues they want to be addressed with the post just let me know here. 