### PR TITLE
Expose underlying platform specific implemenations

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -85,28 +85,29 @@ macro_rules! impl_platform_host {
             )*
         }
 
-        enum DeviceInner {
+        pub enum DeviceInner {
             $(
                 $(#[cfg($feat)])?
                 $HostVariant(crate::host::$host_mod::Device),
             )*
         }
 
-        enum DevicesInner {
+        pub enum DevicesInner {
             $(
                 $(#[cfg($feat)])?
                 $HostVariant(crate::host::$host_mod::Devices),
             )*
         }
 
-        enum HostInner {
+
+        pub enum HostInner {
             $(
                 $(#[cfg($feat)])?
                 $HostVariant(crate::host::$host_mod::Host),
             )*
         }
 
-        enum StreamInner {
+        pub enum StreamInner {
             $(
                 $(#[cfg($feat)])?
                 $HostVariant(crate::host::$host_mod::Stream),
@@ -138,6 +139,44 @@ macro_rules! impl_platform_host {
             }
         }
 
+        impl Devices {
+            /// Returns a reference to the underlying platform specific implementation of this
+            /// `Devices`.
+            pub fn as_inner(&self) -> &DevicesInner {
+                &self.0
+            }
+
+            /// Returns a mutable reference to the underlying platform specific implementation of
+            /// this `Devices`.
+            pub fn as_inner_mut(&self) -> &DevicesInner {
+                &self.0
+            }
+
+            /// Returns the underlying platform specific implementation of this `Devices`.
+            pub fn into_inner(self) -> DevicesInner {
+                self.0
+            }
+        }
+
+        impl Device {
+            /// Returns a reference to the underlying platform specific implementation of this
+            /// `Device`.
+            pub fn as_inner(&self) -> &DeviceInner {
+                &self.0
+            }
+
+            /// Returns a mutable reference to the underlying platform specific implementation of
+            /// this `Device`.
+            pub fn as_inner_mut(&self) -> &DeviceInner {
+                &self.0
+            }
+
+            /// Returns the underlying platform specific implementation of this `Device`.
+            pub fn into_inner(self) -> DeviceInner {
+                self.0
+            }
+        }
+
         impl Host {
             /// The unique identifier associated with this host.
             pub fn id(&self) -> HostId {
@@ -147,6 +186,42 @@ macro_rules! impl_platform_host {
                         HostInner::$HostVariant(_) => HostId::$HostVariant,
                     )*
                 }
+            }
+
+            /// Returns a reference to the underlying platform specific implementation of this
+            /// `Host`.
+            pub fn as_inner(&self) -> &HostInner {
+                &self.0
+            }
+
+            /// Returns a mutable reference to the underlying platform specific implementation of
+            /// this `Host`.
+            pub fn as_inner_mut(&self) -> &HostInner {
+                &self.0
+            }
+
+            /// Returns the underlying platform specific implementation of this `Host`.
+            pub fn into_inner(self) -> HostInner {
+                self.0
+            }
+        }
+
+        impl Stream {
+            /// Returns a reference to the underlying platform specific implementation of this
+            /// `Stream`.
+            pub fn as_inner(&self) -> &StreamInner {
+                &self.0
+            }
+
+            /// Returns a mutable reference to the underlying platform specific implementation of
+            /// this `Stream`.
+            pub fn as_inner_mut(&self) -> &StreamInner {
+                &self.0
+            }
+
+            /// Returns the underlying platform specific implementation of this `Stream`.
+            pub fn into_inner(self) -> StreamInner {
+                self.0
             }
         }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -151,8 +151,8 @@ macro_rules! impl_platform_host {
 
             /// Returns a mutable reference to the underlying platform specific implementation of
             /// this `Devices`.
-            pub fn as_inner_mut(&self) -> &DevicesInner {
-                &self.0
+            pub fn as_inner_mut(&mut self) -> &mut DevicesInner {
+                &mut self.0
             }
 
             /// Returns the underlying platform specific implementation of this `Devices`.
@@ -170,8 +170,8 @@ macro_rules! impl_platform_host {
 
             /// Returns a mutable reference to the underlying platform specific implementation of
             /// this `Device`.
-            pub fn as_inner_mut(&self) -> &DeviceInner {
-                &self.0
+            pub fn as_inner_mut(&mut self) -> &mut DeviceInner {
+                &mut self.0
             }
 
             /// Returns the underlying platform specific implementation of this `Device`.
@@ -199,8 +199,8 @@ macro_rules! impl_platform_host {
 
             /// Returns a mutable reference to the underlying platform specific implementation of
             /// this `Host`.
-            pub fn as_inner_mut(&self) -> &HostInner {
-                &self.0
+            pub fn as_inner_mut(&mut self) -> &mut HostInner {
+                &mut self.0
             }
 
             /// Returns the underlying platform specific implementation of this `Host`.
@@ -218,8 +218,8 @@ macro_rules! impl_platform_host {
 
             /// Returns a mutable reference to the underlying platform specific implementation of
             /// this `Stream`.
-            pub fn as_inner_mut(&self) -> &StreamInner {
-                &self.0
+            pub fn as_inner_mut(&mut self) -> &mut StreamInner {
+                &mut self.0
             }
 
             /// Returns the underlying platform specific implementation of this `Stream`.

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -85,6 +85,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
+        /// Contains a platform specific `Device` implementation.
         pub enum DeviceInner {
             $(
                 $(#[cfg($feat)])?
@@ -92,6 +93,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
+        /// Contains a platform specific `Devices` implementation.
         pub enum DevicesInner {
             $(
                 $(#[cfg($feat)])?
@@ -99,7 +101,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
-
+        /// Contains a platform specific `Host` implementation.
         pub enum HostInner {
             $(
                 $(#[cfg($feat)])?
@@ -107,6 +109,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
+        /// Contains a platform specific `Stream` implementation.
         pub enum StreamInner {
             $(
                 $(#[cfg($feat)])?


### PR DESCRIPTION
The conversion between platform specific structs to platform-agnostic ones is already implemented, but the reverse path does not exist.

To allow that, this PR exposes `DeviceInner`, `DevicesInner`, `HostInner` and `StreamInner` (structs that already existed before), by the methods `as_inner`, `as_inner_mut` and `into_inner`.

Other possible implementation would be replacing each struct by its own inner (like replace `Device` by `DeviceInner`), but this was not possible because of the `Stream` struct that contains a seconds field.

Another one would be to make the inner field public (i.e. field `0` in the current implementation), but this may guarantee better documentation and forward compatibility. And, to be honest, I only think of that possibility while writing this comment.

If you prefer a different implementation, I can change it.