### PR TITLE
Handle ALSA overruns/underruns by resetting the PCM device

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -504,9 +504,11 @@ fn input_stream_worker(
         .unwrap_or(PollDescriptorsFlow::Continue);
 
         match flow {
-            PollDescriptorsFlow::Continue => continue,
+            PollDescriptorsFlow::Continue => {
+                continue;
+            }
             PollDescriptorsFlow::XRun => {
-                stream.channel.prepare().unwrap();
+                report_error(stream.channel.prepare(), error_callback);
                 continue;
             }
             PollDescriptorsFlow::Return => return,
@@ -549,9 +551,12 @@ fn output_stream_worker(
         .unwrap_or(PollDescriptorsFlow::Continue);
 
         match flow {
-            PollDescriptorsFlow::Continue => continue,
+            PollDescriptorsFlow::Continue => {
+                report_error(stream.channel.prepare(), error_callback);
+                continue;
+            }
             PollDescriptorsFlow::XRun => {
-                stream.channel.prepare().unwrap();
+                report_error(stream.channel.prepare(), error_callback);
                 continue;
             }
             PollDescriptorsFlow::Return => return,
@@ -665,7 +670,12 @@ fn poll_descriptors_and_prepare_buffer(
     };
 
     let status = stream.channel.status()?;
-    let avail_frames = status.get_avail() as usize;
+    let avail_frames = match stream.channel.avail() {
+        Err(err) if err.errno() == Some(nix::errno::Errno::EPIPE) => {
+            return Ok(PollDescriptorsFlow::XRun)
+        }
+        res => res,
+    }? as usize;
     let delay_frames = match status.get_delay() {
         // Buffer underrun. TODO: Notify the user.
         d if d < 0 => 0,
@@ -675,11 +685,7 @@ fn poll_descriptors_and_prepare_buffer(
 
     // Only go on if there is at least `stream.period_len` samples.
     if available_samples < stream.period_len {
-        return if status.get_state() == alsa::pcm::State::XRun {
-            Ok(PollDescriptorsFlow::XRun)
-        } else {
-            Ok(PollDescriptorsFlow::Continue)
-        };
+        return Ok(PollDescriptorsFlow::Continue);
     }
 
     // Prepare the data buffer.


### PR DESCRIPTION
This fixes an issue I was running into where when an underrun happened on the output buffer, the output stream worker would get stuck in a loop using up 100% cpu polling the descriptors and audio playback would stop.