### PR TITLE
Cleanup and document cpal's ALSA backend

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -556,13 +556,11 @@ fn input_stream_worker(
 ) {
     let mut ctxt = StreamWorkerContext::default();
     loop {
-        let flow = match poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt) {
-            Ok(val) => val,
-            Err(err) => {
+        let flow =
+            poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt).unwrap_or_else(|err| {
                 error_callback(err.into());
                 PollDescriptorsFlow::Continue
-            }
-        };
+            });
 
         match flow {
             PollDescriptorsFlow::Continue => {
@@ -608,13 +606,11 @@ fn output_stream_worker(
 ) {
     let mut ctxt = StreamWorkerContext::default();
     loop {
-        let flow = match poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt) {
-            Ok(val) => val,
-            Err(err) => {
+        let flow =
+            poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt).unwrap_or_else(|err| {
                 error_callback(err.into());
                 PollDescriptorsFlow::Continue
-            }
-        };
+            });
 
         match flow {
             PollDescriptorsFlow::Continue => continue,

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -252,15 +252,12 @@ impl Device {
 
         handle.prepare()?;
 
-        let num_descriptors = {
-            let num_descriptors = handle.count();
-            if num_descriptors == 0 {
-                let description = "poll descriptor count for stream was 0".to_string();
-                let err = BackendSpecificError { description };
-                return Err(err.into());
-            }
-            num_descriptors
-        };
+        let num_descriptors = handle.count();
+        if num_descriptors == 0 {
+            let description = "poll descriptor count for stream was 0".to_string();
+            let err = BackendSpecificError { description };
+            return Err(err.into());
+        }
 
         // Check to see if we can retrieve valid timestamps from the device.
         // Related: https://bugs.freedesktop.org/show_bug.cgi?id=88503

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1018,6 +1018,11 @@ fn set_sw_params_from_format(
 
         let start_threshold = match stream_type {
             alsa::Direction::Playback => buffer - period,
+
+            // For capture streams, the start threshold is irrelevant and ignored,
+            // because build_stream_inner() starts the stream before process_input()
+            // reads from it. Set it anyway I guess, since it's better than leaving
+            // it at an unspecified default value.
             alsa::Direction::Capture => 1,
         };
         sw_params.set_start_threshold(start_threshold.try_into().unwrap())?;


### PR DESCRIPTION
Questions:

- [ ] Are the changes in "Remove report_error(), replace monadic error handling with match" and "Alternatively..." improvements?
- [ ] Should I merge the two commits?
- [ ] "Set it anyway I guess" is arguably too informal.
- [ ] Should `poll_descriptors_and_prepare_buffer()` loop and never return `Continue`?
- [ ] ~~Should we skip calling `set_start_threshold()` for capture streams?~~
	- The start threshold actually *does* matter in capture streams: when we hit `PollDescriptorsFlow::XRun`, we prepare the device but don't start it explicitly. Should we do so? (it doesn't make much of a difference in practice, since we read immediately from input streams... except we don't, we poll them! Is this a CPAL bug where input streams never restart after xrun?!)
	- I tried testing xrun. But when I suspend the cpal process (feedback talking to pipewire-alsa) with Ctrl+Z, then fg a second later, it somehow doesn't hit xrun. This even happens if I add a 500ms sleep in the loop of `input_stream_worker()`!
	- And cpal feedback `cargo run --example feedback -- front:CARD=Generic,DEV=0 front:CARD=Generic,DEV=0` won't detect `front:CARD=Generic,DEV=0` as an output device, only input, so I can't run it talking to my physical hardware! (`aplay /dev/urandom -D front:CARD=Generic,DEV=0 --format=S16_LE --channels=2 --rate=48000` *does* work.)
	- `cargo run --example record_wav -- front:CARD=Generic,DEV=0` also doesn't hit xrun when I ctrl+z. So I can't actually reproduce this case to see if cpal bugs out or not.
		- It also produces an empty wav file whether I ctrl+z or not. It produces a proper wav if I don't sleep in `input_stream_worker()`.
	- If I add a stop threshold, it never actually kicks in. Weeeeiiiiiird.
	- `stream.channel.state()` remains in `Running`, and `poll_descriptors_and_prepare_buffer()` always returns `PollDescriptorsFlow::Ready`, even with the 500ms sleeps.

It would be nice to write multi-paragraph-level commentary on the code, but I'm not sure where I should put it. In the file itself? In a new DESIGN.md file in the alsa directory? I have a Google Doc, but I don't want to share it because there are some IRC chat logs I didn't ask permission to share publicly.

Notes to self:

- [ ] Verify that the code is functionally identical to before.