### PR TITLE
Eliminate or suppress Clippy messages.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag
     match env::var(CPAL_ASIO_DIR) {
-        Err(_) => {},
+        Err(_) => {}
         Ok(_) => println!("cargo:rustc-cfg=asio"),
     };
 }

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ fn main() {
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag
     match env::var(CPAL_ASIO_DIR) {
-        Err(_) => return,
+        Err(_) => {},
         Ok(_) => println!("cargo:rustc-cfg=asio"),
     };
 }

--- a/src/host/coreaudio/enumerate.rs
+++ b/src/host/coreaudio/enumerate.rs
@@ -108,9 +108,7 @@ pub fn default_input_device() -> Option<Device> {
         return None;
     }
 
-    let device = Device {
-        audio_device_id,
-    };
+    let device = Device { audio_device_id };
     Some(device)
 }
 
@@ -137,9 +135,7 @@ pub fn default_output_device() -> Option<Device> {
         return None;
     }
 
-    let device = Device {
-        audio_device_id,
-    };
+    let device = Device { audio_device_id };
     Some(device)
 }
 

--- a/src/host/coreaudio/enumerate.rs
+++ b/src/host/coreaudio/enumerate.rs
@@ -109,7 +109,7 @@ pub fn default_input_device() -> Option<Device> {
     }
 
     let device = Device {
-        audio_device_id: audio_device_id,
+        audio_device_id,
     };
     Some(device)
 }
@@ -138,7 +138,7 @@ pub fn default_output_device() -> Option<Device> {
     }
 
     let device = Device {
-        audio_device_id: audio_device_id,
+        audio_device_id,
     };
     Some(device)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,7 @@ impl OutputCallbackInfo {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Data {
     // Internal constructor for host implementations to use.
     //
@@ -457,7 +458,7 @@ impl Data {
     pub fn len(&self) -> usize {
         self.len
     }
-
+    
     /// The raw slice of memory representing the underlying audio data as a slice of bytes.
     ///
     /// It is up to the user to interpret the slice of memory based on `Data::sample_format`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,7 +458,7 @@ impl Data {
     pub fn len(&self) -> usize {
         self.len
     }
-    
+
     /// The raw slice of memory representing the underlying audio data as a slice of bytes.
     ///
     /// It is up to the user to interpret the slice of memory based on `Data::sample_format`.

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -15,10 +15,10 @@ impl SampleFormat {
     /// Returns the size in bytes of a sample of this format.
     #[inline]
     pub fn sample_size(&self) -> usize {
-        match self {
-            &SampleFormat::I16 => mem::size_of::<i16>(),
-            &SampleFormat::U16 => mem::size_of::<u16>(),
-            &SampleFormat::F32 => mem::size_of::<f32>(),
+        match *self {
+            SampleFormat::I16 => mem::size_of::<i16>(),
+            SampleFormat::U16 => mem::size_of::<u16>(),
+            SampleFormat::F32 => mem::size_of::<f32>(),
         }
     }
 }


### PR DESCRIPTION
Clippy insists on checking all dependencies to my project, so I'm motivated to eliminate its warnings. Most of Clippy's recommendations here are stylistic, but one identifies a potential bug: in src/host/coreaudio/mod.rs line 660, there is a loop waiting for changes to the variable "reported_rate," which can only happen because of an unsafe alias earlier in the method. A compiler might optimize away the loop.