### PR TITLE
Update feedback examples to use mpsc's sync_channel.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ thiserror = "1.0.2"
 [dev-dependencies]
 anyhow = "1.0.12"
 hound = "3.4"
-ringbuf = "0.2"
 clap = { version = "2.33.3", default-features = false }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -9,11 +9,10 @@
 extern crate anyhow;
 extern crate clap;
 extern crate cpal;
-extern crate ringbuf;
 
 use anyhow::Context;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use ringbuf::RingBuffer;
+use std::sync::mpsc;
 
 #[derive(Debug)]
 struct Opt {
@@ -128,42 +127,17 @@ fn main() -> anyhow::Result<()> {
     let latency_frames = (opt.latency / 1_000.0) * config.sample_rate.0 as f32;
     let latency_samples = latency_frames as usize * config.channels as usize;
 
-    // The buffer to share samples
-    let ring = RingBuffer::new(latency_samples * 2);
-    let (mut producer, mut consumer) = ring.split();
-
-    // Fill the samples with 0.0 equal to the length of the delay.
-    for _ in 0..latency_samples {
-        // The ring buffer has twice as much space as necessary to add latency here,
-        // so this should never fail
-        producer.push(0.0).unwrap();
-    }
+    let (tx, rx) = mpsc::sync_channel(latency_samples * 2);
 
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
-        let mut output_fell_behind = false;
         for &sample in data {
-            if producer.push(sample).is_err() {
-                output_fell_behind = true;
-            }
-        }
-        if output_fell_behind {
-            eprintln!("output stream fell behind: try increasing latency");
+            tx.send(sample).unwrap();
         }
     };
 
     let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        let mut input_fell_behind = false;
         for sample in data {
-            *sample = match consumer.pop() {
-                Some(s) => s,
-                None => {
-                    input_fell_behind = true;
-                    0.0
-                }
-            };
-        }
-        if input_fell_behind {
-            eprintln!("input stream fell behind: try increasing latency");
+            *sample = rx.recv().unwrap_or(0.0);
         }
     };
 

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -127,6 +127,8 @@ fn main() -> anyhow::Result<()> {
     let latency_frames = (opt.latency / 1_000.0) * config.sample_rate.0 as f32;
     let latency_samples = latency_frames as usize * config.channels as usize;
 
+    // The channel has twice as much space as necessary to add latency here,
+    // so this should never fail
     let (tx, rx) = mpsc::sync_channel(latency_samples * 2);
 
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {

--- a/examples/ios-feedback/Cargo.toml
+++ b/examples/ios-feedback/Cargo.toml
@@ -13,5 +13,4 @@ crate-type = ["staticlib"]
 [dependencies]
 cpal = { path = "../.." }
 anyhow = "1.0.12"
-ringbuf = "0.1.6"
 

--- a/examples/ios-feedback/README.md
+++ b/examples/ios-feedback/README.md
@@ -1,7 +1,7 @@
 # iOS Feedback Example
 
 This example is an Xcode project that exercises both input and output
-audio streams. Audio samples are read in from your micrphone and then
+audio streams. Audio samples are read in from your microphone and then
 routed to your audio output device with a small but noticeable delay
 so you can verify it is working correctly.
 

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -8,10 +8,9 @@
 
 extern crate anyhow;
 extern crate cpal;
-extern crate ringbuf;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use ringbuf::RingBuffer;
+use std::sync::mpsc;
 
 const LATENCY_MS: f32 = 1000.0;
 
@@ -35,45 +34,17 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     let latency_frames = (LATENCY_MS / 1_000.0) * config.sample_rate.0 as f32;
     let latency_samples = latency_frames as usize * config.channels as usize;
 
-    // The buffer to share samples
-    let ring = RingBuffer::new(latency_samples * 2);
-    let (mut producer, mut consumer) = ring.split();
-
-    // Fill the samples with 0.0 equal to the length of the delay.
-    for _ in 0..latency_samples {
-        // The ring buffer has twice as much space as necessary to add latency here,
-        // so this should never fail
-        producer.push(0.0).unwrap();
-    }
+    let (tx, rx) = mpsc::sync_channel(latency_samples * 2);
 
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {
-        let mut output_fell_behind = false;
         for &sample in data {
-            if producer.push(sample).is_err() {
-                output_fell_behind = true;
-            }
-        }
-        if output_fell_behind {
-            eprintln!("output stream fell behind: try increasing latency");
+            tx.send(sample).unwrap();
         }
     };
 
     let output_data_fn = move |data: &mut [f32], _: &cpal::OutputCallbackInfo| {
-        let mut input_fell_behind = None;
         for sample in data {
-            *sample = match consumer.pop() {
-                Ok(s) => s,
-                Err(err) => {
-                    input_fell_behind = Some(err);
-                    0.0
-                }
-            };
-        }
-        if let Some(err) = input_fell_behind {
-            eprintln!(
-                "input stream fell behind: {:?}: try increasing latency",
-                err
-            );
+            *sample = rx.recv().unwrap_or(0.0);
         }
     };
 

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -34,6 +34,8 @@ pub fn run_example() -> Result<(), anyhow::Error> {
     let latency_frames = (LATENCY_MS / 1_000.0) * config.sample_rate.0 as f32;
     let latency_samples = latency_frames as usize * config.channels as usize;
 
+    // The channel has twice as much space as necessary to add latency here,
+    // so this should never fail
     let (tx, rx) = mpsc::sync_channel(latency_samples * 2);
 
     let input_data_fn = move |data: &[f32], _: &cpal::InputCallbackInfo| {


### PR DESCRIPTION
## Testing
### In General
1. Run `cargo test` to ensure that everything still passes.
2. Navigate to the `examples` directory.
3. Run `cargo run --example feedback`
4. Observe feedback from the default input device to the default output device.
### On Apple Device
1. Navigate to `ios-feedback`.
2. Follow instructions in `README.md` to build and run the project.
3. Observe feedback from the default input device to the default output device.

## Changes
- Removed ringbuf dependency from dev-dependencies.
- Replaced buffer with transmitter/receiver pattern.
- Some documentation polish.

What are your thoughts on these changes?