### PR TITLE
Implement BufferSize::Fixed in wasapi, and migrate wasapi to officially-supported Windows crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "3.1", default-features = false, features = ["std"] }
 ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.36", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia"]}
+windows = { version = "0.36", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
 # winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "3.1", default-features = false, features = ["std"] }
 ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.36", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
+windows = { version = "0.37", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.36", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
-# winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ clap = { version = "3.1", default-features = false, features = ["std"] }
 ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
+windows = { version = "0.36", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia"]}
+# winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.11"

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -4,7 +4,6 @@ use super::IoError;
 use std::marker::PhantomData;
 use std::ptr;
 
-use windows::core::HRESULT;
 use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
 

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -16,19 +16,19 @@ thread_local!(static COM_INITIALIZED: ComInitialized = {
         // That's OK though since COM ensures thread-safety/compatibility through marshalling when
         // necessary.
         let result = CoInitializeEx(ptr::null_mut(), COINIT_APARTMENTTHREADED);
-	match result.clone().map_err(|e| e.code()) {
-	    Ok(_) |
-	    Err(RPC_E_CHANGED_MODE) => {
-		ComInitialized {
-		    result,
-		    _ptr: PhantomData,
-		}
-	    },
-	    Err(e) => {
-		// COM initialization failed in another way, something is really wrong.
-		panic!("Failed to initialize COM: {}", IoError::from_raw_os_error(e.0));
-	    }
-	}
+        match result.clone().map_err(|e| e.code()) {
+            Ok(_) |
+            Err(RPC_E_CHANGED_MODE) => {
+                ComInitialized {
+                    result,
+                    _ptr: PhantomData,
+                }
+            },
+            Err(e) => {
+                // COM initialization failed in another way, something is really wrong.
+                panic!("Failed to initialize COM: {}", IoError::from_raw_os_error(e.0));
+            }
+        }
     }
 });
 

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -4,9 +4,9 @@ use super::IoError;
 use std::marker::PhantomData;
 use std::ptr;
 
-use super::winapi::shared::winerror::{HRESULT, RPC_E_CHANGED_MODE, SUCCEEDED};
-use super::winapi::um::combaseapi::{CoInitializeEx, CoUninitialize};
-use super::winapi::um::objbase::COINIT_APARTMENTTHREADED;
+use windows::core::HRESULT;
+use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
+use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
 
 thread_local!(static COM_INITIALIZED: ComInitialized = {
     unsafe {
@@ -17,7 +17,7 @@ thread_local!(static COM_INITIALIZED: ComInitialized = {
         // That's OK though since COM ensures thread-safety/compatibility through marshalling when
         // necessary.
         let result = CoInitializeEx(ptr::null_mut(), COINIT_APARTMENTTHREADED);
-        if SUCCEEDED(result) || result == RPC_E_CHANGED_MODE {
+        if result.is_ok() || result == RPC_E_CHANGED_MODE {
             ComInitialized {
                 result,
                 _ptr: PhantomData,
@@ -43,7 +43,7 @@ impl Drop for ComInitialized {
     fn drop(&mut self) {
         // Need to avoid calling CoUninitialize() if CoInitializeEx failed since it may have
         // returned RPC_E_MODE_CHANGED - which is OK, see above.
-        if SUCCEEDED(self.result) {
+        if self.result.is_ok() {
             unsafe { CoUninitialize() };
         }
     }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -858,8 +858,8 @@ impl PartialEq for Device {
             // 16-bit null-terminated comparison.
             let mut offset = 0;
             loop {
-                let w1: u16 = *id1.0 .0.offset(offset);
-                let w2: u16 = *id2.0 .0.offset(offset);
+                let w1: u16 = *(id1.0).0.offset(offset);
+                let w2: u16 = *(id2.0).0.offset(offset);
                 if w1 == 0 && w2 == 0 {
                     return true;
                 }

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -197,38 +197,6 @@ pub unsafe fn is_format_supported(
     client: &Audio::IAudioClient,
     waveformatex_ptr: *const Audio::WAVEFORMATEX,
 ) -> Result<bool, SupportedStreamConfigsError> {
-    /*
-    // `IsFormatSupported` checks whether the format is supported and fills
-    // a `WAVEFORMATEX`
-    let mut dummy_fmt_ptr: *mut Audio::WAVEFORMATEX = mem::uninitialized();
-    let hresult =
-        audio_client
-            .IsFormatSupported(share_mode, &format_attempt.Format, &mut dummy_fmt_ptr);
-    // we free that `WAVEFORMATEX` immediately after because we don't need it
-    if !dummy_fmt_ptr.is_null() {
-        CoTaskMemFree(dummy_fmt_ptr as *mut _);
-    }
-
-    // `IsFormatSupported` can return `S_FALSE` (which means that a compatible format
-    // has been found), but we also treat this as an error
-    match (hresult, check_result(hresult)) {
-        (_, Err(ref e))
-            if e.raw_os_error() == Some(AUDCLNT_E_DEVICE_INVALIDATED) => {
-            audio_client.Release();
-            return Err(BuildStreamError::DeviceNotAvailable);
-        },
-        (_, Err(e)) => {
-            audio_client.Release();
-            panic!("{:?}", e);
-        },
-        (Foundation::S_FALSE, _) => {
-            audio_client.Release();
-            return Err(BuildStreamError::StreamConfigNotSupported);
-        },
-        (_, Ok(())) => (),
-    };
-    */
-
     // Check if the given format is supported.
     let is_supported = |waveformatex_ptr, mut closest_waveformatex_ptr| {
         let result = client.IsFormatSupported(

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -245,7 +245,7 @@ unsafe fn format_from_waveformatex_ptr(
     audio_client: &Audio::IAudioClient,
 ) -> Option<SupportedStreamConfig> {
     fn cmp_guid(a: &GUID, b: &GUID) -> bool {
-        a.data1 == b.data1 && a.data2 == b.data2 && a.data3 == b.data3 && a.data4 == b.data4
+        (a.data1, a.data2, a.data3, a.data4) == (b.data1, b.data2, b.data3, b.data4)
     }
     let sample_format = match (
         (*waveformatex_ptr).wBitsPerSample,

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -909,7 +909,8 @@ static ENUMERATOR: Lazy<Enumerator> = Lazy::new(|| {
             &Audio::MMDeviceEnumerator,
             None,
             Com::CLSCTX_ALL,
-        ).unwrap();
+        )
+        .unwrap();
 
         Enumerator(enumerator)
     }

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -1,11 +1,9 @@
-extern crate winapi;
-
 pub use self::device::{
     default_input_device, default_output_device, Device, Devices, SupportedInputConfigs,
     SupportedOutputConfigs,
 };
 pub use self::stream::Stream;
-use self::winapi::um::winnt::HRESULT;
+use windows::core::HRESULT;
 use crate::traits::HostTrait;
 use crate::BackendSpecificError;
 use crate::DevicesError;

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -51,9 +51,9 @@ impl HostTrait for Host {
 
 impl From<windows::core::Error> for BackendSpecificError {
     fn from(error: windows::core::Error) -> Self {
-	BackendSpecificError {
-	    description: format!("{}", IoError::from(error))
-	}
+        BackendSpecificError {
+            description: format!("{}", IoError::from(error))
+        }
     }
 }
 
@@ -63,25 +63,25 @@ trait ErrDeviceNotAvailable: From<BackendSpecificError> {
 
 impl ErrDeviceNotAvailable for crate::BuildStreamError {
     fn device_not_available() -> Self {
-	Self::DeviceNotAvailable
+        Self::DeviceNotAvailable
     }
 }
 
 impl ErrDeviceNotAvailable for crate::SupportedStreamConfigsError {
     fn device_not_available() -> Self {
-	Self::DeviceNotAvailable
+        Self::DeviceNotAvailable
     }
 }
 
 impl ErrDeviceNotAvailable for crate::DefaultStreamConfigError {
     fn device_not_available() -> Self {
-	Self::DeviceNotAvailable
+        Self::DeviceNotAvailable
     }
 }
 
 impl ErrDeviceNotAvailable for crate::StreamError {
     fn device_not_available() -> Self {
-	Self::DeviceNotAvailable
+        Self::DeviceNotAvailable
     }
 }
 
@@ -92,7 +92,7 @@ fn windows_err_to_cpal_err<E: ErrDeviceNotAvailable>(e: windows::core::Error) ->
 fn windows_err_to_cpal_err_message<E: ErrDeviceNotAvailable>(e: windows::core::Error, message: &str) -> E {
     match e.code() {
         Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
-	    E::device_not_available()
+            E::device_not_available()
         }
         _ => {
             let description = format!("{}{}", message, e);

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -3,7 +3,6 @@ pub use self::device::{
     SupportedOutputConfigs,
 };
 pub use self::stream::Stream;
-use windows::core::HRESULT;
 use windows::Win32::Media::Audio;
 use crate::traits::HostTrait;
 use crate::BackendSpecificError;
@@ -50,15 +49,6 @@ impl HostTrait for Host {
     }
 }
 
-#[inline]
-fn check_result(result: HRESULT) -> Result<(), IoError> {
-    if result.is_err() {
-        Err(IoError::from_raw_os_error(result.0))
-    } else {
-        Ok(())
-    }
-}
-
 impl From<windows::core::Error> for BackendSpecificError {
     fn from(error: windows::core::Error) -> Self {
 	BackendSpecificError {
@@ -66,16 +56,6 @@ impl From<windows::core::Error> for BackendSpecificError {
 	}
     }
 }
-
-fn check_result_backend_specific(result: HRESULT) -> Result<(), BackendSpecificError> {
-    match check_result(result) {
-        Ok(()) => Ok(()),
-        Err(err) => Err(BackendSpecificError {
-            description: format!("{}", err),
-        }),
-    }
-}
-
 
 trait ErrDeviceNotAvailable: From<BackendSpecificError> {
     fn device_not_available() -> Self;

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -85,13 +85,11 @@ impl ErrDeviceNotAvailable for crate::StreamError {
     }
 }
 
-// TODO: This isn't just used for audioclient, so rename it
-// appropriately.
-fn audioclient_error<E: ErrDeviceNotAvailable>(e: windows::core::Error) -> E {
-    audioclient_error_message::<E>(e, "")
+fn windows_err_to_cpal_err<E: ErrDeviceNotAvailable>(e: windows::core::Error) -> E {
+    windows_err_to_cpal_err_message::<E>(e, "")
 }
 
-fn audioclient_error_message<E: ErrDeviceNotAvailable>(e: windows::core::Error, message: &str) -> E {
+fn windows_err_to_cpal_err_message<E: ErrDeviceNotAvailable>(e: windows::core::Error, message: &str) -> E {
     match e.code() {
         Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
 	    E::device_not_available()

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -3,11 +3,11 @@ pub use self::device::{
     SupportedOutputConfigs,
 };
 pub use self::stream::Stream;
-use windows::Win32::Media::Audio;
 use crate::traits::HostTrait;
 use crate::BackendSpecificError;
 use crate::DevicesError;
 use std::io::Error as IoError;
+use windows::Win32::Media::Audio;
 
 mod com;
 mod device;
@@ -52,7 +52,7 @@ impl HostTrait for Host {
 impl From<windows::core::Error> for BackendSpecificError {
     fn from(error: windows::core::Error) -> Self {
         BackendSpecificError {
-            description: format!("{}", IoError::from(error))
+            description: format!("{}", IoError::from(error)),
         }
     }
 }
@@ -89,11 +89,12 @@ fn windows_err_to_cpal_err<E: ErrDeviceNotAvailable>(e: windows::core::Error) ->
     windows_err_to_cpal_err_message::<E>(e, "")
 }
 
-fn windows_err_to_cpal_err_message<E: ErrDeviceNotAvailable>(e: windows::core::Error, message: &str) -> E {
+fn windows_err_to_cpal_err_message<E: ErrDeviceNotAvailable>(
+    e: windows::core::Error,
+    message: &str,
+) -> E {
     match e.code() {
-        Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
-            E::device_not_available()
-        }
+        Audio::AUDCLNT_E_DEVICE_INVALIDATED => E::device_not_available(),
         _ => {
             let description = format!("{}{}", message, e);
             let err = BackendSpecificError { description };

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -96,7 +96,7 @@ impl Stream {
                 windows::core::PCSTR(ptr::null()),
             )
         }
-        .unwrap(); // TODO: ADD ERROR MESSAGE
+        .expect("cpal: could not create input stream event")
         let (tx, rx) = channel();
 
         let run_context = RunContext {
@@ -134,7 +134,7 @@ impl Stream {
                 windows::core::PCSTR(ptr::null()),
             )
         }
-        .unwrap(); // TODO: GIVE SPECIFIC ERROR MESSAGE
+        .expect("cpal: could not create output stream event");
         let (tx, rx) = channel();
 
         let run_context = RunContext {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -96,7 +96,7 @@ impl Stream {
                 windows::core::PCSTR(ptr::null()),
             )
         }
-        .expect("cpal: could not create input stream event")
+        .expect("cpal: could not create input stream event");
         let (tx, rx) = channel();
 
         let run_context = RunContext {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -193,15 +193,15 @@ fn process_commands(run_context: &mut RunContext) -> Result<bool, StreamError> {
         match command {
             Command::PlayStream => unsafe {
                 if !run_context.stream.playing {
-		    run_context.stream.audio_client.Start()
-			.map_err(windows_err_to_cpal_err::<StreamError>)?;
+                    run_context.stream.audio_client.Start()
+                        .map_err(windows_err_to_cpal_err::<StreamError>)?;
                     run_context.stream.playing = true;
                 }
             }
             Command::PauseStream => unsafe {
                 if run_context.stream.playing {
-		    run_context.stream.audio_client.Stop()
-			.map_err(windows_err_to_cpal_err::<StreamError>)?;
+                    run_context.stream.audio_client.Stop()
+                        .map_err(windows_err_to_cpal_err::<StreamError>)?;
                     run_context.stream.playing = false;
                 }
             }
@@ -225,7 +225,7 @@ fn wait_for_handle_signal(handles: &[Foundation::HANDLE]) -> Result<usize, Backe
     debug_assert!(handles.len() <= SystemServices::MAXIMUM_WAIT_OBJECTS as usize);
     let result = unsafe {
         Threading::WaitForMultipleObjectsEx(
-	    handles,
+            handles,
             false,             // Don't wait for all, just wait for the first
             WindowsProgramming::INFINITE, // TODO: allow setting a timeout
             false,             // irrelevant parameter here
@@ -245,8 +245,8 @@ fn wait_for_handle_signal(handles: &[Foundation::HANDLE]) -> Result<usize, Backe
 // Get the number of available frames that are available for writing/reading.
 fn get_available_frames(stream: &StreamInner) -> Result<u32, StreamError> {
     unsafe {
-	let padding = stream.audio_client.GetCurrentPadding()
-	    .map_err(windows_err_to_cpal_err::<StreamError>)?;
+        let padding = stream.audio_client.GetCurrentPadding()
+            .map_err(windows_err_to_cpal_err::<StreamError>)?;
         Ok(stream.max_frames_in_buffer - padding)
     }
 }
@@ -354,14 +354,14 @@ fn process_input(
         let mut buffer: *mut u8 = ptr::null_mut();
         let mut flags = mem::MaybeUninit::uninit();
         loop {
-	    let mut frames_available = match capture_client.GetNextPacketSize() {
-		Ok(0) => return ControlFlow::Continue,
-		Ok(f) => f,
-		Err(err) => {
-		    error_callback(windows_err_to_cpal_err(err));
-		    return ControlFlow::Break;
-		}
-	    };
+            let mut frames_available = match capture_client.GetNextPacketSize() {
+                Ok(0) => return ControlFlow::Continue,
+                Ok(f) => f,
+                Err(err) => {
+                    error_callback(windows_err_to_cpal_err(err));
+                    return ControlFlow::Break;
+                }
+            };
             let mut qpc_position: u64 = 0;
             let result = capture_client.GetBuffer(
                 &mut buffer,
@@ -371,15 +371,15 @@ fn process_input(
                 &mut qpc_position,
             );
 
-	    match result {
-		// TODO: Can this happen?
-		Err(e) if e.code() == Audio::AUDCLNT_S_BUFFER_EMPTY => continue,
-		Err(e) => {
-		    error_callback(windows_err_to_cpal_err(e));
-		    return ControlFlow::Break;
-		},
-		Ok(_) => (),
-	    }
+            match result {
+                // TODO: Can this happen?
+                Err(e) if e.code() == Audio::AUDCLNT_S_BUFFER_EMPTY => continue,
+                Err(e) => {
+                    error_callback(windows_err_to_cpal_err(e));
+                    return ControlFlow::Break;
+                },
+                Ok(_) => (),
+            }
 
             debug_assert!(!buffer.is_null());
 
@@ -428,13 +428,13 @@ fn process_output(
     };
 
     unsafe {
-	let buffer = match render_client.GetBuffer(frames_available) {
-	    Ok(b) => b,
-	    Err(e) => {
-		error_callback(windows_err_to_cpal_err(e));
-		return ControlFlow::Break;
-	    }
-	};
+        let buffer = match render_client.GetBuffer(frames_available) {
+            Ok(b) => b,
+            Err(e) => {
+                error_callback(windows_err_to_cpal_err(e));
+                return ControlFlow::Break;
+            }
+        };
 
         debug_assert!(!buffer.is_null());
 
@@ -453,10 +453,10 @@ fn process_output(
         let info = OutputCallbackInfo { timestamp };
         data_callback(&mut data, &info);
 
-	if let Err(err) = render_client.ReleaseBuffer(frames_available, 0) {
-	    error_callback(windows_err_to_cpal_err(err));
-	    return ControlFlow::Break;
-	}
+        if let Err(err) = render_client.ReleaseBuffer(frames_available, 0) {
+            error_callback(windows_err_to_cpal_err(err));
+            return ControlFlow::Break;
+        }
     }
 
     ControlFlow::Continue
@@ -477,7 +477,7 @@ fn stream_instant(stream: &StreamInner) -> Result<crate::StreamInstant, StreamEr
     let mut position: u64 = 0;
     let mut qpc_position: u64 = 0;
     unsafe {
-	stream.audio_clock.GetPosition(&mut position, &mut qpc_position)
+        stream.audio_clock.GetPosition(&mut position, &mut qpc_position)
             .map_err(windows_err_to_cpal_err::<StreamError>)?;
     };
         // The `qpc_position` is in 100 nanosecond units. Convert it to nanoseconds.

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,4 +1,3 @@
-use super::check_result;
 use super::audioclient_error;
 // use super::winapi::shared::basetsd::{UINT32, UINT64};
 // use super::winapi::shared::minwindef::{BYTE, FALSE, WORD};
@@ -7,7 +6,6 @@ use super::audioclient_error;
 // use super::winapi::um::synchapi;
 // use super::winapi::um::winbase;
 // use super::winapi::um::winnt;
-use windows::core;
 use windows::Win32::Foundation;
 use windows::Win32::Media::Audio;
 use windows::Win32::System::Threading;
@@ -260,19 +258,6 @@ fn get_available_frames(stream: &StreamInner) -> Result<u32, StreamError> {
     }
 }
 
-// Convert the given `HRESULT` into a `StreamError` if it does indicate an error.
-fn stream_error_from_hresult(hresult: core::HRESULT) -> Result<(), StreamError> {
-    if hresult == Audio::AUDCLNT_E_DEVICE_INVALIDATED {
-        return Err(StreamError::DeviceNotAvailable);
-    }
-    if let Err(err) = check_result(hresult) {
-        let description = format!("{}", err);
-        let err = BackendSpecificError { description };
-        return Err(err.into());
-    }
-    Ok(())
-}
-
 fn run_input(
     mut run_ctxt: RunContext,
     data_callback: &mut dyn FnMut(&Data, &InputCallbackInfo),
@@ -371,7 +356,6 @@ fn process_input(
     data_callback: &mut dyn FnMut(&Data, &InputCallbackInfo),
     error_callback: &mut dyn FnMut(StreamError),
 ) -> ControlFlow {
-    let mut frames_available = 0;
     unsafe {
         // Get the available data in the shared buffer.
         let mut buffer: *mut u8 = ptr::null_mut();


### PR DESCRIPTION
I migrated to `windows-rs` in this PR since exposing the buffer size range for hardware-offloaded audio processing requires `IAudioClient2`, which isn't exposed in the `winapi` crate, and `winapi` seems to be more or less unmaintained at this point.

Regarding fixed buffer sizes - `wasapi` doesn't seem to support requesting *exact* audio buffer sizes, but will always get an audio buffer that is at least the size requested. Should that be mentioned in the documentation? Also, the buffer exposed to the `data_callback` doesn't always match the size of the buffer requested, since `wasapi` incrementally updates the buffer as audio gets played, instead of updating it all at once once the buffer is cleared. I'm not sure if that's standard behavior or not but it may also be worth documenting.

Related to #544, #534, #667, and #616. @est31, you'd mentioned at https://github.com/RustAudio/cpal/issues/616#issuecomment-969904220 that `windows-rs` had some issues with cross-compilation, but from what I can tell from skimming their issue tracker the cross-compilation issues have been addressed. Are there other issues there that are unresolved?