### PR TITLE
Avoid calling alsa::PCM::new() multiple times.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lazy_static = "1.3"
 alsa = "0.4.3"
 nix = "0.15.0"
 libc = "0.2.65"
+parking_lot = "0.11"
 jack = { version = "0.6.5", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,6 +1,6 @@
 use super::alsa;
 use super::parking_lot::Mutex;
-use super::Device;
+use super::{Device, DeviceHandles};
 use {BackendSpecificError, DevicesError};
 
 /// ALSA implementation for `Devices`.
@@ -27,37 +27,17 @@ impl Iterator for Devices {
             match self.hint_iter.next() {
                 None => return None,
                 Some(hint) => {
-                    let name = hint.name;
-
-                    let io = hint.direction;
-
-                    if let Some(io) = io {
-                        if io != alsa::Direction::Playback {
-                            continue;
-                        }
-                    }
-
-                    let name = match name {
-                        Some(name) => {
-                            // Ignoring the `null` device.
-                            if name == "null" {
-                                continue;
-                            }
-                            name
-                        }
-                        _ => continue,
+                    let name = match hint.name {
+                        None => continue,
+                        // Ignoring the `null` device.
+                        Some(name) if name == "null" => continue,
+                        Some(name) => name,
                     };
 
-                    // See if the device has an available output stream.
-                    let playback = alsa::pcm::PCM::new(&name, alsa::Direction::Playback, true).ok();
-
-                    // See if the device has an available input stream.
-                    let capture = alsa::pcm::PCM::new(&name, alsa::Direction::Capture, true).ok();
-
-                    if playback.is_some() || capture.is_some() {
+                    if let Ok(handles) = DeviceHandles::open(&name) {
                         return Some(Device {
                             name,
-                            handles: Mutex::new(super::DeviceHandles { playback, capture }),
+                            handles: Mutex::new(handles),
                         });
                     }
                 }
@@ -70,10 +50,7 @@ impl Iterator for Devices {
 pub fn default_input_device() -> Option<Device> {
     Some(Device {
         name: "default".to_owned(),
-        handles: Mutex::new(super::DeviceHandles {
-            playback: None,
-            capture: None,
-        }),
+        handles: Mutex::new(Default::default()),
     })
 }
 
@@ -81,10 +58,7 @@ pub fn default_input_device() -> Option<Device> {
 pub fn default_output_device() -> Option<Device> {
     Some(Device {
         name: "default".to_owned(),
-        handles: Mutex::new(super::DeviceHandles {
-            playback: None,
-            capture: None,
-        }),
+        handles: Mutex::new(Default::default()),
     })
 }
 

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,4 +1,5 @@
 use super::alsa;
+use super::parking_lot::Mutex;
 use super::Device;
 use {BackendSpecificError, DevicesError};
 
@@ -48,21 +49,16 @@ impl Iterator for Devices {
                     };
 
                     // See if the device has an available output stream.
-                    let has_available_output = {
-                        let playback_handle =
-                            alsa::pcm::PCM::new(&name, alsa::Direction::Playback, true);
-                        playback_handle.is_ok()
-                    };
+                    let playback = alsa::pcm::PCM::new(&name, alsa::Direction::Playback, true).ok();
 
                     // See if the device has an available input stream.
-                    let has_available_input = {
-                        let capture_handle =
-                            alsa::pcm::PCM::new(&name, alsa::Direction::Capture, true);
-                        capture_handle.is_ok()
-                    };
+                    let capture = alsa::pcm::PCM::new(&name, alsa::Direction::Capture, true).ok();
 
-                    if has_available_output || has_available_input {
-                        return Some(Device(name));
+                    if playback.is_some() || capture.is_some() {
+                        return Some(Device {
+                            name,
+                            handles: Mutex::new(super::DeviceHandles { playback, capture }),
+                        });
                     }
                 }
             }
@@ -72,12 +68,24 @@ impl Iterator for Devices {
 
 #[inline]
 pub fn default_input_device() -> Option<Device> {
-    Some(Device("default".to_owned()))
+    Some(Device {
+        name: "default".to_owned(),
+        handles: Mutex::new(super::DeviceHandles {
+            playback: None,
+            capture: None,
+        }),
+    })
 }
 
 #[inline]
 pub fn default_output_device() -> Option<Device> {
-    Some(Device("default".to_owned()))
+    Some(Device {
+        name: "default".to_owned(),
+        handles: Mutex::new(super::DeviceHandles {
+            playback: None,
+            capture: None,
+        }),
+    })
 }
 
 impl From<alsa::Error> for DevicesError {


### PR DESCRIPTION
Some low-level ALSA devices seem to not react well to having `snd_pcm_open()` called immediately after `snd_pcm_close()` on another handle for the same device. See for example this StackOverflow [answer](https://stackoverflow.com/questions/4474858/alsa-opening-and-closing-pcm-on-the-fly#answer-4474959).

Currently enumerating ALSA devices will cause each device to be opened and immediately closed, as will calling `supported_configs()`. Finally, the device is only opened for good when `build_*_stream_[raw]()` is called.

This patch ensures that `alsa::PCM::new()` is called only once for a given `Device` by saving each `PCM` object in the `Device` instance the first time it is opened and then handing ownership off to the `Stream` when it is created. A `parking_lot::Mutex` is used to provide interior mutability and `Sync` for the `Device`.

This also ensures that a `Device` that isn't shared can't be "stolen" by another process between when it is enumerated and when the stream is opened.