### PR TITLE
Add CI for linux on armv7 (32bit)

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -99,6 +99,51 @@ jobs:
         command: test
         args: --all --all-features --verbose
 
+  arm32bit-check-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: armv7-unknown-linux-gnueabihf
+          override: true
+
+      - name: Build image
+        run: docker build -t cross/cpal_armv7:v1 ./
+
+      - name: Check without features for armv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          use-cross: true
+          args: --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
+
+      - name: Test without features for armv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          use-cross: true
+          args: --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
+
+      - name: Check all features for armv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          use-cross: true
+          args: --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose  
+
+      - name: Test all features for armv7
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          use-cross: true
+          args: --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose      
+
   asmjs-wasm32-test:
     strategy:
       matrix:

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -99,7 +99,7 @@ jobs:
         command: test
         args: --all --all-features --verbose
 
-  arm32bit-check-and-test:
+  linux-check-and-test-armv7:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+[target.armv7-unknown-linux-gnueabihf]
+image = "cross/cpal_armv7:v1"
+
+[target.armv7-unknown-linux-gnueabihf.env]
+passthrough = [
+    "RUSTFLAGS",
+]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rustembedded/cross:armv7-unknown-linux-gnueabihf
+
+ENV PKG_CONFIG_ALLOW_CROSS 1
+ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
+
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install libasound2-dev:armhf -y && \
+    apt-get install libjack-jackd2-dev:armhf libjack-jackd2-0:armhf -y \


### PR DESCRIPTION
This PR is inspired by https://github.com/RustAudio/cpal/issues/473. 
It adds an action to run cargo check and test for the 32-bit armv7 arch. 
First it builds a docker container, by starting from `rustembedded/cross:armv7-unknown-linux-gnueabihf` and adding all dependencies. Then it uses `cross` (https://crates.io/crates/cross) to run check and test.