### PR TITLE
Use the given sample rate in `SupportedStreamConfigRange::with_sample_rate()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,7 +545,7 @@ impl SupportedStreamConfigRange {
         assert!(self.min_sample_rate <= sample_rate && sample_rate <= self.max_sample_rate);
         SupportedStreamConfig {
             channels: self.channels,
-            sample_rate: self.max_sample_rate,
+            sample_rate: sample_rate,
             sample_format: self.sample_format,
             buffer_size: self.buffer_size,
         }


### PR DESCRIPTION
`with_sample_rate` previously returned the same as `with_max_sample_rate`, which seems like a typo.
Additionally, ALSA reports that some soundcards have a maximum sample rate of `INT_MAX` in which case there will be an error when opening the stream.