### PR TITLE
Examples improvements

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -262,6 +262,8 @@ jobs:
         toolchain: stable
         override: true
         target: armv7-linux-androideabi
+    - name: Check android
+      run: cargo check --example android --target armv7-linux-androideabi --verbose
     - name: Check beep
       run: cargo check --example beep --target armv7-linux-androideabi --verbose
     - name: Check enumerate
@@ -284,4 +286,4 @@ jobs:
     - name: Install Cargo APK
       run: cargo install cargo-apk
     - name: Build APK
-      run: cargo apk build --example beep
+      run: cargo apk build --example android

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.2"
 anyhow = "1.0.12"
 hound = "3.4"
 ringbuf = "0.2"
-structopt = "0.3.21"
+clap = { version = "2.33.3", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
@@ -60,20 +60,12 @@ crate-type = ["cdylib"]
 
 [[example]]
 name = "beep"
-path = "examples/beep.rs"
-crate-type = ["bin"]
 
 [[example]]
 name = "enumerate"
-path = "examples/enumerate.rs"
-crate-type = ["bin"]
 
 [[example]]
 name = "feedback"
-path = "examples/feedback.rs"
-crate-type = ["bin"]
 
 [[example]]
 name = "record_wav"
-path = "examples/record_wav.rs"
-crate-type = ["bin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0.2"
 anyhow = "1.0.12"
 hound = "3.4"
 ringbuf = "0.2"
+structopt = "0.3.21"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
@@ -53,21 +54,26 @@ ndk-glue = "0.2"
 jni = "0.17"
 
 [[example]]
+name = "android"
+path = "examples/android.rs"
+crate-type = ["cdylib"]
+
+[[example]]
 name = "beep"
 path = "examples/beep.rs"
-crate-type = ["cdylib"]
+crate-type = ["bin"]
 
 [[example]]
 name = "enumerate"
 path = "examples/enumerate.rs"
-crate-type = ["cdylib"]
+crate-type = ["bin"]
 
 [[example]]
 name = "feedback"
 path = "examples/feedback.rs"
-crate-type = ["cdylib"]
+crate-type = ["bin"]
 
 [[example]]
 name = "record_wav"
 path = "examples/record_wav.rs"
-crate-type = ["cdylib"]
+crate-type = ["bin"]

--- a/examples/android.rs
+++ b/examples/android.rs
@@ -1,0 +1,65 @@
+#![allow(dead_code)]
+
+extern crate anyhow;
+extern crate cpal;
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+#[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
+fn main() {
+    let host = cpal::default_host();
+
+    let device = host
+        .default_output_device()
+        .expect("failed to find output device");
+
+    let config = device.default_output_config().unwrap();
+
+    match config.sample_format() {
+        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()).unwrap(),
+    }
+}
+
+fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Result<(), anyhow::Error>
+where
+    T: cpal::Sample,
+{
+    let sample_rate = config.sample_rate.0 as f32;
+    let channels = config.channels as usize;
+
+    // Produce a sinusoid of maximum amplitude.
+    let mut sample_clock = 0f32;
+    let mut next_value = move || {
+        sample_clock = (sample_clock + 1.0) % sample_rate;
+        (sample_clock * 440.0 * 2.0 * std::f32::consts::PI / sample_rate).sin()
+    };
+
+    let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
+
+    let stream = device.build_output_stream(
+        config,
+        move |data: &mut [T], _: &cpal::OutputCallbackInfo| {
+            write_data(data, channels, &mut next_value)
+        },
+        err_fn,
+    )?;
+    stream.play()?;
+
+    std::thread::sleep(std::time::Duration::from_millis(1000));
+
+    Ok(())
+}
+
+fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
+where
+    T: cpal::Sample,
+{
+    for frame in output.chunks_mut(channels) {
+        let value: T = cpal::Sample::from::<f32>(&next_sample());
+        for sample in frame.iter_mut() {
+            *sample = value;
+        }
+    }
+}

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -26,16 +26,16 @@ fn main() -> Result<(), anyhow::Error> {
             if let Ok(conf) = device.default_input_config() {
                 println!("    Default input stream config:\n      {:?}", conf);
             }
-            let mut input_configs = match device.supported_input_configs() {
-                Ok(f) => f.peekable(),
+            let input_configs = match device.supported_input_configs() {
+                Ok(f) => f.collect(),
                 Err(e) => {
-                    println!("Error: {:?}", e);
-                    continue;
+                    println!("    Error getting supported input configs: {:?}", e);
+                    Vec::new()
                 }
             };
-            if input_configs.peek().is_some() {
+            if !input_configs.is_empty() {
                 println!("    All supported input stream configs:");
-                for (config_index, config) in input_configs.enumerate() {
+                for (config_index, config) in input_configs.into_iter().enumerate() {
                     println!(
                         "      {}.{}. {:?}",
                         device_index + 1,
@@ -49,16 +49,16 @@ fn main() -> Result<(), anyhow::Error> {
             if let Ok(conf) = device.default_output_config() {
                 println!("    Default output stream config:\n      {:?}", conf);
             }
-            let mut output_configs = match device.supported_output_configs() {
-                Ok(f) => f.peekable(),
+            let output_configs = match device.supported_output_configs() {
+                Ok(f) => f.collect(),
                 Err(e) => {
-                    println!("Error: {:?}", e);
-                    continue;
+                    println!("    Error getting supported output configs: {:?}", e);
+                    Vec::new()
                 }
             };
-            if output_configs.peek().is_some() {
+            if !output_configs.is_empty() {
                 println!("    All supported output stream configs:");
-                for (config_index, config) in output_configs.enumerate() {
+                for (config_index, config) in output_configs.into_iter().enumerate() {
                     println!(
                         "      {}.{}. {:?}",
                         device_index + 1,

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -3,28 +3,52 @@
 //! The input data is recorded to "$CARGO_MANIFEST_DIR/recorded.wav".
 
 extern crate anyhow;
+extern crate clap;
 extern crate cpal;
 extern crate hound;
-extern crate structopt;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use std::fs::File;
 use std::io::BufWriter;
 use std::sync::{Arc, Mutex};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "beep", about = "Simple example of audio playback.")]
+#[derive(Debug)]
 struct Opt {
     #[cfg(all(
         any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
         feature = "jack"
     ))]
-    #[structopt(short, long)]
     jack: bool,
 
-    #[structopt(default_value = "default")]
     device: String,
+}
+
+impl Opt {
+    fn from_args() -> Self {
+        let app = clap::App::new("beep").arg_from_usage("[DEVICE] 'The audio device to use'");
+        #[cfg(all(
+            any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+            feature = "jack"
+        ))]
+        let app = app.arg_from_usage("-j, --jack 'Use the JACK host");
+        let matches = app.get_matches();
+        let device = matches.value_of("DEVICE").unwrap_or("default").to_string();
+
+        #[cfg(all(
+            any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+            feature = "jack"
+        ))]
+        return Opt {
+            jack: matches.is_present("jack"),
+            device,
+        };
+
+        #[cfg(any(
+            not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd")),
+            not(feature = "jack")
+        ))]
+        Opt { device }
+    }
 }
 
 fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
Since the Android target was added, the examples have been building as cdylibs instead of binaries. This obviously makes testing more difficult on platforms that are not Android. This PR creates a copy of the beep example specifically for building as an Android APK and sets the remaining examples back to a crate-type of bin.

This PR also adds argument parsing (using structopt) to several of the examples to allow selecting non-default devices and (for the feedback example) setting the latency. Finally, it improves error handling in the enumerate example in the case that supported_input_configs() or supported_output_configs() returns an error.

These changes make it easier to test cpal on systems with multiple audio devices.
