### PR TITLE
Bump android dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ js-sys = { version = "0.3.35" }
 web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-oboe = { version = "0.4.0", features = [ "java-interface" ] }
-ndk = "0.4"
-ndk-glue = "0.4"
+oboe = { version = "0.4", features = [ "java-interface" ] }
+ndk = "0.6"
+ndk-glue = "0.6"
 jni = "0.19"
 
 [[example]]


### PR DESCRIPTION
Bump `oboe`, `ndk` and `ndk-glue` dependency versions.