### PR TITLE
Rust 2021 and clap 3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ repository = "https://github.com/rustaudio/cpal"
 documentation = "https://docs.rs/cpal"
 license = "Apache-2.0"
 keywords = ["audio", "sound"]
+edition = "2021"
 
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
@@ -18,7 +19,7 @@ thiserror = "1.0.2"
 anyhow = "1.0.12"
 hound = "3.4"
 ringbuf = "0.2"
-clap = { version = "3", default-features = false, features = ["std"] }
+clap = { version = "3.0", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 ndk-glue = "0.6"

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,7 +1,7 @@
 use super::alsa;
 use super::parking_lot::Mutex;
 use super::{Device, DeviceHandles};
-use {BackendSpecificError, DevicesError};
+use crate::{BackendSpecificError, DevicesError};
 
 /// ALSA's implementation for `Devices`.
 pub struct Devices {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -4,6 +4,7 @@ extern crate parking_lot;
 
 use self::alsa::poll::Descriptors;
 use self::parking_lot::Mutex;
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, ChannelCount, Data,
     DefaultStreamConfigError, DeviceNameError, DevicesError, InputCallbackInfo, OutputCallbackInfo,
@@ -16,7 +17,6 @@ use std::convert::TryInto;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::vec::IntoIter as VecIntoIter;
-use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 pub use self::enumerate::{default_input_device, default_output_device, Devices};
 

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -21,7 +21,7 @@ trait Silence {
 /// Constraints on the ASIO sample types.
 trait AsioSample: Clone + Copy + Silence + std::ops::Add<Self, Output = Self> {
     fn to_cpal_sample<T: Sample>(&self) -> T;
-    fn from_cpal_sample<T: Sample>(&T) -> Self;
+    fn from_cpal_sample<T: Sample>(_: &T) -> Self;
 }
 
 // Used to keep track of whether or not the current asio stream buffer requires

--- a/src/host/coreaudio/ios/enumerate.rs
+++ b/src/host/coreaudio/ios/enumerate.rs
@@ -1,7 +1,7 @@
 use std::vec::IntoIter as VecIntoIter;
 
-use DevicesError;
-use SupportedStreamConfigRange;
+use crate::DevicesError;
+use crate::SupportedStreamConfigRange;
 
 use super::Device;
 

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -20,7 +20,7 @@ use self::coreaudio::sys::{
 };
 
 use super::{asbd_from_config, frames_to_duration, host_time_to_stream_instant};
-use traits::{DeviceTrait, HostTrait, StreamTrait};
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, Data, DefaultStreamConfigError,

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -8,10 +8,10 @@ use self::coreaudio::sys::{
     AudioObjectPropertyAddress, OSStatus,
 };
 use super::Device;
+use crate::{BackendSpecificError, DevicesError, SupportedStreamConfigRange};
 use std::mem;
 use std::ptr::null;
 use std::vec::IntoIter as VecIntoIter;
-use {BackendSpecificError, DevicesError, SupportedStreamConfigRange};
 
 unsafe fn audio_devices() -> Result<Vec<AudioDeviceID>, OSStatus> {
     let property_address = AudioObjectPropertyAddress {

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -5,8 +5,8 @@ use self::coreaudio::sys::{
     AudioStreamBasicDescription, OSStatus,
 };
 
-use DefaultStreamConfigError;
-use {BuildStreamError, SupportedStreamConfigsError};
+use crate::DefaultStreamConfigError;
+use crate::{BuildStreamError, SupportedStreamConfigsError};
 
 use crate::{BackendSpecificError, SampleFormat, StreamConfig};
 

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -7,13 +7,13 @@ use stdweb::web::set_timeout;
 use stdweb::web::TypedArray;
 use stdweb::Reference;
 
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BufferSize, BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat,
     SampleRate, StreamConfig, StreamError, SupportedBufferSize, SupportedStreamConfig,
     SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
-use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 // The emscripten backend currently works by instantiating an `AudioContext` object per `Stream`.
 // Creating a stream creates a new `AudioContext`. Destroying a stream destroys it. Creation of a

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -1,3 +1,4 @@
+use crate::traits::DeviceTrait;
 use crate::{
     BackendSpecificError, BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError,
     InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, StreamError,
@@ -5,7 +6,6 @@ use crate::{
     SupportedStreamConfigsError,
 };
 use std::hash::{Hash, Hasher};
-use traits::DeviceTrait;
 
 use super::stream::Stream;
 use super::JACK_SAMPLE_FORMAT;

--- a/src/host/jack/mod.rs
+++ b/src/host/jack/mod.rs
@@ -1,7 +1,7 @@
 extern crate jack;
 
+use crate::traits::HostTrait;
 use crate::{DevicesError, SampleFormat, SupportedStreamConfigRange};
-use traits::HostTrait;
 
 mod device;
 pub use self::device::Device;

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -1,7 +1,7 @@
+use crate::traits::StreamTrait;
 use crate::ChannelCount;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use traits::StreamTrait;
 
 use crate::{
     BackendSpecificError, Data, InputCallbackInfo, OutputCallbackInfo, PauseStreamError,

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,10 +1,10 @@
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat,
     StreamConfig, StreamError, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError,
 };
-use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 #[derive(Default)]
 pub struct Devices;

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -6,10 +6,10 @@ pub use self::device::{
 };
 pub use self::stream::Stream;
 use self::winapi::um::winnt::HRESULT;
+use crate::traits::HostTrait;
+use crate::BackendSpecificError;
+use crate::DevicesError;
 use std::io::Error as IoError;
-use traits::HostTrait;
-use BackendSpecificError;
-use DevicesError;
 
 mod com;
 mod device;

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -6,6 +6,7 @@ use self::js_sys::eval;
 use self::wasm_bindgen::prelude::*;
 use self::wasm_bindgen::JsCast;
 use self::web_sys::{AudioContext, AudioContextOptions};
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, Data, DefaultStreamConfigError,
     DeviceNameError, DevicesError, InputCallbackInfo, OutputCallbackInfo, PauseStreamError,
@@ -14,7 +15,6 @@ use crate::{
 };
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock};
-use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,6 +1,6 @@
 //! The suite of traits allowing CPAL to abstract over hosts, devices, event loops and stream IDs.
 
-use {
+use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, PauseStreamError,
     PlayStreamError, Sample, SampleFormat, StreamConfig, StreamError, SupportedStreamConfig,


### PR DESCRIPTION
The api between clap 3.0 and 3.1 as change and make the test uncompilable.