### PR TITLE
android: Migrate from `ndk-glue` to `ndk-context`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ hound = "3.4"
 ringbuf = "0.2"
 clap = { version = "3", default-features = false, features = ["std"] }
 
+[target.'cfg(target_os = "android")'.dev-dependencies]
+ndk-glue = "0.6"
+
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
@@ -55,7 +58,7 @@ web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOption
 [target.'cfg(target_os = "android")'.dependencies]
 oboe = { version = "0.4", features = [ "java-interface" ] }
 ndk = "0.6"
-ndk-glue = "0.6"
+ndk-context = "0.1"
 jni = "0.19"
 
 [[example]]


### PR DESCRIPTION
`ndk-glue` suffers one fatal flaw: it's "only" supposed to be used by the crate providing `fn main()` and only supposed to end up in the dependency graph once as it has `static` globals which get duplicated across versions.

In the current case with `winit 0.26` still on `ndk-glue 0.5` but `cpal` on `ndk-glue 0.6` it'll always panic in `fn native_activity()` as the `static` globals on this version is not initialized.

Introducing `ndk-context`: a crate that holds these `static`s, with the intention/premise to not see a breaking release /ever/ and make this a problem of the past.  The crate is currently initialized with the VM and Android Context on `ndk-glue` 0.5.1 and 0.6.1 (0.4.1 pending) making it compatible with whatever is current, and the possibility for backporting to older `ndk-glue` versions too.

See also:
https://github.com/rust-windowing/android-ndk-rs/issues/211
https://github.com/rust-windowing/android-ndk-rs/pull/223
