### PR TITLE
Proposal: Duplex API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,4 +73,7 @@ name = "enumerate"
 name = "feedback"
 
 [[example]]
+name = "duplex"
+
+[[example]]
 name = "record_wav"

--- a/examples/duplex.rs
+++ b/examples/duplex.rs
@@ -1,0 +1,127 @@
+//! Feeds back the input stream directly into the output stream by opening the device in full
+//! duplex mode.
+//!
+//! Assumes that the device can use the f32 sample format.
+
+extern crate anyhow;
+extern crate clap;
+extern crate cpal;
+
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+#[derive(Debug)]
+struct Opt {
+    #[cfg(all(
+        any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+        feature = "jack"
+    ))]
+    jack: bool,
+
+    device: String,
+}
+
+impl Opt {
+    fn from_args() -> anyhow::Result<Self> {
+        let app = clap::App::new("duplex").arg_from_usage("[DEVICE] 'The audio device to use'");
+
+        #[cfg(all(
+            any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+            feature = "jack"
+        ))]
+        let app = app.arg_from_usage("-j, --jack 'Use the JACK host");
+        let matches = app.get_matches();
+        let device = matches.value_of("DEVICE").unwrap_or("default").to_string();
+
+        #[cfg(all(
+            any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+            feature = "jack"
+        ))]
+        return Ok(Opt {
+            jack: matches.is_present("jack"),
+            device,
+        });
+
+        #[cfg(any(
+            not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd")),
+            not(feature = "jack")
+        ))]
+        Ok(Opt { device })
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let opt = Opt::from_args()?;
+
+    // Conditionally compile with jack if the feature is specified.
+    #[cfg(all(
+        any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
+        feature = "jack"
+    ))]
+    // Manually check for flags. Can be passed through cargo with -- e.g.
+    // cargo run --release --example beep --features jack -- --jack
+    let host = if opt.jack {
+        cpal::host_from_id(cpal::available_hosts()
+            .into_iter()
+            .find(|id| *id == cpal::HostId::Jack)
+            .expect(
+                "make sure --features jack is specified. only works on OSes where jack is available",
+            )).expect("jack host unavailable")
+    } else {
+        cpal::default_host()
+    };
+
+    #[cfg(any(
+        not(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd")),
+        not(feature = "jack")
+    ))]
+    let host = cpal::default_host();
+
+    // Find the device
+    let device = if opt.device == "default" {
+        host.default_duplex_device()
+    } else {
+        host.duplex_devices()?
+            .find(|x| x.name().map(|y| y == opt.device).unwrap_or(false))
+    }
+    .expect("failed to find device");
+
+    println!("Using device: \"{}\"", device.name()?);
+
+    let config: cpal::DuplexStreamConfig = device.default_duplex_config()?.into();
+    let input_channels: usize = config.input_channels.into();
+    let output_channels: usize = config.output_channels.into();
+    // Simply copy as many channels as both input and output allow
+    let copy_channels = input_channels.min(output_channels);
+
+    let data_fn = move |data_in: &[f32], data_out: &mut [f32], _: &cpal::DuplexCallbackInfo| {
+        for (frame_in, frame_out) in data_in
+            .chunks(input_channels)
+            .zip(data_out.chunks_mut(output_channels))
+        {
+            frame_out[..copy_channels].clone_from_slice(&frame_in[..copy_channels]);
+        }
+    };
+
+    // Build streams.
+    println!(
+        "Attempting to build stream with f32 samples and `{:?}`.",
+        config
+    );
+    let stream = device.build_duplex_stream(&config, data_fn, err_fn)?;
+    println!("Successfully built stream.");
+
+    // Play the stream.
+    println!("Starting the duplex stream.");
+    stream.play()?;
+
+    // Run for 3 seconds before closing.
+    println!("Playing for 3 seconds... ");
+    std::thread::sleep(std::time::Duration::from_secs(3));
+    drop(stream);
+    println!("Done!");
+    Ok(())
+}
+
+fn err_fn(err: cpal::StreamError) {
+    eprintln!("an error occurred on stream: {}", err);
+}

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -6,10 +6,11 @@ use self::alsa::poll::Descriptors;
 use self::parking_lot::Mutex;
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, ChannelCount, Data,
-    DefaultStreamConfigError, DeviceNameError, DevicesError, InputCallbackInfo, OutputCallbackInfo,
-    PauseStreamError, PlayStreamError, SampleFormat, SampleRate, StreamConfig, StreamError,
-    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
-    SupportedStreamConfigsError,
+    DefaultStreamConfigError, DeviceNameError, DevicesError, DuplexCallbackInfo,
+    DuplexStreamConfig, InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError,
+    SampleFormat, SampleRate, StreamConfig, StreamError, SupportedBufferSize,
+    SupportedDuplexStreamConfig, SupportedDuplexStreamConfigRange, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use std::cmp;
 use std::convert::TryInto;
@@ -22,6 +23,7 @@ pub use self::enumerate::{default_input_device, default_output_device, Devices};
 
 pub type SupportedInputConfigs = VecIntoIter<SupportedStreamConfigRange>;
 pub type SupportedOutputConfigs = VecIntoIter<SupportedStreamConfigRange>;
+pub type SupportedDuplexConfigs = VecIntoIter<SupportedDuplexStreamConfigRange>;
 
 mod enumerate;
 
@@ -55,11 +57,16 @@ impl HostTrait for Host {
     fn default_output_device(&self) -> Option<Self::Device> {
         default_output_device()
     }
+
+    fn default_duplex_device(&self) -> Option<Self::Device> {
+        todo!()
+    }
 }
 
 impl DeviceTrait for Device {
     type SupportedInputConfigs = SupportedInputConfigs;
     type SupportedOutputConfigs = SupportedOutputConfigs;
+    type SupportedDuplexConfigs = SupportedDuplexConfigs;
     type Stream = Stream;
 
     fn name(&self) -> Result<String, DeviceNameError> {
@@ -78,12 +85,24 @@ impl DeviceTrait for Device {
         Device::supported_output_configs(self)
     }
 
+    fn supported_duplex_configs(
+        &self,
+    ) -> Result<Self::SupportedDuplexConfigs, SupportedStreamConfigsError> {
+        todo!()
+    }
+
     fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         Device::default_input_config(self)
     }
 
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         Device::default_output_config(self)
+    }
+
+    fn default_duplex_config(
+        &self,
+    ) -> Result<SupportedDuplexStreamConfig, DefaultStreamConfigError> {
+        todo!()
     }
 
     fn build_input_stream_raw<D, E>(
@@ -118,6 +137,20 @@ impl DeviceTrait for Device {
             self.build_stream_inner(conf, sample_format, alsa::Direction::Playback)?;
         let stream = Stream::new_output(Arc::new(stream_inner), data_callback, error_callback);
         Ok(stream)
+    }
+
+    fn build_duplex_stream_raw<D, E>(
+        &self,
+        _conf: &DuplexStreamConfig,
+        _sample_format: SampleFormat,
+        _data_callback: D,
+        _error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &mut Data, &DuplexCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        todo!()
     }
 }
 

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,10 +1,9 @@
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
-    InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat,
-    StreamConfig, StreamError, SupportedStreamConfig, SupportedStreamConfigRange,
-    SupportedStreamConfigsError,
-    SupportedDuplexStreamConfig, DuplexStreamConfig, SupportedDuplexStreamConfigRange,
-    DuplexCallbackInfo,
+    DuplexCallbackInfo, DuplexStreamConfig, InputCallbackInfo, OutputCallbackInfo,
+    PauseStreamError, PlayStreamError, SampleFormat, StreamConfig, StreamError,
+    SupportedDuplexStreamConfig, SupportedDuplexStreamConfigRange, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -79,7 +78,9 @@ impl DeviceTrait for Device {
     }
 
     #[inline]
-    fn default_duplex_config(&self) -> Result<SupportedDuplexStreamConfig, DefaultStreamConfigError> {
+    fn default_duplex_config(
+        &self,
+    ) -> Result<SupportedDuplexStreamConfig, DefaultStreamConfigError> {
         unimplemented!()
     }
 

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -3,6 +3,8 @@ use crate::{
     InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat,
     StreamConfig, StreamError, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError,
+    SupportedDuplexStreamConfig, DuplexStreamConfig, SupportedDuplexStreamConfigRange,
+    DuplexCallbackInfo,
 };
 use traits::{DeviceTrait, HostTrait, StreamTrait};
 
@@ -19,6 +21,7 @@ pub struct Stream;
 
 pub struct SupportedInputConfigs;
 pub struct SupportedOutputConfigs;
+pub struct SupportedDuplexConfigs;
 
 impl Host {
     #[allow(dead_code)]
@@ -36,6 +39,7 @@ impl Devices {
 impl DeviceTrait for Device {
     type SupportedInputConfigs = SupportedInputConfigs;
     type SupportedOutputConfigs = SupportedOutputConfigs;
+    type SupportedDuplexConfigs = SupportedDuplexConfigs;
     type Stream = Stream;
 
     #[inline]
@@ -58,12 +62,24 @@ impl DeviceTrait for Device {
     }
 
     #[inline]
+    fn supported_duplex_configs(
+        &self,
+    ) -> Result<SupportedDuplexConfigs, SupportedStreamConfigsError> {
+        unimplemented!()
+    }
+
+    #[inline]
     fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
         unimplemented!()
     }
 
     #[inline]
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn default_duplex_config(&self) -> Result<SupportedDuplexStreamConfig, DefaultStreamConfigError> {
         unimplemented!()
     }
 
@@ -95,6 +111,20 @@ impl DeviceTrait for Device {
     {
         unimplemented!()
     }
+
+    fn build_duplex_stream_raw<D, E>(
+        &self,
+        _config: &DuplexStreamConfig,
+        _sample_format: SampleFormat,
+        _data_callback: D,
+        _error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &mut Data, &DuplexCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        unimplemented!()
+    }
 }
 
 impl HostTrait for Host {
@@ -114,6 +144,10 @@ impl HostTrait for Host {
     }
 
     fn default_output_device(&self) -> Option<Device> {
+        None
+    }
+
+    fn default_duplex_device(&self) -> Option<Device> {
         None
     }
 }
@@ -151,6 +185,15 @@ impl Iterator for SupportedOutputConfigs {
 
     #[inline]
     fn next(&mut self) -> Option<SupportedStreamConfigRange> {
+        None
+    }
+}
+
+impl Iterator for SupportedDuplexConfigs {
+    type Item = SupportedDuplexStreamConfigRange;
+
+    #[inline]
+    fn next(&mut self) -> Option<SupportedDuplexStreamConfigRange> {
         None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -820,7 +820,7 @@ impl SupportedDuplexStreamConfigRange {
     /// - Max input channels
     pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
         // TODO: Refactor out common parts with the half duplex implementation
-        unimplemented!()
+        todo!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,9 @@ pub type InputDevices<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bo
 /// A host's device iterator yielding only *output* devices.
 pub type OutputDevices<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>;
 
+/// A host's device iterator yielding only *duplex* devices.
+pub type DuplexDevices<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>;
+
 /// Number of channels.
 pub type ChannelCount = u16;
 
@@ -227,6 +230,17 @@ pub struct StreamConfig {
     pub buffer_size: BufferSize,
 }
 
+/// The set of parameters used to describe how to open a *duplex* stream.
+///
+/// The sample format is omitted in favour of using a sample type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DuplexStreamConfig {
+    pub input_channels: ChannelCount,
+    pub output_channels: ChannelCount,
+    pub sample_rate: SampleRate,
+    pub buffer_size: BufferSize,
+}
+
 /// Describes the minimum and maximum supported buffer size for the device
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SupportedBufferSize {
@@ -254,11 +268,38 @@ pub struct SupportedStreamConfigRange {
     pub(crate) sample_format: SampleFormat,
 }
 
+/// Describes a range of supported *duplex* stream configurations, retrieved via the
+/// `Device::supported_duplex_configs` method.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupportedDuplexStreamConfigRange {
+    pub(crate) input_channels: ChannelCount,
+    pub(crate) output_channels: ChannelCount,
+    /// Minimum value for the samples rate of the supported formats.
+    pub(crate) min_sample_rate: SampleRate,
+    /// Maximum value for the samples rate of the supported formats.
+    pub(crate) max_sample_rate: SampleRate,
+    /// Buffersize ranges supported by the device
+    pub(crate) buffer_size: SupportedBufferSize,
+    /// Type of data expected by the device.
+    pub(crate) sample_format: SampleFormat,
+}
+
 /// Describes a single supported stream configuration, retrieved via either a
 /// `SupportedStreamConfigRange` instance or one of the `Device::default_input/output_config` methods.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SupportedStreamConfig {
     channels: ChannelCount,
+    sample_rate: SampleRate,
+    buffer_size: SupportedBufferSize,
+    sample_format: SampleFormat,
+}
+
+/// Describes a single supported *duplex* stream configuration, retrieved via either a
+/// `SupportedDuplexStreamConfigRange` instance or the `Device::default_duplex_config` method.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SupportedDuplexStreamConfig {
+    input_channels: ChannelCount,
+    output_channels: ChannelCount,
     sample_rate: SampleRate,
     buffer_size: SupportedBufferSize,
     sample_format: SampleFormat,
@@ -321,6 +362,21 @@ pub struct OutputStreamTimestamp {
     pub playback: StreamInstant,
 }
 
+/// A timestamp associated with a call to a duplex stream's data callback.
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DuplexStreamTimestamp {
+    /// The instant the stream's data callback was invoked.
+    pub callback: StreamInstant,
+    /// The instant that data was captured from the device.
+    ///
+    /// E.g. The instant data was read from an ADC.
+    pub capture: StreamInstant,
+    /// The predicted instant that data written will be delivered to the device for playback.
+    ///
+    /// E.g. The instant data will be played by a DAC.
+    pub playback: StreamInstant,
+}
+
 /// Information relevant to a single call to the user's input stream data callback.
 #[derive(Debug, Clone, PartialEq)]
 pub struct InputCallbackInfo {
@@ -331,6 +387,12 @@ pub struct InputCallbackInfo {
 #[derive(Debug, Clone, PartialEq)]
 pub struct OutputCallbackInfo {
     timestamp: OutputStreamTimestamp,
+}
+
+/// Information relevant to a single call to the user's duplex stream data callback.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DuplexCallbackInfo {
+    timestamp: DuplexStreamTimestamp,
 }
 
 impl SupportedStreamConfig {
@@ -353,6 +415,37 @@ impl SupportedStreamConfig {
     pub fn config(&self) -> StreamConfig {
         StreamConfig {
             channels: self.channels,
+            sample_rate: self.sample_rate,
+            buffer_size: BufferSize::Default,
+        }
+    }
+}
+
+impl SupportedDuplexStreamConfig {
+    pub fn input_channels(&self) -> ChannelCount {
+        self.input_channels
+    }
+
+    pub fn output_channels(&self) -> ChannelCount {
+        self.output_channels
+    }
+
+    pub fn sample_rate(&self) -> SampleRate {
+        self.sample_rate
+    }
+
+    pub fn buffer_size(&self) -> &SupportedBufferSize {
+        &self.buffer_size
+    }
+
+    pub fn sample_format(&self) -> SampleFormat {
+        self.sample_format
+    }
+
+    pub fn config(&self) -> DuplexStreamConfig {
+        DuplexStreamConfig {
+            input_channels: self.input_channels,
+            output_channels: self.output_channels,
             sample_rate: self.sample_rate,
             buffer_size: BufferSize::Default,
         }
@@ -440,6 +533,13 @@ impl InputCallbackInfo {
 impl OutputCallbackInfo {
     /// The timestamp associated with the call to an output stream's data callback.
     pub fn timestamp(&self) -> OutputStreamTimestamp {
+        self.timestamp
+    }
+}
+
+impl DuplexCallbackInfo {
+    /// The timestamp associated with the call to a duplex stream's data callback.
+    pub fn timestamp(&self) -> DuplexStreamTimestamp {
         self.timestamp
     }
 }
@@ -652,6 +752,75 @@ impl SupportedStreamConfigRange {
         }
 
         self.max_sample_rate.cmp(&other.max_sample_rate)
+    }
+}
+
+impl SupportedDuplexStreamConfigRange {
+    pub fn input_channels(&self) -> ChannelCount {
+        self.input_channels
+    }
+
+    pub fn output_channels(&self) -> ChannelCount {
+        self.output_channels
+    }
+
+    pub fn min_sample_rate(&self) -> SampleRate {
+        self.min_sample_rate
+    }
+
+    pub fn max_sample_rate(&self) -> SampleRate {
+        self.max_sample_rate
+    }
+
+    pub fn buffer_size(&self) -> &SupportedBufferSize {
+        &self.buffer_size
+    }
+
+    pub fn sample_format(&self) -> SampleFormat {
+        self.sample_format
+    }
+
+    /// Retrieve a `SupportedDuplexStreamConfig` with the given sample rate and buffer size.
+    ///
+    /// **panic!**s if the given `sample_rate` is outside the range specified within this
+    /// `SupportedDuplexStreamConfigRange` instance.
+    pub fn with_sample_rate(self, sample_rate: SampleRate) -> SupportedDuplexStreamConfig {
+        assert!(self.min_sample_rate <= sample_rate && sample_rate <= self.max_sample_rate);
+        SupportedDuplexStreamConfig {
+            input_channels: self.input_channels,
+            output_channels: self.output_channels,
+            sample_rate,
+            sample_format: self.sample_format,
+            buffer_size: self.buffer_size,
+        }
+    }
+
+    /// Turns this `SupportedDuplexStreamConfigRange` into a `SupportedDuplexStreamConfig` corresponding to the maximum samples rate.
+    #[inline]
+    pub fn with_max_sample_rate(self) -> SupportedDuplexStreamConfig {
+        SupportedDuplexStreamConfig {
+            input_channels: self.input_channels,
+            output_channels: self.output_channels,
+            sample_rate: self.max_sample_rate,
+            sample_format: self.sample_format,
+            buffer_size: self.buffer_size,
+        }
+    }
+
+    /// A comparison function which compares two `SupportedDuplexStreamConfigRange`s in terms of their priority of
+    /// use as a default stream format.
+    ///
+    /// Refer to [`SupportStreamConfigRange::cmp_default_heuristics`] for more details. The duplex
+    /// version prioritizes channel configurations as follows:
+    ///
+    /// - Both input and output stereo
+    /// - Mono input and stereo output (does this make sense?)
+    /// - Mono input and mono output
+    /// - Max output channels
+    /// - Max input channels
+    pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
+        // TODO: Refactor out common parts with the half duplex implementation
+        unimplemented!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,6 @@ pub struct SupportedDuplexChannels {
     pub default: Option<ChannelCount>,
 }
 
-
 /// Describes a range of supported *duplex* stream configurations, retrieved via the
 /// `Device::supported_duplex_configs` method.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -815,7 +814,7 @@ impl SupportedDuplexStreamConfigRange {
             buffer_size: self.buffer_size,
         }
     }
-    
+
     /// Turns this `SupportedDuplexStreamConfigRange` into a `SupportedDuplexStreamConfig`
     /// corresponding to the maximum sample rate and default channel counts.
     ///
@@ -840,11 +839,19 @@ impl SupportedDuplexStreamConfigRange {
     ///
     /// **panic!**s if the given `input_channels`, `output_channels` or `sample_rate` are outside
     /// the range specified within this `SupportedDuplexStreamConfigRange` instance.
-    pub fn with_channels_sample_rate(self, input_channels: ChannelCount, output_channels: ChannelCount, sample_rate: SampleRate) -> SupportedDuplexStreamConfig {
+    pub fn with_channels_sample_rate(
+        self,
+        input_channels: ChannelCount,
+        output_channels: ChannelCount,
+        sample_rate: SampleRate,
+    ) -> SupportedDuplexStreamConfig {
         assert!(
-            self.min_sample_rate <= sample_rate && sample_rate <= self.max_sample_rate
-            && self.input_channels.min <= input_channels && input_channels <= self.input_channels.max
-            && self.output_channels.min <= output_channels && output_channels <= self.output_channels.max
+            self.min_sample_rate <= sample_rate
+                && sample_rate <= self.max_sample_rate
+                && self.input_channels.min <= input_channels
+                && input_channels <= self.input_channels.max
+                && self.output_channels.min <= output_channels
+                && output_channels <= self.output_channels.max
         );
         SupportedDuplexStreamConfig {
             input_channels,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -954,6 +954,12 @@ impl From<SupportedStreamConfig> for StreamConfig {
     }
 }
 
+impl From<SupportedDuplexStreamConfig> for DuplexStreamConfig {
+    fn from(conf: SupportedDuplexStreamConfig) -> Self {
+        conf.config()
+    }
+}
+
 // If a backend does not provide an API for retrieving supported formats, we query it with a bunch
 // of commonly used rates. This is always the case for wasapi and is sometimes the case for alsa.
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,7 +865,7 @@ impl SupportedDuplexStreamConfigRange {
     /// A comparison function which compares two `SupportedDuplexStreamConfigRange`s in terms of their priority of
     /// use as a default stream format.
     ///
-    /// Refer to [`SupportStreamConfigRange::cmp_default_heuristics`] for more details. The duplex
+    /// Refer to [`SupportedStreamConfigRange::cmp_default_heuristics`] for more details. The duplex
     /// version prioritizes channel configurations as follows:
     ///
     /// - Both input and output stereo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -769,11 +769,11 @@ impl SupportedStreamConfigRange {
 
 impl SupportedDuplexStreamConfigRange {
     pub fn input_channels(&self) -> SupportedDuplexChannels {
-        self.input_channels
+        self.input_channels.clone()
     }
 
     pub fn output_channels(&self) -> SupportedDuplexChannels {
-        self.output_channels
+        self.output_channels.clone()
     }
 
     pub fn min_sample_rate(&self) -> SampleRate {
@@ -866,7 +866,7 @@ impl SupportedDuplexStreamConfigRange {
     /// - Mono input and mono output
     /// - Max output channels
     /// - Max input channels
-    pub fn cmp_default_heuristics(&self, other: &Self) -> std::cmp::Ordering {
+    pub fn cmp_default_heuristics(&self, _other: &Self) -> std::cmp::Ordering {
         // TODO: Refactor out common parts with the half duplex implementation?
         todo!()
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -219,7 +219,7 @@ pub trait DeviceTrait {
             move |input_data, output_data, info| {
                 data_callback(
                     input_data
-                        .as_slice_mut()
+                        .as_slice()
                         .expect("host supplied incorrect sample type"),
                     output_data
                         .as_slice_mut()

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,9 +2,10 @@
 
 use {
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
-    InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, PauseStreamError,
-    PlayStreamError, Sample, SampleFormat, StreamConfig, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError,
+    DuplexCallbackInfo, DuplexDevices, DuplexStreamConfig, InputCallbackInfo, InputDevices,
+    OutputCallbackInfo, OutputDevices, PauseStreamError, PlayStreamError, Sample, SampleFormat,
+    StreamConfig, StreamError, SupportedDuplexStreamConfig, SupportedDuplexStreamConfigRange,
+    SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 
 /// A **Host** provides access to the available audio devices on the system.
@@ -50,6 +51,11 @@ pub trait HostTrait {
     /// Returns `None` if no output device is available.
     fn default_output_device(&self) -> Option<Self::Device>;
 
+    /// The default duplex audio device on the system.
+    ///
+    /// Returns `None` if no duplex device is available.
+    fn default_duplex_device(&self) -> Option<Self::Device>;
+
     /// An iterator yielding all `Device`s currently available to the system that support one or more
     /// input stream formats.
     ///
@@ -77,9 +83,23 @@ pub trait HostTrait {
         }
         Ok(self.devices()?.filter(supports_output::<Self::Device>))
     }
+
+    /// An iterator yielding all `Device`s currently available to the system that support one or more
+    /// duplex stream formats.
+    ///
+    /// Can be empty if the system does not support duplex audio.
+    fn duplex_devices(&self) -> Result<DuplexDevices<Self::Devices>, DevicesError> {
+        fn supports_duplex<D: DeviceTrait>(device: &D) -> bool {
+            device
+                .supported_duplex_configs()
+                .map(|mut iter| iter.next().is_some())
+                .unwrap_or(false)
+        }
+        Ok(self.devices()?.filter(supports_duplex::<Self::Device>))
+    }
 }
 
-/// A device that is capable of audio input and/or output.
+/// A device that is capable of audio input and/or output, or both synchronized as full duplex.
 ///
 /// Please note that `Device`s may become invalid if they get disconnected. Therefore all the
 /// methods that involve a device return a `Result` allowing the user to handle this case.
@@ -88,7 +108,10 @@ pub trait DeviceTrait {
     type SupportedInputConfigs: Iterator<Item = SupportedStreamConfigRange>;
     /// The iterator type yielding supported output stream formats.
     type SupportedOutputConfigs: Iterator<Item = SupportedStreamConfigRange>;
-    /// The stream type created by `build_input_stream_raw` and `build_output_stream_raw`.
+    /// The iterator type yielding supported duplex stream formats.
+    type SupportedDuplexConfigs: Iterator<Item = SupportedDuplexStreamConfigRange>;
+    /// The stream type created by `build_input_stream_raw`, `build_output_stream_raw`
+    /// and `build_duplex_stream_raw`.
     type Stream: StreamTrait;
 
     /// The human-readable name of the device.
@@ -108,11 +131,23 @@ pub trait DeviceTrait {
         &self,
     ) -> Result<Self::SupportedOutputConfigs, SupportedStreamConfigsError>;
 
+    /// An iterator yielding duplex stream formats that are supported by the device.
+    ///
+    /// Can return an error if the device is no longer valid (eg. it has been disconnected).
+    fn supported_duplex_configs(
+        &self,
+    ) -> Result<Self::SupportedDuplexConfigs, SupportedStreamConfigsError>;
+
     /// The default input stream format for the device.
     fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError>;
 
     /// The default output stream format for the device.
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError>;
+
+    /// The default duplex stream format for the device.
+    fn default_duplex_config(
+        &self,
+    ) -> Result<SupportedDuplexStreamConfig, DefaultStreamConfigError>;
 
     /// Create an input stream.
     fn build_input_stream<T, D, E>(
@@ -166,6 +201,36 @@ pub trait DeviceTrait {
         )
     }
 
+    /// Create a duplex stream.
+    fn build_duplex_stream<T, D, E>(
+        &self,
+        config: &DuplexStreamConfig,
+        mut data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        T: Sample,
+        D: FnMut(&[T], &mut [T], &DuplexCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        self.build_duplex_stream_raw(
+            config,
+            T::FORMAT,
+            move |input_data, output_data, info| {
+                data_callback(
+                    input_data
+                        .as_slice_mut()
+                        .expect("host supplied incorrect sample type"),
+                    output_data
+                        .as_slice_mut()
+                        .expect("host supplied incorrect sample type"),
+                    info,
+                )
+            },
+            error_callback,
+        )
+    }
+
     /// Create a dynamically typed input stream.
     fn build_input_stream_raw<D, E>(
         &self,
@@ -188,6 +253,18 @@ pub trait DeviceTrait {
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static;
+
+    /// Create a dynamically typed duplex stream.
+    fn build_duplex_stream_raw<D, E>(
+        &self,
+        config: &DuplexStreamConfig,
+        sample_format: SampleFormat,
+        data_callback: D,
+        error_callback: E,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &mut Data, &DuplexCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static;
 }
 


### PR DESCRIPTION
We're working on an [audio editor / DAW](https://github.com/RustyDAW/multitrack-audio-editor), and full duplex audio IO is a fairly important feature for such software that is currently missing from CPAL.

For reference, duplex (or more accurately, full duplex) means that both input and output are processed at the same time, on the same stream, implicitly synchronized. Hosts have different levels of support for this: some provide it natively (JACK, CoreAudio), while on others this API merely allows input and output to run on the same loop to simplify synchronization. Without it, a CPAL user needs to handle synchronization manually and buffer an indeterminate amount to avoid over/underruns, as is done in the `feedback` example. This proposal does not address combining input and output streams from separate devices since in general that opens up further responsibilities such as clock drift compensation.

The API I have laid out in this PR is based on the one [previously discussed here](https://github.com/RustAudio/cpal/issues/116#issuecomment-362575520), though some things in CPAL have since changed. It is mostly a mirror of the existing input / output APIs, forming a third type of stream called "duplex". In particular,

 - `input/output_devices` -> `duplex_devices`, `default_input/output_device` -> `default_duplex_device`
 - `supported_input/output_configs` -> `supported_duplex_configs`, `default_input/output_config` -> `default_duplex_config`
 - `build_input/output_stream` -> `build_duplex_stream`
   - The data callback for duplex has the signature `FnMut(&Data, &mut Data, &DuplexCallbackInfo)`. In general the order of parameters should always be input, then output.

The largest difference is with how channels are configured. I determined it doesn't make sense to list out every possible combination of the amount of input and output channels as separate `SupportedDuplexStreamConfigRange` instances for the user to iterate over. Therefore I instead incorporate ranges of possible channel configurations (min, max, default) for both input and output in the `SupportedDuplexStreamConfigRange` structs. Hopefully this doesn't make the API too illogical. I wrote up a more in-depth rationale in [this commit](https://github.com/RustAudio/cpal/commit/4625da18cdeded5e73655fef2edf2c1c8f54380e).

In addition, it should be straightforward to add a conversion layer to convert input/output `SupportedStreamConfig` into `SupportedDuplexStreamConfig` with zero channels of the other type. This would allow users of CPAL to only write one type of callback handler, but have their code still work even if duplex devices aren't available. Internally, `build_duplex_stream` would delegate to the respective `raw` methods so the host implementation doesn't have to be aware of it or try to open devices with zero channels.

Feedback and improvement ideas are welcome. If this is deemed the way to go, I and anyone interested can start implementing support for it in more hosts.

### Host implementation status

- [x] [JACK](https://github.com/rustydaw/cpal/tree/duplex-jack)
  - Initially done, and it works (try the duplex example!). There is an (existing) issue with the temporary buffer allocation, meaning it panics when buffer size is increased beyond the initial amount in the input and duplex modes. This seems like it stems from an [issue](https://github.com/RustAudio/rust-jack/issues/137) I've filed in rust-jack.
- [ ] ALSA has `todo!` stubs so that it compiles on Linux.

I will keep this PR as a draft at least until all hosts compile and return empty configuration options.