### PR TITLE
fix: Android - Return Device(None) as a default i/o device

### DIFF
--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -73,19 +73,11 @@ impl HostTrait for Host {
     }
 
     fn default_input_device(&self) -> Option<Self::Device> {
-        if let Ok(devices) = oboe::AudioDeviceInfo::request(oboe::AudioDeviceDirection::Input) {
-            devices.into_iter().map(|d| Device(Some(d))).next()
-        } else {
-            Some(Device(None))
-        }
+        Some(Device(None))
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        if let Ok(devices) = oboe::AudioDeviceInfo::request(oboe::AudioDeviceDirection::Output) {
-            devices.into_iter().map(|d| Device(Some(d))).next()
-        } else {
-            Some(Device(None))
-        }
+        Some(Device(None))
     }
 }
 


### PR DESCRIPTION
In some cases, device with index 0 is NOT the default output device - in my case it happens to be the ear speaker. Returning Device(None) there makes Oboe choose the default input/output device - everything works as expected.