### PR TITLE
Use alsa::pcm::Frames in alsa API calls instead of fixed-width integers.

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -903,7 +903,7 @@ fn set_hw_params_from_format<'a>(
     hw_params.set_channels(config.channels as u32)?;
 
     match config.buffer_size {
-        BufferSize::Fixed(v) => hw_params.set_buffer_size(v as i64)?,
+        BufferSize::Fixed(v) => hw_params.set_buffer_size(v as alsa::pcm::Frames)?,
         BufferSize::Default => {
             // These values together represent a moderate latency and wakeup interval.
             // Without them we are at the mercy of the device


### PR DESCRIPTION
`alsa::pcm::Frames` resolves to `c_long` which is 32 bits instead of 64 when compiling for raspberry pi (armv7l).