### PR TITLE
More ease of use for StreamInstant

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,7 @@ pub enum StreamError {
         err: BackendSpecificError,
     },
 }
+
 /// Underflow while converting a StreamInstant to a Duration.
 #[derive(Clone, Debug, Error)]
 #[error("Underflow while converting a StreamInstant to a Duration.")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -162,5 +162,5 @@ pub enum StreamError {
 }
 /// Underflow while converting a StreamInstant to a Duration.
 #[derive(Clone, Debug, Error)]
-#[error("the requested host is unavailable")]
+#[error("Underflow while converting a StreamInstant to a Duration.")]
 pub struct StreamInstantUnderflow;

--- a/src/error.rs
+++ b/src/error.rs
@@ -160,3 +160,7 @@ pub enum StreamError {
         err: BackendSpecificError,
     },
 }
+/// Underflow while converting a StreamInstant to a Duration.
+#[derive(Clone, Debug, Error)]
+#[error("the requested host is unavailable")]
+pub struct StreamInstantUnderflow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,7 +446,7 @@ impl StreamInstant {
         Self::new(s, ns)
     }
 
-    fn new(secs: i64, nanos: u32) -> Self {
+    pub fn new(secs: i64, nanos: u32) -> Self {
         StreamInstant { secs, nanos }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,12 +302,12 @@ pub struct StreamInstant {
 impl StreamInstant {
     /// An attempted conversion that consumes self
     ///
-    /// Fails with a StreamInstantUnderflow error when the seconds field is negative
+    /// Fails with a StreamInstantUnderflow error when the secs field is negative
     pub fn to_duration(self) -> Result<Duration, StreamInstantUnderflow> {
         TryInto::<Duration>::try_into(self)
     }
 }
-// This impl also gives us Into<Duration> for StreamInstant
+// This impl also gives us TryInto<Duration> for StreamInstant
 impl std::convert::TryFrom<StreamInstant> for Duration {
     type Error = StreamInstantUnderflow;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,8 +295,8 @@ pub struct Data {
 /// | emscripten | `AudioContext.getOutputTimestamp` |
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
-    secs: i64,
-    nanos: u32,
+    pub secs: i64,
+    pub nanos: u32,
 }
 
 impl StreamInstant {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,9 +301,9 @@ pub struct StreamInstant {
 
 impl StreamInstant {
     /// An attempted conversion that consumes self
-    /// 
+    ///
     /// Fails with a StreamInstantUnderflow error when the seconds field is negative
-    pub fn to_duration(self) -> Result<Duration, StreamInstantUnderflow>{
+    pub fn to_duration(self) -> Result<Duration, StreamInstantUnderflow> {
         TryInto::<Duration>::try_into(self)
     }
 }
@@ -318,7 +318,6 @@ impl std::convert::TryFrom<StreamInstant> for Duration {
             Ok(Duration::new(value.secs as u64, value.nanos))
         }
     }
-
 }
 /// A timestamp associated with a call to an input stream's data callback.
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
@@ -810,13 +809,7 @@ fn test_stream_instant() {
 fn test_stream_instant_into_duration() {
     let a = StreamInstant::new(2, 0);
     let b = StreamInstant::new(-2, 0);
-    let a_duration : Duration = a.try_into().unwrap();
-    assert_eq!(
-        a_duration,
-        Duration::new(2,0)
-    );
-    assert!(
-        TryInto::<Duration>::try_into(b).is_err()
-    )
-
+    let a_duration: Duration = a.try_into().unwrap();
+    assert_eq!(a_duration, Duration::new(2, 0));
+    assert!(TryInto::<Duration>::try_into(b).is_err())
 }


### PR DESCRIPTION
This pr attempts to make `StreamInstant` easier to work with by adding:
- `TryFrom` / `TryInto` conversion with `Duration` (with an error for underflows)
- a to_duration method as sugar for `TryInto::<Duration>::try_into`

Further commits make `new` public, along with the struct's fields `secs` and `nanos`

## motivation

When writing a simple POC synth to experiment with some DSP the privateness of everything on StreamInstant was preventing me from getting the time associated with samples

```rust
fn run<T: Sample>(data: &mut [T], info: &cpal::OutputCallbackInfo) {
    let buf_start = info.timestamp().playback;
    for (i, sample) in data.iter_mut().enumerate() {
        let t = buf_start.add(Duration::new(0, (i as u32) / SAMPLE_RATE * NANOSECONDS_IN_SECOND)).unwrap(); 
        // ...
    }
}
```

