### PR TITLE
ALSA I/O worker threads rewrite

### DIFF
--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,6 +1,5 @@
 use super::alsa;
-use super::parking_lot::Mutex;
-use super::{Device, DeviceHandles};
+use super::Device;
 use {BackendSpecificError, DevicesError};
 
 /// ALSA implementation for `Devices`.
@@ -34,12 +33,11 @@ impl Iterator for Devices {
                         Some(name) => name,
                     };
 
-                    if let Ok(handles) = DeviceHandles::open(&name) {
-                        return Some(Device {
-                            name,
-                            handles: Mutex::new(handles),
-                        });
-                    }
+                    return Some(Device {
+                        name,
+                        direction: hint.direction,
+                        handles: Default::default(),
+                    });
                 }
             }
         }
@@ -48,18 +46,12 @@ impl Iterator for Devices {
 
 #[inline]
 pub fn default_input_device() -> Option<Device> {
-    Some(Device {
-        name: "default".to_owned(),
-        handles: Mutex::new(Default::default()),
-    })
+    Some(Default::default())
 }
 
 #[inline]
 pub fn default_output_device() -> Option<Device> {
-    Some(Device {
-        name: "default".to_owned(),
-        handles: Mutex::new(Default::default()),
-    })
+    Some(Default::default())
 }
 
 impl From<alsa::Error> for DevicesError {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -255,6 +255,22 @@ macro_rules! impl_platform_host {
                 }
             }
 
+            fn supports_input(&self) -> bool {
+                match self.0 {
+                    $(
+                        DeviceInner::$HostVariant(ref d) => d.supports_input(),
+                    )*
+                }
+            }
+
+            fn supports_output(&self) -> bool {
+                match self.0 {
+                    $(
+                        DeviceInner::$HostVariant(ref d) => d.supports_output(),
+                    )*
+                }
+            }
+
             fn build_input_stream_raw<D, E>(
                 &self,
                 config: &crate::StreamConfig,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -55,13 +55,7 @@ pub trait HostTrait {
     ///
     /// Can be empty if the system does not support audio input.
     fn input_devices(&self) -> Result<InputDevices<Self::Devices>, DevicesError> {
-        fn supports_input<D: DeviceTrait>(device: &D) -> bool {
-            device
-                .supported_input_configs()
-                .map(|mut iter| iter.next().is_some())
-                .unwrap_or(false)
-        }
-        Ok(self.devices()?.filter(supports_input::<Self::Device>))
+        Ok(self.devices()?.filter(Self::Device::supports_input))
     }
 
     /// An iterator yielding all `Device`s currently available to the system that support one or more
@@ -69,13 +63,7 @@ pub trait HostTrait {
     ///
     /// Can be empty if the system does not support audio output.
     fn output_devices(&self) -> Result<OutputDevices<Self::Devices>, DevicesError> {
-        fn supports_output<D: DeviceTrait>(device: &D) -> bool {
-            device
-                .supported_output_configs()
-                .map(|mut iter| iter.next().is_some())
-                .unwrap_or(false)
-        }
-        Ok(self.devices()?.filter(supports_output::<Self::Device>))
+        Ok(self.devices()?.filter(Self::Device::supports_output))
     }
 }
 
@@ -113,6 +101,20 @@ pub trait DeviceTrait {
 
     /// The default output stream format for the device.
     fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError>;
+
+    /// Whether this device supports input streams
+    fn supports_input(&self) -> bool {
+        self.supported_input_configs()
+            .map(|mut iter| iter.next().is_some())
+            .unwrap_or(false)
+    }
+
+    /// Whether this device supports output streams
+    fn supports_output(&self) -> bool {
+        self.supported_output_configs()
+            .map(|mut iter| iter.next().is_some())
+            .unwrap_or(false)
+    }
 
     /// Create an input stream.
     fn build_input_stream<T, D, E>(


### PR DESCRIPTION
This pull request rewrites the ALSA input/output worker threads to use alsa::PCM::IO instead of dealing with the raw file descriptors directly. This removes nearly all of the unsafe blocks from cpal's ALSA implementation and fixes a number of problems I had with audio recording/playback through low level ALSA devices on platforms like the Raspberry Pi. It also ensures a consistently sized buffer is passed to callbacks and avoids allocations in the inner loop. The implementation is modeled on ALSA's aplay and arecord utilities, so should be maximally compatible with ALSA devices.

Fixes #495 and #460.