### PR TITLE
Fix example typos

### DIFF
--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -31,7 +31,7 @@ struct Opt {
 
 impl Opt {
     fn from_args() -> anyhow::Result<Self> {
-        let app = clap::Command::new("beep")
+        let app = clap::Command::new("feedback")
             .arg(arg!(
             -l --latency [DELAY_MS] "Specify the delay between input and output [default: 150]"))
             .arg(arg!([IN] "The input audio device to use"))

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -26,7 +26,7 @@ struct Opt {
 
 impl Opt {
     fn from_args() -> Self {
-        let app = clap::Command::new("beep").arg(arg!([DEVICE] "The audio device to use"));
+        let app = clap::Command::new("record_wav").arg(arg!([DEVICE] "The audio device to use"));
         #[cfg(all(
             any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"),
             feature = "jack"


### PR DESCRIPTION
both feedback.rs and record_wav.rs have "bleep" as their application name when constructing `clap::Command`. This commit changes the constructor argument for each example to match their filenames.