### PR TITLE
change from COINIT_MULTITHREADED to COINIT_APARTMENTTHREADED in wasapi

### DIFF
--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -4,13 +4,13 @@ use super::check_result;
 use std::ptr;
 
 use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
-use super::winapi::um::objbase::COINIT_MULTITHREADED;
+use super::winapi::um::objbase::COINIT_APARTMENTTHREADED;
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
         // this call can fail if another library initialized COM in single-threaded mode
         // handling this situation properly would make the API more annoying, so we just don't care
-        check_result(CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED)).unwrap();
+        check_result(CoInitializeEx(ptr::null_mut(), COINIT_APARTMENTTHREADED)).unwrap();
         ComInitialized(ptr::null_mut())
     }
 });


### PR DESCRIPTION
There is currently a problem in windows when trying to use cpal with winit 0.20. 

Winit now uses `COINIT_APARTMENTTHREADED` because it is required by the OLE API they are using to properly handle file dropping. [See this link](https://github.com/rust-windowing/winit/issues/1185#issuecomment-535322283) for more information

@bolcom ran into this problem and submitted PR #330 to address this but it was never merged, and instead decided to spin up a whole separate thread for using winit. I also noted that @ishitatsuyuki was concerned that moving to apartment threading would require marshaling. I don't really understand what this means, would be nice to hear further clarification as to what this would actually involve.

It would be nice if cpal and winit could share the same threading model so users on windows didn't have to spin up separate threads. Keen to hear poeples thoughts. 

