### PR TITLE
Android support via Oboe

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -18,11 +18,17 @@ jobs:
         toolchain: stable
         override: true
         components: clippy
+        target: armv7-linux-androideabi
     - name: Run clippy
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --all --all-features
+    - name: Run clippy for Android target
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all --all-features --target armv7-linux-androideabi
 
   rustfmt-check:
     runs-on: ubuntu-latest
@@ -177,3 +183,23 @@ jobs:
       run: cargo test --all --no-default-features --verbose
     - name: Run all features
       run: cargo test --all --all-features --verbose
+
+  android-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        target: armv7-linux-androideabi
+    - name: Check beep
+      run: cargo check --example beep --target armv7-linux-androideabi --verbose
+    - name: Check enumerate
+      run: cargo check --example enumerate --target armv7-linux-androideabi --verbose
+    - name: Check feedback
+      run: cargo check --example feedback --target armv7-linux-androideabi --verbose
+    - name: Check record_wav
+      run: cargo check --example record_wav --target armv7-linux-androideabi --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,9 @@ stdweb = { version = "0.1.3", default-features = false }
 wasm-bindgen = { version = "0.2.58", optional = true }
 js-sys = { version = "0.3.35" }
 web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }
+
+[target.'cfg(target_os = "android")'.dependencies]
+oboe = { version = "0.2.1", features = [ "java-interface" ] }
+ndk = "0.2"
+ndk-glue = "0.2"
+jni = "0.17"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently supported hosts include:
 - Windows (via WASAPI by default, see ASIO instructions below)
 - macOS (via CoreAudio)
 - iOS (via CoreAudio)
+- Android (via Oboe)
 - Emscripten
 
 Note that on Linux, the ALSA development files are required. These are provided

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -7,6 +7,8 @@ pub(crate) mod coreaudio;
 #[cfg(target_os = "emscripten")]
 pub(crate) mod emscripten;
 pub(crate) mod null;
+#[cfg(target_os = "android")]
+pub(crate) mod oboe;
 #[cfg(windows)]
 pub(crate) mod wasapi;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]

--- a/src/host/oboe/android_media.rs
+++ b/src/host/oboe/android_media.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+extern crate jni;
+extern crate ndk_glue;
+
+use self::jni::Executor;
+use self::jni::{errors::Result as JResult, objects::JObject, JNIEnv, JavaVM};
+
+// constants from android.media.AudioFormat
+pub const ENCODING_PCM_16BIT: i32 = 2;
+pub const ENCODING_PCM_FLOAT: i32 = 4;
+pub const CHANNEL_OUT_MONO: i32 = 4;
+pub const CHANNEL_OUT_STEREO: i32 = 12;
+
+fn with_attached<F, R>(closure: F) -> JResult<R>
+where
+    F: FnOnce(&JNIEnv, JObject) -> JResult<R>,
+{
+    let activity = ndk_glue::native_activity();
+    let vm = Arc::new(unsafe { JavaVM::from_raw(activity.vm())? });
+    let activity = activity.activity();
+    Executor::new(vm).with_attached(|env| closure(env, activity.into()))
+}
+
+fn get_min_buffer_size(
+    class: &'static str,
+    sample_rate: i32,
+    channel_mask: i32,
+    format: i32,
+) -> i32 {
+    // Unwrapping everything because these operations are not expected to fail
+    // or throw exceptions. Android returns negative values for invalid parameters,
+    // which is what we expect.
+    with_attached(|env, _activity| {
+        let class = env.find_class(class).unwrap();
+        env.call_static_method(
+            class,
+            "getMinBufferSize",
+            "(III)I",
+            &[sample_rate.into(), channel_mask.into(), format.into()],
+        )
+        .unwrap()
+        .i()
+    })
+    .unwrap()
+}
+
+pub fn get_audio_track_min_buffer_size(sample_rate: i32, channel_mask: i32, format: i32) -> i32 {
+    get_min_buffer_size(
+        "android/media/AudioTrack",
+        sample_rate,
+        channel_mask,
+        format,
+    )
+}
+
+pub fn get_audio_record_min_buffer_size(sample_rate: i32, channel_mask: i32, format: i32) -> i32 {
+    get_min_buffer_size(
+        "android/media/AudioRecord",
+        sample_rate,
+        channel_mask,
+        format,
+    )
+}

--- a/src/host/oboe/convert.rs
+++ b/src/host/oboe/convert.rs
@@ -1,0 +1,82 @@
+use std::convert::TryInto;
+use std::time::Duration;
+
+extern crate oboe;
+
+use crate::{
+    BackendSpecificError, BuildStreamError, PauseStreamError, PlayStreamError, StreamError,
+    StreamInstant,
+};
+
+pub fn to_stream_instant(duration: Duration) -> StreamInstant {
+    StreamInstant::new(
+        duration.as_secs().try_into().unwrap(),
+        duration.subsec_nanos(),
+    )
+}
+
+pub fn stream_instant<T: oboe::AudioStream + ?Sized>(stream: &mut T) -> StreamInstant {
+    const CLOCK_MONOTONIC: i32 = 1;
+    let ts = stream
+        .get_timestamp(CLOCK_MONOTONIC)
+        .unwrap_or(oboe::FrameTimestamp {
+            position: 0,
+            timestamp: 0,
+        });
+    to_stream_instant(Duration::from_nanos(ts.timestamp as u64))
+}
+
+impl From<oboe::Error> for StreamError {
+    fn from(error: oboe::Error) -> Self {
+        use self::oboe::Error::*;
+        match error {
+            Disconnected | Unavailable | Closed => Self::DeviceNotAvailable,
+            e => (BackendSpecificError {
+                description: e.to_string(),
+            })
+            .into(),
+        }
+    }
+}
+
+impl From<oboe::Error> for PlayStreamError {
+    fn from(error: oboe::Error) -> Self {
+        use self::oboe::Error::*;
+        match error {
+            Disconnected | Unavailable | Closed => Self::DeviceNotAvailable,
+            e => (BackendSpecificError {
+                description: e.to_string(),
+            })
+            .into(),
+        }
+    }
+}
+
+impl From<oboe::Error> for PauseStreamError {
+    fn from(error: oboe::Error) -> Self {
+        use self::oboe::Error::*;
+        match error {
+            Disconnected | Unavailable | Closed => Self::DeviceNotAvailable,
+            e => (BackendSpecificError {
+                description: e.to_string(),
+            })
+            .into(),
+        }
+    }
+}
+
+impl From<oboe::Error> for BuildStreamError {
+    fn from(error: oboe::Error) -> Self {
+        use self::oboe::Error::*;
+        match error {
+            Disconnected | Unavailable | Closed => Self::DeviceNotAvailable,
+            NoFreeHandles => Self::StreamIdOverflow,
+            InvalidFormat | InvalidRate => Self::StreamConfigNotSupported,
+            IllegalArgument => Self::InvalidArgument,
+            e => (BackendSpecificError {
+                description: e.to_string(),
+            })
+            .into(),
+        }
+    }
+}

--- a/src/host/oboe/input_callback.rs
+++ b/src/host/oboe/input_callback.rs
@@ -1,0 +1,90 @@
+use std::marker::PhantomData;
+use std::time::Instant;
+
+extern crate oboe;
+
+use super::convert::{stream_instant, to_stream_instant};
+use crate::{Data, InputCallbackInfo, InputStreamTimestamp, Sample, StreamError};
+
+pub struct CpalInputCallback<I, C> {
+    data_cb: Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>,
+    error_cb: Box<dyn FnMut(StreamError) + Send + 'static>,
+    created: Instant,
+    phantom_channel: PhantomData<C>,
+    phantom_input: PhantomData<I>,
+}
+
+impl<I, C> CpalInputCallback<I, C> {
+    pub fn new<D, E>(data_cb: D, error_cb: E) -> Self
+    where
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        Self {
+            data_cb: Box::new(data_cb),
+            error_cb: Box::new(error_cb),
+            created: Instant::now(),
+            phantom_channel: PhantomData,
+            phantom_input: PhantomData,
+        }
+    }
+
+    fn make_callback_info(
+        &self,
+        audio_stream: &mut dyn oboe::AudioInputStream,
+    ) -> InputCallbackInfo {
+        InputCallbackInfo {
+            timestamp: InputStreamTimestamp {
+                callback: to_stream_instant(self.created.elapsed()),
+                capture: stream_instant(audio_stream),
+            },
+        }
+    }
+}
+
+impl<T: Sample, C: oboe::IsChannelCount> oboe::AudioInputCallback for CpalInputCallback<T, C>
+where
+    (T, C): oboe::IsFrameType,
+{
+    type FrameType = (T, C);
+
+    fn on_audio_ready(
+        &mut self,
+        audio_stream: &mut dyn oboe::AudioInputStream,
+        audio_data: &[<<Self as oboe::AudioInputCallback>::FrameType as oboe::IsFrameType>::Type],
+    ) -> oboe::DataCallbackResult {
+        let cb_info = self.make_callback_info(audio_stream);
+        let channel_count = if C::CHANNEL_COUNT == oboe::ChannelCount::Mono {
+            1
+        } else {
+            2
+        };
+        (self.data_cb)(
+            &unsafe {
+                Data::from_parts(
+                    audio_data.as_ptr() as *mut _,
+                    audio_data.len() * channel_count,
+                    T::FORMAT,
+                )
+            },
+            &cb_info,
+        );
+        oboe::DataCallbackResult::Continue
+    }
+
+    fn on_error_before_close(
+        &mut self,
+        _audio_stream: &mut dyn oboe::AudioInputStream,
+        error: oboe::Error,
+    ) {
+        (self.error_cb)(StreamError::from(error))
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        _audio_stream: &mut dyn oboe::AudioInputStream,
+        error: oboe::Error,
+    ) {
+        (self.error_cb)(StreamError::from(error))
+    }
+}

--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -1,0 +1,487 @@
+use std::cell::RefCell;
+use std::cmp;
+use std::convert::TryInto;
+use std::vec::IntoIter as VecIntoIter;
+
+extern crate oboe;
+
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
+use crate::{
+    BackendSpecificError, BufferSize, BuildStreamError, Data, DefaultStreamConfigError,
+    DeviceNameError, DevicesError, InputCallbackInfo, OutputCallbackInfo, PauseStreamError,
+    PlayStreamError, Sample, SampleFormat, SampleRate, StreamConfig, StreamError,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    SupportedStreamConfigsError,
+};
+
+mod android_media;
+mod convert;
+mod input_callback;
+mod output_callback;
+
+use self::android_media::{get_audio_record_min_buffer_size, get_audio_track_min_buffer_size};
+use self::input_callback::CpalInputCallback;
+use self::output_callback::CpalOutputCallback;
+
+// Android Java API supports up to 8 channels, but oboe API
+// only exposes mono and stereo.
+const CHANNEL_MASKS: [i32; 2] = [
+    android_media::CHANNEL_OUT_MONO,
+    android_media::CHANNEL_OUT_STEREO,
+];
+
+const SAMPLE_RATES: [i32; 13] = [
+    5512, 8000, 11025, 16000, 22050, 32000, 44100, 48000, 64000, 88200, 96000, 176_400, 192_000,
+];
+
+pub struct Host;
+pub struct Device(Option<oboe::AudioDeviceInfo>);
+pub struct Stream(Box<RefCell<dyn oboe::AudioStream>>);
+pub type SupportedInputConfigs = VecIntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = VecIntoIter<SupportedStreamConfigRange>;
+pub type Devices = VecIntoIter<Device>;
+
+impl Host {
+    pub fn new() -> Result<Self, crate::HostUnavailable> {
+        Ok(Host)
+    }
+}
+
+impl HostTrait for Host {
+    type Devices = Devices;
+    type Device = Device;
+
+    fn is_available() -> bool {
+        true
+    }
+
+    fn devices(&self) -> Result<Self::Devices, DevicesError> {
+        if let Ok(devices) = oboe::AudioDeviceInfo::request(oboe::AudioDeviceDirection::InputOutput)
+        {
+            Ok(devices
+                .into_iter()
+                .map(|d| Device(Some(d)))
+                .collect::<Vec<_>>()
+                .into_iter())
+        } else {
+            Ok(vec![Device(None)].into_iter())
+        }
+    }
+
+    fn default_input_device(&self) -> Option<Self::Device> {
+        if let Ok(devices) = oboe::AudioDeviceInfo::request(oboe::AudioDeviceDirection::Input) {
+            devices.into_iter().map(|d| Device(Some(d))).next()
+        } else {
+            Some(Device(None))
+        }
+    }
+
+    fn default_output_device(&self) -> Option<Self::Device> {
+        if let Ok(devices) = oboe::AudioDeviceInfo::request(oboe::AudioDeviceDirection::Output) {
+            devices.into_iter().map(|d| Device(Some(d))).next()
+        } else {
+            Some(Device(None))
+        }
+    }
+}
+
+fn buffer_size_range_for_params(
+    is_output: bool,
+    sample_rate: i32,
+    channel_mask: i32,
+    android_format: i32,
+) -> SupportedBufferSize {
+    let min_buffer_size = if is_output {
+        get_audio_track_min_buffer_size(sample_rate, channel_mask, android_format)
+    } else {
+        get_audio_record_min_buffer_size(sample_rate, channel_mask, android_format)
+    };
+    if min_buffer_size > 0 {
+        SupportedBufferSize::Range {
+            min: min_buffer_size as u32,
+            max: i32::MAX as u32,
+        }
+    } else {
+        SupportedBufferSize::Unknown
+    }
+}
+
+fn default_supported_configs(is_output: bool) -> VecIntoIter<SupportedStreamConfigRange> {
+    // Have to "brute force" the parameter combinations with getMinBufferSize
+    const FORMATS: [SampleFormat; 2] = [SampleFormat::I16, SampleFormat::F32];
+
+    let mut output = Vec::with_capacity(SAMPLE_RATES.len() * CHANNEL_MASKS.len() * FORMATS.len());
+    for sample_format in &FORMATS {
+        let android_format = if *sample_format == SampleFormat::I16 {
+            android_media::ENCODING_PCM_16BIT
+        } else {
+            android_media::ENCODING_PCM_FLOAT
+        };
+        for (mask_idx, channel_mask) in CHANNEL_MASKS.iter().enumerate() {
+            let channel_count = mask_idx + 1;
+            for sample_rate in &SAMPLE_RATES {
+                if let SupportedBufferSize::Range { min, max } = buffer_size_range_for_params(
+                    is_output,
+                    *sample_rate,
+                    *channel_mask,
+                    android_format,
+                ) {
+                    output.push(SupportedStreamConfigRange {
+                        channels: channel_count as u16,
+                        min_sample_rate: SampleRate(*sample_rate as u32),
+                        max_sample_rate: SampleRate(*sample_rate as u32),
+                        buffer_size: SupportedBufferSize::Range { min, max },
+                        sample_format: *sample_format,
+                    });
+                }
+            }
+        }
+    }
+
+    output.into_iter()
+}
+
+fn device_supported_configs(
+    device: &oboe::AudioDeviceInfo,
+    is_output: bool,
+) -> VecIntoIter<SupportedStreamConfigRange> {
+    let sample_rates = if !device.sample_rates.is_empty() {
+        device.sample_rates.as_slice()
+    } else {
+        &SAMPLE_RATES
+    };
+
+    const ALL_CHANNELS: [i32; 2] = [1, 2];
+    let channel_counts = if !device.channel_counts.is_empty() {
+        device.channel_counts.as_slice()
+    } else {
+        &ALL_CHANNELS
+    };
+
+    const ALL_FORMATS: [oboe::AudioFormat; 2] = [oboe::AudioFormat::I16, oboe::AudioFormat::F32];
+    let formats = if !device.formats.is_empty() {
+        device.formats.as_slice()
+    } else {
+        &ALL_FORMATS
+    };
+
+    let mut output = Vec::with_capacity(sample_rates.len() * channel_counts.len() * formats.len());
+    for sample_rate in sample_rates {
+        for channel_count in channel_counts {
+            assert!(*channel_count > 0);
+            if *channel_count > 2 {
+                // could be supported by the device, but oboe does not support more than 2 channels
+                continue;
+            }
+            let channel_mask = CHANNEL_MASKS[*channel_count as usize - 1];
+            for format in formats {
+                let (android_format, sample_format) = match format {
+                    oboe::AudioFormat::I16 => {
+                        (android_media::ENCODING_PCM_16BIT, SampleFormat::I16)
+                    }
+                    oboe::AudioFormat::F32 => {
+                        (android_media::ENCODING_PCM_FLOAT, SampleFormat::F32)
+                    }
+                    _ => panic!("Unexpected format"),
+                };
+                let buffer_size = buffer_size_range_for_params(
+                    is_output,
+                    *sample_rate,
+                    channel_mask,
+                    android_format,
+                );
+                output.push(SupportedStreamConfigRange {
+                    channels: cmp::min(*channel_count as u16, 2u16),
+                    min_sample_rate: SampleRate(*sample_rate as u32),
+                    max_sample_rate: SampleRate(*sample_rate as u32),
+                    buffer_size,
+                    sample_format,
+                });
+            }
+        }
+    }
+
+    output.into_iter()
+}
+
+fn configure_for_device<D, C, I>(
+    builder: oboe::AudioStreamBuilder<D, C, I>,
+    device: &Device,
+    config: &StreamConfig,
+) -> oboe::AudioStreamBuilder<D, C, I> {
+    let mut builder = if let Some(info) = &device.0 {
+        builder.set_device_id(info.id)
+    } else {
+        builder
+    };
+    builder = builder.set_sample_rate(config.sample_rate.0.try_into().unwrap());
+    match &config.buffer_size {
+        BufferSize::Default => builder,
+        BufferSize::Fixed(size) => builder.set_buffer_capacity_in_frames(*size as i32),
+    }
+}
+
+fn build_input_stream<D, E, C, T>(
+    device: &Device,
+    config: &StreamConfig,
+    data_callback: D,
+    error_callback: E,
+    builder: oboe::AudioStreamBuilder<oboe::Input, C, T>,
+) -> Result<Stream, BuildStreamError>
+where
+    T: Sample + oboe::IsFormat + Send + 'static,
+    C: oboe::IsChannelCount + Send + 'static,
+    (T, C): oboe::IsFrameType,
+    D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+    E: FnMut(StreamError) + Send + 'static,
+{
+    let builder = configure_for_device(builder, device, config);
+    let stream = builder
+        .set_callback(CpalInputCallback::<T, C>::new(
+            data_callback,
+            error_callback,
+        ))
+        .open_stream()?;
+    Ok(Stream(Box::new(RefCell::new(stream))))
+}
+
+fn build_output_stream<D, E, C, T>(
+    device: &Device,
+    config: &StreamConfig,
+    data_callback: D,
+    error_callback: E,
+    builder: oboe::AudioStreamBuilder<oboe::Output, C, T>,
+) -> Result<Stream, BuildStreamError>
+where
+    T: Sample + oboe::IsFormat + Send + 'static,
+    C: oboe::IsChannelCount + Send + 'static,
+    (T, C): oboe::IsFrameType,
+    D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+    E: FnMut(StreamError) + Send + 'static,
+{
+    let builder = configure_for_device(builder, device, config);
+    let stream = builder
+        .set_callback(CpalOutputCallback::<T, C>::new(
+            data_callback,
+            error_callback,
+        ))
+        .open_stream()?;
+    Ok(Stream(Box::new(RefCell::new(stream))))
+}
+
+impl DeviceTrait for Device {
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
+    type Stream = Stream;
+
+    fn name(&self) -> Result<String, DeviceNameError> {
+        match &self.0 {
+            None => Ok("default".to_owned()),
+            Some(info) => Ok(info.product_name.clone()),
+        }
+    }
+
+    fn supported_input_configs(
+        &self,
+    ) -> Result<Self::SupportedInputConfigs, SupportedStreamConfigsError> {
+        if let Some(info) = &self.0 {
+            Ok(device_supported_configs(info, false))
+        } else {
+            Ok(default_supported_configs(false))
+        }
+    }
+
+    fn supported_output_configs(
+        &self,
+    ) -> Result<Self::SupportedOutputConfigs, SupportedStreamConfigsError> {
+        if let Some(info) = &self.0 {
+            Ok(device_supported_configs(info, true))
+        } else {
+            Ok(default_supported_configs(true))
+        }
+    }
+
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        let mut configs: Vec<_> = self.supported_input_configs().unwrap().collect();
+        configs.sort_by(|a, b| b.cmp_default_heuristics(a));
+        let config = configs
+            .into_iter()
+            .next()
+            .ok_or(DefaultStreamConfigError::StreamTypeNotSupported)?
+            .with_max_sample_rate();
+        Ok(config)
+    }
+
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        let mut configs: Vec<_> = self.supported_output_configs().unwrap().collect();
+        configs.sort_by(|a, b| b.cmp_default_heuristics(a));
+        let config = configs
+            .into_iter()
+            .next()
+            .ok_or(DefaultStreamConfigError::StreamTypeNotSupported)?
+            .with_max_sample_rate();
+        Ok(config)
+    }
+
+    fn build_input_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        match sample_format {
+            SampleFormat::I16 => {
+                let builder = oboe::AudioStreamBuilder::default()
+                    .set_input()
+                    .set_format::<i16>();
+                if config.channels == 1 {
+                    build_input_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_mono(),
+                    )
+                } else if config.channels == 2 {
+                    build_input_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_stereo(),
+                    )
+                } else {
+                    Err(BackendSpecificError {
+                        description: "More than 2 channels are not supported by Oboe.".to_owned(),
+                    }
+                    .into())
+                }
+            }
+            SampleFormat::F32 => {
+                let builder = oboe::AudioStreamBuilder::default()
+                    .set_input()
+                    .set_format::<f32>();
+                if config.channels == 1 {
+                    build_input_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_mono(),
+                    )
+                } else if config.channels == 2 {
+                    build_input_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_stereo(),
+                    )
+                } else {
+                    Err(BackendSpecificError {
+                        description: "More than 2 channels are not supported by Oboe.".to_owned(),
+                    }
+                    .into())
+                }
+            }
+            SampleFormat::U16 => Err(BackendSpecificError {
+                description: "U16 format is not supported on Android.".to_owned(),
+            }
+            .into()),
+        }
+    }
+
+    fn build_output_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        match sample_format {
+            SampleFormat::I16 => {
+                let builder = oboe::AudioStreamBuilder::default()
+                    .set_output()
+                    .set_format::<i16>();
+                if config.channels == 1 {
+                    build_output_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_mono(),
+                    )
+                } else if config.channels == 2 {
+                    build_output_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_stereo(),
+                    )
+                } else {
+                    Err(BackendSpecificError {
+                        description: "More than 2 channels are not supported by Oboe.".to_owned(),
+                    }
+                    .into())
+                }
+            }
+            SampleFormat::F32 => {
+                let builder = oboe::AudioStreamBuilder::default()
+                    .set_output()
+                    .set_format::<f32>();
+                if config.channels == 1 {
+                    build_output_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_mono(),
+                    )
+                } else if config.channels == 2 {
+                    build_output_stream(
+                        self,
+                        config,
+                        data_callback,
+                        error_callback,
+                        builder.set_stereo(),
+                    )
+                } else {
+                    Err(BackendSpecificError {
+                        description: "More than 2 channels are not supported by Oboe.".to_owned(),
+                    }
+                    .into())
+                }
+            }
+            SampleFormat::U16 => Err(BackendSpecificError {
+                description: "U16 format is not supported on Android.".to_owned(),
+            }
+            .into()),
+        }
+    }
+}
+
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        self.0
+            .borrow_mut()
+            .request_start()
+            .map_err(PlayStreamError::from)
+    }
+
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        self.0
+            .borrow_mut()
+            .request_pause()
+            .map_err(PauseStreamError::from)
+    }
+}

--- a/src/host/oboe/output_callback.rs
+++ b/src/host/oboe/output_callback.rs
@@ -1,0 +1,90 @@
+use std::marker::PhantomData;
+use std::time::Instant;
+
+extern crate oboe;
+
+use super::convert::{stream_instant, to_stream_instant};
+use crate::{Data, OutputCallbackInfo, OutputStreamTimestamp, Sample, StreamError};
+
+pub struct CpalOutputCallback<I, C> {
+    data_cb: Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>,
+    error_cb: Box<dyn FnMut(StreamError) + Send + 'static>,
+    created: Instant,
+    phantom_channel: PhantomData<C>,
+    phantom_input: PhantomData<I>,
+}
+
+impl<I, C> CpalOutputCallback<I, C> {
+    pub fn new<D, E>(data_cb: D, error_cb: E) -> Self
+    where
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        Self {
+            data_cb: Box::new(data_cb),
+            error_cb: Box::new(error_cb),
+            created: Instant::now(),
+            phantom_channel: PhantomData,
+            phantom_input: PhantomData,
+        }
+    }
+
+    fn make_callback_info(
+        &self,
+        audio_stream: &mut dyn oboe::AudioOutputStream,
+    ) -> OutputCallbackInfo {
+        OutputCallbackInfo {
+            timestamp: OutputStreamTimestamp {
+                callback: to_stream_instant(self.created.elapsed()),
+                playback: stream_instant(audio_stream),
+            },
+        }
+    }
+}
+
+impl<T: Sample, C: oboe::IsChannelCount> oboe::AudioOutputCallback for CpalOutputCallback<T, C>
+where
+    (T, C): oboe::IsFrameType,
+{
+    type FrameType = (T, C);
+
+    fn on_audio_ready(
+        &mut self,
+        audio_stream: &mut dyn oboe::AudioOutputStream,
+        audio_data: &mut [<<Self as oboe::AudioOutputCallback>::FrameType as oboe::IsFrameType>::Type],
+    ) -> oboe::DataCallbackResult {
+        let cb_info = self.make_callback_info(audio_stream);
+        let channel_count = if C::CHANNEL_COUNT == oboe::ChannelCount::Mono {
+            1
+        } else {
+            2
+        };
+        (self.data_cb)(
+            &mut unsafe {
+                Data::from_parts(
+                    audio_data.as_mut_ptr() as *mut _,
+                    audio_data.len() * channel_count,
+                    T::FORMAT,
+                )
+            },
+            &cb_info,
+        );
+        oboe::DataCallbackResult::Continue
+    }
+
+    fn on_error_before_close(
+        &mut self,
+        _audio_stream: &mut dyn oboe::AudioOutputStream,
+        error: oboe::Error,
+    ) {
+        (self.error_cb)(StreamError::from(error))
+    }
+
+    fn on_error_after_close(
+        &mut self,
+        _audio_stream: &mut dyn oboe::AudioOutputStream,
+        error: oboe::Error,
+    ) {
+        (self.error_cb)(StreamError::from(error))
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -546,6 +546,24 @@ mod platform_impl {
     }
 }
 
+#[cfg(target_os = "android")]
+mod platform_impl {
+    pub use crate::host::oboe::{
+        Device as OboeDevice, Devices as OboeDevices, Host as OboeHost, Stream as OboeStream,
+        SupportedInputConfigs as OboeSupportedInputConfigs,
+        SupportedOutputConfigs as OboeSupportedOutputConfigs,
+    };
+
+    impl_platform_host!(Oboe oboe "Oboe");
+
+    /// The default host for the current compilation target platform.
+    pub fn default_host() -> Host {
+        OboeHost::new()
+            .expect("the default host should always be available")
+            .into()
+    }
+}
+
 #[cfg(not(any(
     windows,
     target_os = "linux",
@@ -554,6 +572,7 @@ mod platform_impl {
     target_os = "macos",
     target_os = "ios",
     target_os = "emscripten",
+    target_os = "android",
     all(target_arch = "wasm32", feature = "wasm-bindgen"),
 )))]
 mod platform_impl {


### PR DESCRIPTION
This code compiles (assuming my PR into `oboe-rs` gets merged), but has not been tested yet, because there are problems with including multiple .so in a single .apk (https://github.com/katyo/oboe-rs/issues/5). In the meantime I'd like to ask for clarifications for a couple of questions that occurred during implementation:

1. `StreamInstant` for callbacks.

It's unclear whether CPAL guarantees any relations between different `StreamInstant` values. For example, should `callback` and `capture` fields of `InputStreamTimestamp` be comparable in any way? Should `InputStreamTimestamp` values for different streams be comparable?

Oboe provides only the number of frames read/written from/to the stream. Based on the number of frames and sample rate it's possible to compute the duration. This is how I provide values for `capture` and `playback` fields of `InputStreamTimestamp` and `OutputStreamTimestamp`. For `callback` fields I simply use `std::time::Instant`, providing the time elapsed since the stream creation. Is that OK?

2. There seems to be no good way to query maximum buffer size from Android, but methods for querying minimum buffer size exist. So I decided to return `i32::MAX` as the maximum buffer size. Providing this value should theoretically work, but the implementation may reduce the value to something more meaningful. Again, is this fine or is there a better approach?