### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio I/O library in pure Rust."
 repository = "https://github.com/rustaudio/cpal"
@@ -25,11 +25,11 @@ winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "com
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.11"
-lazy_static = "1.3"
+lazy_static = "1.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
-alsa = "0.4.3"
-nix = "0.15.0"
+alsa = "0.5"
+nix = "0.20"
 libc = "0.2.65"
 parking_lot = "0.11"
 jack = { version = "0.6.5", optional = true }


### PR DESCRIPTION
alsa 0.5 updates the nix version which is quite outdated.

Also did some cargo clappy hints