### PR TITLE
Bump cpal crate version to 0.13.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.13.4"
+version = "0.13.5"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio I/O library in pure Rust."
 repository = "https://github.com/rustaudio/cpal"


### PR DESCRIPTION
Is there anything that blocks from bumping the `cpal` version? We are struggling with `ndk-glue` collision errors, and it would be great to release a new `cpal` version to get rid of them.