### PR TITLE
Don't call AudioObjectGetPropertyData again if CFStringGetCStringPtr fails

### DIFF
--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -162,15 +162,6 @@ impl Device {
 
             let c_string: *const c_char = CFStringGetCStringPtr(device_name, kCFStringEncodingUTF8);
             if c_string.is_null() {
-                let status = AudioObjectGetPropertyData(
-                    self.audio_device_id,
-                    &property_address as *const _,
-                    0,
-                    null(),
-                    &data_size as *const _ as *mut _,
-                    &device_name as *const _ as *mut _,
-                );
-                check_os_status(status)?;
                 let mut buf: [i8; 255] = [0; 255];
                 let result = CFStringGetCString(
                     device_name,


### PR DESCRIPTION
There's no indication that `CFStringGetCStringPtr` failing is destructive for the `CFString`:

https://developer.apple.com/documentation/corefoundation/1542133-cfstringgetcstringptr

So calling `AudioObjectGetPropertyData` a second time to get the device name isn't necessary.

It looks like this was an unintentional error in #399, but I don't have a wide-character install of macOS to try this against.

cc @thavlik 