### PR TITLE
Fix alsa in some configs outputting bad audio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.13.2"
+version = "0.13.3"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio I/O library in pure Rust."
 repository = "https://github.com/rustaudio/cpal"

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -619,10 +619,7 @@ fn output_stream_worker(
         .unwrap_or(PollDescriptorsFlow::Continue);
 
         match flow {
-            PollDescriptorsFlow::Continue => {
-                report_error(stream.channel.prepare(), error_callback);
-                continue;
-            }
+            PollDescriptorsFlow::Continue => continue,
             PollDescriptorsFlow::XRun => {
                 report_error(stream.channel.prepare(), error_callback);
                 continue;


### PR DESCRIPTION
This was introduced in `6b91485` and it caused issues with some alsa
configurations like with `pipewire-alsa` for me which caused the audio to be
become weirdly distorted.