### PR TITLE
webaudio: Fix default_output_config

### DIFF
--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -107,7 +107,7 @@ impl Device {
         configs.sort_by(|a, b| a.cmp_default_heuristics(b));
         let config = configs
             .into_iter()
-            .next()
+            .last()
             .expect(EXPECT)
             .with_sample_rate(DEFAULT_SAMPLE_RATE);
         Ok(config)

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -103,13 +103,13 @@ impl Device {
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         const EXPECT: &str = "expected at least one valid webaudio stream config";
-        let mut configs: Vec<_> = self.supported_output_configs().expect(EXPECT).collect();
-        configs.sort_by(|a, b| a.cmp_default_heuristics(b));
-        let config = configs
-            .into_iter()
-            .last()
+        let config = self
+            .supported_output_configs()
             .expect(EXPECT)
+            .max_by(|a, b| a.cmp_default_heuristics(b))
+            .unwrap()
             .with_sample_rate(DEFAULT_SAMPLE_RATE);
+
         Ok(config)
     }
 }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -125,7 +125,7 @@ impl Device {
         configs.sort_by(|a, b| a.cmp_default_heuristics(b));
         let config = configs
             .into_iter()
-            .next()
+            .last()
             .expect(EXPECT)
             .with_sample_rate(DEFAULT_SAMPLE_RATE);
         Ok(config)

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -121,13 +121,13 @@ impl Device {
     #[inline]
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         const EXPECT: &str = "expected at least one valid webaudio stream config";
-        let mut configs: Vec<_> = self.supported_output_configs().expect(EXPECT).collect();
-        configs.sort_by(|a, b| a.cmp_default_heuristics(b));
-        let config = configs
-            .into_iter()
-            .last()
+        let config = self
+            .supported_output_configs()
             .expect(EXPECT)
+            .max_by(|a, b| a.cmp_default_heuristics(b))
+            .unwrap()
             .with_sample_rate(DEFAULT_SAMPLE_RATE);
+
         Ok(config)
     }
 }


### PR DESCRIPTION
Fix the behaviour of wasm `default_output_device()` based on the documentation [here](https://github.com/RustAudio/cpal/blob/master/src/lib.rs#L570), and in-browser testing
