### PR TITLE
WebAudio: expose AudioContext in WebAudioStream

### DIFF
--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -350,6 +350,14 @@ impl DeviceTrait for Device {
     }
 }
 
+impl Stream {
+    /// Return the [`AudioContext`](https://developer.mozilla.org/docs/Web/API/AudioContext) used
+    /// by this stream.
+    pub fn audio_context(&self) -> &AudioContext {
+        &*self.ctx
+    }
+}
+
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
         let window = web_sys::window().unwrap();


### PR DESCRIPTION
On Chrome, If a `AudioContext` is created before a user interaction, it starts in `suspended` state. To resume it, I must call `AudioContext.resume()`. For more information: https://developer.chrome.com/blog/autoplay/

To allow that, this PR exposes the `AudioContext` of `WebAudioStream`.

Related to #49.