### PR TITLE
Update dependencies, switch to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,28 +28,28 @@ ndk-glue = "0.6"
 winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
-parking_lot = "0.11"
-lazy_static = "1.4"
+parking_lot = "0.12"
+once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.23"
+nix = "0.24"
 libc = "0.2.65"
 parking_lot = "0.12"
-jack = { version = "0.9", optional = true }
+jack = { version = "0.10", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
 mach = "0.3" # For access to mach_timebase type.
 
 [target.'cfg(target_os = "macos")'.dependencies]
-coreaudio-rs = { version = "0.10.0", default-features = false, features = ["audio_unit", "core_audio"] }
+coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coreaudio-rs = { version = "0.10.0", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
+coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-stdweb = { version = "0.1.3", default-features = false }
+stdweb = { version = "0.4", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.58", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,23 +33,23 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.24"
+nix = "0.23"
 libc = "0.2.65"
 parking_lot = "0.12"
-jack = { version = "0.10", optional = true }
+jack = { version = "0.9", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
 mach = "0.3" # For access to mach_timebase type.
 
 [target.'cfg(target_os = "macos")'.dependencies]
-coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio"] }
+coreaudio-rs = { version = "0.10", default-features = false, features = ["audio_unit", "core_audio"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
+coreaudio-rs = { version = "0.10", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-stdweb = { version = "0.4", default-features = false }
+stdweb = { version = "0.1.3", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.58", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "3.1", default-features = false, features = ["std"] }
 ndk-glue = "0.6"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
+winapi = { version = "0.3", features = ["audiosessiontypes", "audioclient", "coml2api", "combaseapi", "debug", "devpkey", "errhandlingapi", "handleapi", "ksmedia", "mmdeviceapi", "objbase", "profileapi", "std", "synchapi", "winbase", "winuser"] }
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.12"

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -15,6 +15,6 @@ walkdir = "2"
 cc = "1.0.25"
 
 [dependencies]
-lazy_static = "1.0.0"
+once_cell = "1.12"
 num-derive = "0.3"
 num-traits = "0.2"

--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -4,6 +4,7 @@ pub mod errors;
 
 use self::errors::{AsioError, AsioErrorWrapper, LoadDriverError};
 use num_traits::FromPrimitive;
+use once_cell::sync::Lazy;
 use std::ffi::CStr;
 use std::ffi::CString;
 use std::os::raw::{c_char, c_double, c_long, c_void};
@@ -248,17 +249,16 @@ struct BufferSizes {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CallbackId(usize);
 
-lazy_static! {
-    /// A global way to access all the callbacks.
-    ///
-    /// This is required because of how ASIO calls the `buffer_switch` function with no data
-    /// parameters.
-    ///
-    /// Options are used so that when a callback is removed we don't change the Vec indices.
-    ///
-    /// The indices are how we match a callback with a stream.
-    static ref BUFFER_CALLBACK: Mutex<Vec<(CallbackId, BufferCallback)>> = Mutex::new(Vec::new());
-}
+/// A global way to access all the callbacks.
+///
+/// This is required because of how ASIO calls the `buffer_switch` function with no data
+/// parameters.
+///
+/// Options are used so that when a callback is removed we don't change the Vec indices.
+///
+/// The indices are how we match a callback with a stream.
+static BUFFER_CALLBACK: Lazy<Mutex<Vec<(CallbackId, BufferCallback)>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
 
 impl Asio {
     /// Initialise the ASIO API.

--- a/asio-sys/src/lib.rs
+++ b/asio-sys/src/lib.rs
@@ -2,10 +2,6 @@
 
 #[allow(unused_imports)]
 #[macro_use]
-extern crate lazy_static;
-
-#[allow(unused_imports)]
-#[macro_use]
 extern crate num_derive;
 #[allow(unused_imports)]
 extern crate num_traits;

--- a/asio-sys/src/lib.rs
+++ b/asio-sys/src/lib.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 
 #[allow(unused_imports)]
+extern crate once_cell;
+
+#[allow(unused_imports)]
 #[macro_use]
 extern crate num_derive;
 #[allow(unused_imports)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@
 //! stream.pause().unwrap();
 //! ```
 
-#![recursion_limit = "512"]
+#![recursion_limit = "2048"]
 
 // Extern crate declarations with `#[macro_use]` must unfortunately be at crate root.
 #[cfg(target_os = "emscripten")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,9 +143,6 @@
 
 #![recursion_limit = "512"]
 
-#[cfg(target_os = "windows")]
-#[macro_use]
-extern crate lazy_static;
 // Extern crate declarations with `#[macro_use]` must unfortunately be at crate root.
 #[cfg(target_os = "emscripten")]
 #[macro_use]


### PR DESCRIPTION
Updates all of the dependencies that are currently outdated and switches lazy_static to once_cell. Fixes #670.