### PR TITLE
migrate Sample to dasp_sample

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for se
 
 [dependencies]
 thiserror = "1.0.2"
+dasp_sample = "0.11.0"
 
 [dev-dependencies]
 anyhow = "1.0.12"

--- a/examples/android.rs
+++ b/examples/android.rs
@@ -3,7 +3,8 @@
 extern crate anyhow;
 extern crate cpal;
 
-use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::{traits::{DeviceTrait, HostTrait, StreamTrait}, SizedSample};
+use cpal::{Sample, FromSample};
 
 #[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
 fn main() {
@@ -16,15 +17,27 @@ fn main() {
     let config = device.default_output_config().unwrap();
 
     match config.sample_format() {
-        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::I8 => run::<i8>(&device, &config.into()).unwrap(),
         cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()).unwrap(),
+        // cpal::SampleFormat::I24 => run::<I24>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::I32 => run::<i32>(&device, &config.into()).unwrap(),
+        // cpal::SampleFormat::I48 => run::<I48>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::I64 => run::<i64>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::U8 => run::<u8>(&device, &config.into()).unwrap(),
         cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()).unwrap(),
+        // cpal::SampleFormat::U24 => run::<U24>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::U32 => run::<u32>(&device, &config.into()).unwrap(),
+        // cpal::SampleFormat::U48 => run::<U48>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::U64 => run::<u64>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()).unwrap(),
+        cpal::SampleFormat::F64 => run::<f64>(&device, &config.into()).unwrap(),
+        sample_format => panic!("Unsupported sample format '{sample_format}'"),
     }
 }
 
 fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Result<(), anyhow::Error>
 where
-    T: cpal::Sample,
+    T: SizedSample + FromSample<f32>,
 {
     let sample_rate = config.sample_rate.0 as f32;
     let channels = config.channels as usize;
@@ -54,10 +67,10 @@ where
 
 fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
 where
-    T: cpal::Sample,
+    T: Sample + FromSample<f32>,
 {
     for frame in output.chunks_mut(channels) {
-        let value: T = cpal::Sample::from::<f32>(&next_sample());
+        let value: T = T::from_sample(next_sample());
         for sample in frame.iter_mut() {
             *sample = value;
         }

--- a/examples/android.rs
+++ b/examples/android.rs
@@ -3,8 +3,11 @@
 extern crate anyhow;
 extern crate cpal;
 
-use cpal::{traits::{DeviceTrait, HostTrait, StreamTrait}, SizedSample};
-use cpal::{Sample, FromSample};
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    SizedSample,
+};
+use cpal::{FromSample, Sample};
 
 #[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "full"))]
 fn main() {

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -3,8 +3,11 @@ extern crate clap;
 extern crate cpal;
 
 use clap::arg;
-use cpal::{traits::{DeviceTrait, HostTrait, StreamTrait}, SizedSample};
-use cpal::{Sample, FromSample};
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    SizedSample,
+};
+use cpal::{FromSample, Sample};
 
 #[derive(Debug)]
 struct Opt {

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -133,7 +133,7 @@ fn main() -> Result<(), anyhow::Error> {
             move |data, _: &_| write_input_data::<f32, f32>(data, &writer_2),
             err_fn,
         )?,
-        sample_format => return Err(anyhow::Error::msg(format!("Unsupported sample formet '{sample_format}'"))),
+        sample_format => return Err(anyhow::Error::msg(format!("Unsupported sample format '{sample_format}'"))),
     };
 
     stream.play()?;

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -133,7 +133,11 @@ fn main() -> Result<(), anyhow::Error> {
             move |data, _: &_| write_input_data::<f32, f32>(data, &writer_2),
             err_fn,
         )?,
-        sample_format => return Err(anyhow::Error::msg(format!("Unsupported sample format '{sample_format}'"))),
+        sample_format => {
+            return Err(anyhow::Error::msg(format!(
+                "Unsupported sample format '{sample_format}'"
+            )))
+        }
     };
 
     stream.play()?;
@@ -147,7 +151,11 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 fn sample_format(format: cpal::SampleFormat) -> hound::SampleFormat {
-    if format.is_float() { hound::SampleFormat::Float } else { hound::SampleFormat::Int }
+    if format.is_float() {
+        hound::SampleFormat::Float
+    } else {
+        hound::SampleFormat::Int
+    }
 }
 
 fn wav_spec_from_config(config: &cpal::SupportedStreamConfig) -> hound::WavSpec {

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -6,8 +6,11 @@ extern crate anyhow;
 extern crate clap;
 extern crate cpal;
 
-use cpal::{traits::{DeviceTrait, HostTrait, StreamTrait}, SizedSample};
-use cpal::{Sample, FromSample};
+use cpal::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
+    SizedSample,
+};
+use cpal::{FromSample, Sample};
 
 fn main() -> anyhow::Result<()> {
     let stream = stream_setup_for(sample_next)?;
@@ -58,7 +61,9 @@ where
         cpal::SampleFormat::U64 => stream_make::<u64, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::F32 => stream_make::<f32, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::F64 => stream_make::<f64, _>(&device, &config.into(), on_sample),
-        sample_format => Err(anyhow::Error::msg(format!("Unsupported sample format '{sample_format}'"))),
+        sample_format => Err(anyhow::Error::msg(format!(
+            "Unsupported sample format '{sample_format}'"
+        ))),
     }
 }
 

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -58,7 +58,7 @@ where
         cpal::SampleFormat::U64 => stream_make::<u64, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::F32 => stream_make::<f32, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::F64 => stream_make::<f64, _>(&device, &config.into(), on_sample),
-        sample_format => Err(anyhow::Error::msg(format!("Unsupported sample formet '{sample_format}'"))),
+        sample_format => Err(anyhow::Error::msg(format!("Unsupported sample format '{sample_format}'"))),
     }
 }
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -970,9 +970,14 @@ fn set_hw_params_from_format(
             // SampleFormat::U64 => alsa::pcm::Format::U64BE,
             SampleFormat::F32 => alsa::pcm::Format::FloatBE,
             SampleFormat::F64 => alsa::pcm::Format::Float64BE,
-            sample_format => return Err(BackendSpecificError {
-                description: format!("Sample format '{}' is not supported by this backend", sample_format),
-            })
+            sample_format => {
+                return Err(BackendSpecificError {
+                    description: format!(
+                        "Sample format '{}' is not supported by this backend",
+                        sample_format
+                    ),
+                })
+            }
         }
     } else {
         match sample_format {
@@ -990,9 +995,14 @@ fn set_hw_params_from_format(
             // SampleFormat::U64 => alsa::pcm::Format::U64LE,
             SampleFormat::F32 => alsa::pcm::Format::FloatLE,
             SampleFormat::F64 => alsa::pcm::Format::Float64LE,
-            sample_format => return Err(BackendSpecificError {
-                description: format!("Sample format '{}' is not supported by this backend", sample_format),
-            })
+            sample_format => {
+                return Err(BackendSpecificError {
+                    description: format!(
+                        "Sample format '{}' is not supported by this backend",
+                        sample_format
+                    ),
+                })
+            }
         }
     };
 

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -312,9 +312,9 @@ impl Device {
         let hw_params = alsa::pcm::HwParams::any(handle)?;
 
         // TODO: check endianness
-        const FORMATS: [(SampleFormat, alsa::pcm::Format); 3] = [
-            //SND_PCM_FORMAT_S8,
-            //SND_PCM_FORMAT_U8,
+        const FORMATS: [(SampleFormat, alsa::pcm::Format); 8] = [
+            (SampleFormat::I8, alsa::pcm::Format::S8),
+            (SampleFormat::U8, alsa::pcm::Format::U8),
             (SampleFormat::I16, alsa::pcm::Format::S16LE),
             //SND_PCM_FORMAT_S16_BE,
             (SampleFormat::U16, alsa::pcm::Format::U16LE),
@@ -323,13 +323,13 @@ impl Device {
             //SND_PCM_FORMAT_S24_BE,
             //SND_PCM_FORMAT_U24_LE,
             //SND_PCM_FORMAT_U24_BE,
-            //SND_PCM_FORMAT_S32_LE,
+            (SampleFormat::I32, alsa::pcm::Format::S32LE),
             //SND_PCM_FORMAT_S32_BE,
-            //SND_PCM_FORMAT_U32_LE,
+            (SampleFormat::U32, alsa::pcm::Format::U32LE),
             //SND_PCM_FORMAT_U32_BE,
             (SampleFormat::F32, alsa::pcm::Format::FloatLE),
             //SND_PCM_FORMAT_FLOAT_BE,
-            //SND_PCM_FORMAT_FLOAT64_LE,
+            (SampleFormat::F64, alsa::pcm::Format::Float64LE),
             //SND_PCM_FORMAT_FLOAT64_BE,
             //SND_PCM_FORMAT_IEC958_SUBFRAME_LE,
             //SND_PCM_FORMAT_IEC958_SUBFRAME_BE,
@@ -956,15 +956,43 @@ fn set_hw_params_from_format(
 
     let sample_format = if cfg!(target_endian = "big") {
         match sample_format {
+            SampleFormat::I8 => alsa::pcm::Format::S8,
             SampleFormat::I16 => alsa::pcm::Format::S16BE,
+            // SampleFormat::I24 => alsa::pcm::Format::S24BE,
+            SampleFormat::I32 => alsa::pcm::Format::S32BE,
+            // SampleFormat::I48 => alsa::pcm::Format::S48BE,
+            // SampleFormat::I64 => alsa::pcm::Format::S64BE,
+            SampleFormat::U8 => alsa::pcm::Format::U8,
             SampleFormat::U16 => alsa::pcm::Format::U16BE,
+            // SampleFormat::U24 => alsa::pcm::Format::U24BE,
+            SampleFormat::U32 => alsa::pcm::Format::U32BE,
+            // SampleFormat::U48 => alsa::pcm::Format::U48BE,
+            // SampleFormat::U64 => alsa::pcm::Format::U64BE,
             SampleFormat::F32 => alsa::pcm::Format::FloatBE,
+            SampleFormat::F64 => alsa::pcm::Format::Float64BE,
+            sample_format => return Err(BackendSpecificError {
+                description: format!("Sample format '{}' is not supported by this backend", sample_format),
+            })
         }
     } else {
         match sample_format {
+            SampleFormat::I8 => alsa::pcm::Format::S8,
             SampleFormat::I16 => alsa::pcm::Format::S16LE,
+            // SampleFormat::I24 => alsa::pcm::Format::S24LE,
+            SampleFormat::I32 => alsa::pcm::Format::S32LE,
+            // SampleFormat::I48 => alsa::pcm::Format::S48LE,
+            // SampleFormat::I64 => alsa::pcm::Format::S64LE,
+            SampleFormat::U8 => alsa::pcm::Format::U8,
             SampleFormat::U16 => alsa::pcm::Format::U16LE,
+            // SampleFormat::U24 => alsa::pcm::Format::U24LE,
+            SampleFormat::U32 => alsa::pcm::Format::U32LE,
+            // SampleFormat::U48 => alsa::pcm::Format::U48LE,
+            // SampleFormat::U64 => alsa::pcm::Format::U64LE,
             SampleFormat::F32 => alsa::pcm::Format::FloatLE,
+            SampleFormat::F64 => alsa::pcm::Format::Float64LE,
+            sample_format => return Err(BackendSpecificError {
+                description: format!("Sample format '{}' is not supported by this backend", sample_format),
+            })
         }
     };
 

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -61,7 +61,7 @@ impl Device {
     ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
         // Retrieve the default config for the total supported channels and supported sample
         // format.
-        let mut f = match self.default_input_config() {
+        let f = match self.default_input_config() {
             Err(_) => return Err(SupportedStreamConfigsError::DeviceNotAvailable),
             Ok(f) => f,
         };
@@ -98,7 +98,7 @@ impl Device {
     ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
         // Retrieve the default config for the total supported channels and supported sample
         // format.
-        let mut f = match self.default_output_config() {
+        let f = match self.default_output_config() {
             Err(_) => return Err(SupportedStreamConfigsError::DeviceNotAvailable),
             Ok(f) => f,
         };

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -1,12 +1,12 @@
 extern crate asio_sys as sys;
 extern crate parking_lot;
 
+use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat,
     StreamConfig, StreamError, SupportedStreamConfig, SupportedStreamConfigsError,
 };
-use traits::{DeviceTrait, HostTrait, StreamTrait};
 
 pub use self::device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs};
 pub use self::stream::Stream;

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -13,21 +13,6 @@ use std;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-/// Sample types whose constant silent value is known.
-trait Silence {
-    const SILENCE: Self;
-}
-
-/// Constraints on the ASIO sample types.
-trait AsioSample: Clone + Copy + Silence + std::ops::Add<Self, Output = Self> {
-    fn to_cpal_sample<T>(self) -> T
-    where
-        T: FromSample<Self>;
-    fn from_cpal_sample<T>(_: T) -> Self
-    where
-        Self: FromSample<T>;
-}
-
 // Used to keep track of whether or not the current asio stream buffer requires
 // being silencing before summing audio.
 #[derive(Default)]
@@ -107,7 +92,7 @@ impl Device {
 
             /// 1. Write from the ASIO buffer to the interleaved CPAL buffer.
             /// 2. Deliver the CPAL buffer to the user callback.
-            unsafe fn process_input_callback<A, B, D, F>(
+            unsafe fn process_input_callback<A, D, F>(
                 data_callback: &mut D,
                 interleaved: &mut [u8],
                 asio_stream: &sys::AsioStream,
@@ -115,27 +100,26 @@ impl Device {
                 sample_rate: crate::SampleRate,
                 from_endianness: F,
             ) where
-                A: AsioSample,
-                B: Sample,
+                A: SizedSample,
                 D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
                 F: Fn(A) -> A,
             {
                 // 1. Write the ASIO channels to the CPAL buffer.
-                let interleaved: &mut [B] = cast_slice_mut(interleaved);
+                let interleaved: &mut [A] = cast_slice_mut(interleaved);
                 let n_frames = asio_stream.buffer_size as usize;
                 let n_channels = interleaved.len() / n_frames;
                 let buffer_index = asio_info.buffer_index as usize;
                 for ch_ix in 0..n_channels {
                     let asio_channel = asio_channel_slice::<A>(asio_stream, buffer_index, ch_ix);
                     for (frame, s_asio) in interleaved.chunks_mut(n_channels).zip(asio_channel) {
-                        frame[ch_ix] = from_endianness(*s_asio).to_cpal_sample();
+                        frame[ch_ix] = from_endianness(*s_asio);
                     }
                 }
 
                 // 2. Deliver the interleaved buffer to the callback.
                 let data = interleaved.as_mut_ptr() as *mut ();
                 let len = interleaved.len();
-                let data = Data::from_parts(data, len, B::FORMAT);
+                let data = Data::from_parts(data, len, A::FORMAT);
                 let callback = system_time_to_stream_instant(asio_info.system_time);
                 let delay = frames_to_duration(n_frames, sample_rate);
                 let capture = callback
@@ -148,7 +132,7 @@ impl Device {
 
             match (&stream_type, sample_format) {
                 (&sys::AsioSampleType::ASIOSTInt16LSB, SampleFormat::I16) => {
-                    process_input_callback::<i16, i16, _, _>(
+                    process_input_callback::<i16, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -158,7 +142,7 @@ impl Device {
                     );
                 }
                 (&sys::AsioSampleType::ASIOSTInt16MSB, SampleFormat::I16) => {
-                    process_input_callback::<i16, i16, _, _>(
+                    process_input_callback::<i16, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -172,7 +156,7 @@ impl Device {
                 // trait for the `to_le` and `to_be` methods, but this does not support floats.
                 (&sys::AsioSampleType::ASIOSTFloat32LSB, SampleFormat::F32)
                 | (&sys::AsioSampleType::ASIOSTFloat32MSB, SampleFormat::F32) => {
-                    process_input_callback::<f32, f32, _, _>(
+                    process_input_callback::<f32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -182,11 +166,8 @@ impl Device {
                     );
                 }
 
-                // TODO: Add support for the following sample formats to CPAL and simplify the
-                // `process_output_callback` function above by removing the unnecessary sample
-                // conversion function.
-                (&sys::AsioSampleType::ASIOSTInt32LSB, SampleFormat::I16) => {
-                    process_input_callback::<i32, i16, _, _>(
+                (&sys::AsioSampleType::ASIOSTInt32LSB, SampleFormat::I32) => {
+                    process_input_callback::<i32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -195,8 +176,8 @@ impl Device {
                         from_le,
                     );
                 }
-                (&sys::AsioSampleType::ASIOSTInt32MSB, SampleFormat::I16) => {
-                    process_input_callback::<i32, i16, _, _>(
+                (&sys::AsioSampleType::ASIOSTInt32MSB, SampleFormat::I32) => {
+                    process_input_callback::<i32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -205,11 +186,12 @@ impl Device {
                         from_be,
                     );
                 }
+
                 // TODO: Handle endianness conversion for floats? We currently use the `PrimInt`
                 // trait for the `to_le` and `to_be` methods, but this does not support floats.
-                (&sys::AsioSampleType::ASIOSTFloat64LSB, SampleFormat::F32)
-                | (&sys::AsioSampleType::ASIOSTFloat64MSB, SampleFormat::F32) => {
-                    process_input_callback::<f64, f32, _, _>(
+                (&sys::AsioSampleType::ASIOSTFloat64LSB, SampleFormat::F64)
+                | (&sys::AsioSampleType::ASIOSTFloat64MSB, SampleFormat::F64) => {
+                    process_input_callback::<f64, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         asio_stream,
@@ -314,7 +296,7 @@ impl Device {
             /// 2. If required, silence the ASIO buffer.
             /// 3. Finally, write the interleaved data to the non-interleaved ASIO buffer,
             ///    performing endianness conversions as necessary.
-            unsafe fn process_output_callback<A, B, D, F>(
+            unsafe fn process_output_callback<A, D, F>(
                 data_callback: &mut D,
                 interleaved: &mut [u8],
                 silence_asio_buffer: bool,
@@ -324,9 +306,8 @@ impl Device {
                 to_endianness: F,
             ) where
                 A: SizedSample,
-                B: AsioSample,
                 D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
-                F: Fn(B) -> B,
+                F: Fn(A) -> A,
             {
                 // 1. Render interleaved buffer from callback.
                 let interleaved: &mut [A] = cast_slice_mut(interleaved);
@@ -349,26 +330,26 @@ impl Device {
                 if silence_asio_buffer {
                     for ch_ix in 0..n_channels {
                         let asio_channel =
-                            asio_channel_slice_mut::<B>(asio_stream, buffer_index, ch_ix);
+                            asio_channel_slice_mut::<A>(asio_stream, buffer_index, ch_ix);
                         asio_channel
                             .iter_mut()
-                            .for_each(|s| *s = to_endianness(B::SILENCE));
+                            .for_each(|s| *s = to_endianness(A::EQUILIBRIUM));
                     }
                 }
 
                 // 3. Write interleaved samples to ASIO channels, one channel at a time.
                 for ch_ix in 0..n_channels {
                     let asio_channel =
-                        asio_channel_slice_mut::<B>(asio_stream, buffer_index, ch_ix);
+                        asio_channel_slice_mut::<A>(asio_stream, buffer_index, ch_ix);
                     for (frame, s_asio) in interleaved.chunks(n_channels).zip(asio_channel) {
-                        *s_asio = *s_asio + to_endianness(B::from_cpal_sample(&frame[ch_ix]));
+                        *s_asio = *s_asio + to_endianness(A::from_sample(frame[ch_ix]));
                     }
                 }
             }
 
             match (sample_format, &stream_type) {
                 (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt16LSB) => {
-                    process_output_callback::<i16, i16, _, _>(
+                    process_output_callback::<i16, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -379,7 +360,7 @@ impl Device {
                     );
                 }
                 (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt16MSB) => {
-                    process_output_callback::<i16, i16, _, _>(
+                    process_output_callback::<i16, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -394,7 +375,7 @@ impl Device {
                 // trait for the `to_le` and `to_be` methods, but this does not support floats.
                 (SampleFormat::F32, &sys::AsioSampleType::ASIOSTFloat32LSB)
                 | (SampleFormat::F32, &sys::AsioSampleType::ASIOSTFloat32MSB) => {
-                    process_output_callback::<f32, f32, _, _>(
+                    process_output_callback::<f32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -405,11 +386,8 @@ impl Device {
                     );
                 }
 
-                // TODO: Add support for the following sample formats to CPAL and simplify the
-                // `process_output_callback` function above by removing the unnecessary sample
-                // conversion function.
-                (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt32LSB) => {
-                    process_output_callback::<i16, i32, _, _>(
+                (SampleFormat::I32, &sys::AsioSampleType::ASIOSTInt32LSB) => {
+                    process_output_callback::<i32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -419,8 +397,8 @@ impl Device {
                         to_le,
                     );
                 }
-                (SampleFormat::I16, &sys::AsioSampleType::ASIOSTInt32MSB) => {
-                    process_output_callback::<i16, i32, _, _>(
+                (SampleFormat::I32, &sys::AsioSampleType::ASIOSTInt32MSB) => {
+                    process_output_callback::<i32, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -430,11 +408,12 @@ impl Device {
                         to_be,
                     );
                 }
+
                 // TODO: Handle endianness conversion for floats? We currently use the `PrimInt`
                 // trait for the `to_le` and `to_be` methods, but this does not support floats.
-                (SampleFormat::F32, &sys::AsioSampleType::ASIOSTFloat64LSB)
-                | (SampleFormat::F32, &sys::AsioSampleType::ASIOSTFloat64MSB) => {
-                    process_output_callback::<f32, f64, _, _>(
+                (SampleFormat::F64, &sys::AsioSampleType::ASIOSTFloat64LSB)
+                | (SampleFormat::F64, &sys::AsioSampleType::ASIOSTFloat64MSB) => {
+                    process_output_callback::<f64, _, _>(
                         &mut data_callback,
                         &mut interleaved,
                         silence,
@@ -567,86 +546,6 @@ impl Device {
 impl Drop for Stream {
     fn drop(&mut self) {
         self.driver.remove_callback(self.callback_id);
-    }
-}
-
-impl Silence for i16 {
-    const SILENCE: Self = 0;
-}
-
-impl Silence for i32 {
-    const SILENCE: Self = 0;
-}
-
-impl Silence for f32 {
-    const SILENCE: Self = 0.0;
-}
-
-impl Silence for f64 {
-    const SILENCE: Self = 0.0;
-}
-
-impl AsioSample for i16 {
-    fn to_cpal_sample<T>(self) -> T
-    where
-        T: FromSample<Self>,
-    {
-        T::from_sample(self)
-    }
-    fn from_cpal_sample<T>(t: T) -> Self
-    where
-        Self: FromSample<T>,
-    {
-        Self::from_sample(t)
-    }
-}
-
-impl AsioSample for i32 {
-    fn to_cpal_sample<T>(self) -> T
-    where
-        T: FromSample<Self>,
-    {
-        let s = (*self >> 16) as i16;
-        s.to_cpal_sample()
-    }
-    fn from_cpal_sample<T>(t: T) -> Self
-    where
-        Self: FromSample<T>,
-    {
-        let s = i16::from_cpal_sample(t);
-        (s as i32) << 16
-    }
-}
-
-impl AsioSample for f32 {
-    fn to_cpal_sample<T>(self) -> T
-    where
-        T: FromSample<Self>,
-    {
-        T::from(self)
-    }
-    fn from_cpal_sample<T>(t: T) -> Self
-    where
-        Self: FromSample<T>,
-    {
-        Sample::from(t)
-    }
-}
-
-impl AsioSample for f64 {
-    fn to_cpal_sample<T>(self) -> T
-    where
-        T: FromSample<Self>,
-    {
-        let f = self as f32;
-        f.to_cpal_sample()
-    }
-    fn from_cpal_sample<T>(t: T) -> Self
-    where
-        Self: FromSample<T>,
-    {
-        let f = f32::from_cpal_sample(t);
-        f as f64
     }
 }
 

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -305,7 +305,7 @@ impl Device {
                 sample_rate: crate::SampleRate,
                 to_endianness: F,
             ) where
-                A: SizedSample + std::ops::Add,
+                A: SizedSample + std::ops::Add<Output = A>,
                 D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
                 F: Fn(A) -> A,
             {

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -5,9 +5,9 @@ use self::num_traits::PrimInt;
 use super::parking_lot::Mutex;
 use super::Device;
 use crate::{
-    BackendSpecificError, BufferSize, BuildStreamError, Data, FromSample, InputCallbackInfo,
-    OutputCallbackInfo, PauseStreamError, PlayStreamError, Sample, SampleFormat, SizedSample,
-    StreamConfig, StreamError,
+    BackendSpecificError, BufferSize, BuildStreamError, Data, InputCallbackInfo,
+    OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat, SizedSample, StreamConfig,
+    StreamError,
 };
 use std;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -305,7 +305,7 @@ impl Device {
                 sample_rate: crate::SampleRate,
                 to_endianness: F,
             ) where
-                A: SizedSample,
+                A: SizedSample + std::ops::Add,
                 D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
                 F: Fn(A) -> A,
             {

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -584,7 +584,7 @@ fn check_config(
     let StreamConfig {
         channels,
         sample_rate,
-        buffer_size,
+        buffer_size: _,
     } = config;
     // Try and set the sample rate to what the user selected.
     let sample_rate = sample_rate.0.into();
@@ -603,7 +603,7 @@ fn check_config(
     // unsigned formats are not supported by asio
     match sample_format {
         SampleFormat::I16 | SampleFormat::F32 => (),
-        SampleFormat::U16 => return Err(BuildStreamError::StreamConfigNotSupported),
+        _ => return Err(BuildStreamError::StreamConfigNotSupported),
     }
     if *channels > num_asio_channels {
         return Err(BuildStreamError::StreamConfigNotSupported);

--- a/src/host/oboe/input_callback.rs
+++ b/src/host/oboe/input_callback.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 extern crate oboe;
 
 use super::convert::{stream_instant, to_stream_instant};
-use crate::{Data, InputCallbackInfo, InputStreamTimestamp, Sample, StreamError};
+use crate::{Data, InputCallbackInfo, InputStreamTimestamp, SizedSample, StreamError};
 
 pub struct CpalInputCallback<I, C> {
     data_cb: Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>,
@@ -42,7 +42,7 @@ impl<I, C> CpalInputCallback<I, C> {
     }
 }
 
-impl<T: Sample, C: oboe::IsChannelCount> oboe::AudioInputCallback for CpalInputCallback<T, C>
+impl<T: SizedSample, C: oboe::IsChannelCount> oboe::AudioInputCallback for CpalInputCallback<T, C>
 where
     (T, C): oboe::IsFrameType,
 {

--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -458,8 +458,8 @@ impl DeviceTrait for Device {
                     .into())
                 }
             }
-            SampleFormat::U16 => Err(BackendSpecificError {
-                description: "U16 format is not supported on Android.".to_owned(),
+            sample_format => Err(BackendSpecificError {
+                description: format!("{} format is not supported on Android.", sample_format),
             }
             .into()),
         }

--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -9,7 +9,7 @@ use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, Data, DefaultStreamConfigError,
     DeviceNameError, DevicesError, InputCallbackInfo, OutputCallbackInfo, PauseStreamError,
-    PlayStreamError, Sample, SampleFormat, SampleRate, StreamConfig, StreamError,
+    PlayStreamError, SampleFormat, SampleRate, SizedSample, StreamConfig, StreamError,
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError,
 };
@@ -225,7 +225,7 @@ fn build_input_stream<D, E, C, T>(
     builder: oboe::AudioStreamBuilder<oboe::Input, C, T>,
 ) -> Result<Stream, BuildStreamError>
 where
-    T: Sample + oboe::IsFormat + Send + 'static,
+    T: SizedSample + oboe::IsFormat + Send + 'static,
     C: oboe::IsChannelCount + Send + 'static,
     (T, C): oboe::IsFrameType,
     D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -249,7 +249,7 @@ fn build_output_stream<D, E, C, T>(
     builder: oboe::AudioStreamBuilder<oboe::Output, C, T>,
 ) -> Result<Stream, BuildStreamError>
 where
-    T: Sample + oboe::IsFormat + Send + 'static,
+    T: SizedSample + oboe::IsFormat + Send + 'static,
     C: oboe::IsChannelCount + Send + 'static,
     (T, C): oboe::IsFrameType,
     D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -385,8 +385,8 @@ impl DeviceTrait for Device {
                     .into())
                 }
             }
-            SampleFormat::U16 => Err(BackendSpecificError {
-                description: "U16 format is not supported on Android.".to_owned(),
+            sample_format => Err(BackendSpecificError {
+                description: format!("{} format is not supported on Android.", sample_format),
             }
             .into()),
         }

--- a/src/host/oboe/output_callback.rs
+++ b/src/host/oboe/output_callback.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 extern crate oboe;
 
 use super::convert::{stream_instant, to_stream_instant};
-use crate::{Data, OutputCallbackInfo, OutputStreamTimestamp, Sample, StreamError};
+use crate::{Data, OutputCallbackInfo, OutputStreamTimestamp, SizedSample, StreamError};
 
 pub struct CpalOutputCallback<I, C> {
     data_cb: Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>,
@@ -42,7 +42,7 @@ impl<I, C> CpalOutputCallback<I, C> {
     }
 }
 
-impl<T: Sample, C: oboe::IsChannelCount> oboe::AudioOutputCallback for CpalOutputCallback<T, C>
+impl<T: SizedSample, C: oboe::IsChannelCount> oboe::AudioOutputCallback for CpalOutputCallback<T, C>
 where
     (T, C): oboe::IsFrameType,
 {

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -287,7 +287,7 @@ fn run_input(
             _ => unreachable!(),
         };
         match process_input(
-            &mut run_ctxt.stream,
+            &run_ctxt.stream,
             capture_client,
             data_callback,
             error_callback,
@@ -314,7 +314,7 @@ fn run_output(
             _ => unreachable!(),
         };
         match process_output(
-            &mut run_ctxt.stream,
+            &run_ctxt.stream,
             render_client,
             data_callback,
             error_callback,
@@ -439,7 +439,7 @@ fn process_output(
     error_callback: &mut dyn FnMut(StreamError),
 ) -> ControlFlow {
     // The number of frames available for writing.
-    let frames_available = match get_available_frames(&stream) {
+    let frames_available = match get_available_frames(stream) {
         Ok(0) => return ControlFlow::Continue, // TODO: Can this happen?
         Ok(n) => n,
         Err(err) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ impl From<SupportedStreamConfig> for StreamConfig {
 //
 // If a rate you desire is missing from this list, feel free to add it!
 #[cfg(target_os = "windows")]
-const COMMON_SAMPLE_RATES: &'static [SampleRate] = &[
+const COMMON_SAMPLE_RATES: &[SampleRate] = &[
     SampleRate(5512),
     SampleRate(8000),
     SampleRate(11025),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub use platform::{
     available_hosts, default_host, host_from_id, Device, Devices, Host, HostId, Stream,
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
-pub use samples_formats::{SizedSample, SampleFormat, Sample, FromSample, I24, I48, U24, U48};
+pub use samples_formats::{FromSample, Sample, SampleFormat, SizedSample, I24, I48, U24, U48};
 use std::convert::TryInto;
 use std::ops::{Div, Mul};
 use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@
 //! In this example, we simply fill the given output buffer with silence.
 //!
 //! ```no_run
-//! use cpal::{Data, Sample, SampleFormat};
+//! use cpal::{Data, Sample, SampleFormat, FromSample};
 //! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
@@ -100,11 +100,12 @@
 //!     SampleFormat::F32 => device.build_output_stream(&config, write_silence::<f32>, err_fn),
 //!     SampleFormat::I16 => device.build_output_stream(&config, write_silence::<i16>, err_fn),
 //!     SampleFormat::U16 => device.build_output_stream(&config, write_silence::<u16>, err_fn),
+//!     sample_format => panic!("Unsupported sample format '{sample_format}'")
 //! }.unwrap();
 //!
 //! fn write_silence<T: Sample>(data: &mut [T], _: &cpal::OutputCallbackInfo) {
 //!     for sample in data.iter_mut() {
-//!         *sample = Sample::from(&0.0);
+//!         *sample = Sample::EQUILIBRIUM;
 //!     }
 //! }
 //! ```
@@ -154,7 +155,7 @@ pub use platform::{
     available_hosts, default_host, host_from_id, Device, Devices, Host, HostId, Stream,
     SupportedInputConfigs, SupportedOutputConfigs, ALL_HOSTS,
 };
-pub use samples_formats::{Sample, SampleFormat};
+pub use samples_formats::{SizedSample, SampleFormat, Sample, FromSample, I24, I48, U24, U48};
 use std::convert::TryInto;
 use std::ops::{Div, Mul};
 use std::time::Duration;
@@ -516,7 +517,7 @@ impl Data {
     /// Returns `None` if the sample type does not match the expected sample format.
     pub fn as_slice<T>(&self) -> Option<&[T]>
     where
-        T: Sample,
+        T: SizedSample,
     {
         if T::FORMAT == self.sample_format {
             // The safety of this block relies on correct construction of the `Data` instance. See
@@ -532,7 +533,7 @@ impl Data {
     /// Returns `None` if the sample type does not match the expected sample format.
     pub fn as_slice_mut<T>(&mut self) -> Option<&mut [T]>
     where
-        T: Sample,
+        T: SizedSample,
     {
         if T::FORMAT == self.sample_format {
             // The safety of this block relies on correct construction of the `Data` instance. See

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -1,6 +1,6 @@
-use std::{mem, fmt::Display};
+use std::{fmt::Display, mem};
 
-pub use dasp_sample::{I24, I48, U24, U48, Sample, FromSample};
+pub use dasp_sample::{FromSample, Sample, I24, I48, U24, U48};
 
 /// Format that each sample has.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -14,13 +14,11 @@ pub enum SampleFormat {
 
     // /// `I24` with a valid range of '-(1 << 23)..(1 << 23)' with `0` being the origin
     // I24,
-
     /// `i32` with a valid range of 'u32::MIN..=u32::MAX' with `0` being the origin
     I32,
 
     // /// `I24` with a valid range of '-(1 << 47)..(1 << 47)' with `0` being the origin
     // I48,
-
     /// `i64` with a valid range of 'u64::MIN..=u64::MAX' with `0` being the origin
     I64,
 
@@ -32,13 +30,11 @@ pub enum SampleFormat {
 
     // /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
-
     /// `u32` with a valid range of 'u32::MIN..=u32::MAX' with `1 << 31` being the origin
     U32,
 
     // /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
-
     /// `u64` with a valid range of 'u64::MIN..=u64::MAX' with `1 << 63` being the origin
     U64,
 
@@ -70,14 +66,20 @@ impl SampleFormat {
     #[must_use]
     pub fn is_int(&self) -> bool {
         //matches!(*self, SampleFormat::I8 | SampleFormat::I16 | SampleFormat::I24 | SampleFormat::I32 | SampleFormat::I48 | SampleFormat::I64)
-        matches!(*self, SampleFormat::I8 | SampleFormat::I16 | SampleFormat::I32 | SampleFormat::I64)
+        matches!(
+            *self,
+            SampleFormat::I8 | SampleFormat::I16 | SampleFormat::I32 | SampleFormat::I64
+        )
     }
 
     #[inline]
     #[must_use]
     pub fn is_uint(&self) -> bool {
         //matches!(*self, SampleFormat::U8 | SampleFormat::U16 | SampleFormat::U24 | SampleFormat::U32 | SampleFormat::U48 | SampleFormat::U64)
-        matches!(*self, SampleFormat::U8 | SampleFormat::U16 | SampleFormat::U32 | SampleFormat::U64)
+        matches!(
+            *self,
+            SampleFormat::U8 | SampleFormat::U16 | SampleFormat::U32 | SampleFormat::U64
+        )
     }
 
     #[inline]
@@ -85,12 +87,11 @@ impl SampleFormat {
     pub fn is_float(&self) -> bool {
         matches!(*self, SampleFormat::F32 | SampleFormat::F64)
     }
-
 }
 
 impl Display for SampleFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match * self {
+        match *self {
             SampleFormat::I8 => "i8",
             SampleFormat::I16 => "i16",
             // SampleFormat::I24 => "i24",
@@ -105,7 +106,8 @@ impl Display for SampleFormat {
             SampleFormat::U64 => "u64",
             SampleFormat::F32 => "f32",
             SampleFormat::F64 => "f64",
-        }.fmt(f)
+        }
+        .fmt(f)
     }
 }
 
@@ -113,55 +115,50 @@ pub trait SizedSample: Sample {
     const FORMAT: SampleFormat;
 }
 
-impl SizedSample for i8 { const FORMAT: SampleFormat = SampleFormat::I8; }
-impl SizedSample for i16 { const FORMAT: SampleFormat = SampleFormat::I16; }
+impl SizedSample for i8 {
+    const FORMAT: SampleFormat = SampleFormat::I8;
+}
+
+impl SizedSample for i16 {
+    const FORMAT: SampleFormat = SampleFormat::I16;
+}
+
 // impl SizedSample for I24 { const FORMAT: SampleFormat = SampleFormat::I24; }
-impl SizedSample for i32 { const FORMAT: SampleFormat = SampleFormat::I32; }
+
+impl SizedSample for i32 {
+    const FORMAT: SampleFormat = SampleFormat::I32;
+}
+
 // impl SizedSample for I48 { const FORMAT: SampleFormat = SampleFormat::I48; }
-impl SizedSample for i64 { const FORMAT: SampleFormat = SampleFormat::I64; }
-impl SizedSample for u8 { const FORMAT: SampleFormat = SampleFormat::U8; }
-impl SizedSample for u16 { const FORMAT: SampleFormat = SampleFormat::U16; }
+
+impl SizedSample for i64 {
+    const FORMAT: SampleFormat = SampleFormat::I64;
+}
+
+impl SizedSample for u8 {
+    const FORMAT: SampleFormat = SampleFormat::U8;
+}
+
+impl SizedSample for u16 {
+    const FORMAT: SampleFormat = SampleFormat::U16;
+}
+
 // impl SizedSample for U24 { const FORMAT: SampleFormat = SampleFormat::U24; }
-impl SizedSample for u32 { const FORMAT: SampleFormat = SampleFormat::U32; }
+
+impl SizedSample for u32 {
+    const FORMAT: SampleFormat = SampleFormat::U32;
+}
+
 // impl SizedSample for U48 { const FORMAT: SampleFormat = SampleFormat::U48; }
-impl SizedSample for u64 { const FORMAT: SampleFormat = SampleFormat::U64; }
-impl SizedSample for f32 { const FORMAT: SampleFormat = SampleFormat::F32; }
-impl SizedSample for f64 { const FORMAT: SampleFormat = SampleFormat::F64; }
 
+impl SizedSample for u64 {
+    const FORMAT: SampleFormat = SampleFormat::U64;
+}
 
-// enum SampleStorageFormat {
-//     I8,
-//     I16LE,
-//     I16BE,
-//     I24LE3,
-//     I24BE3,
-//     I24LE4,
-//     I24BE4,
-//     I32LE,
-//     I32BE,
-//     I48LE6,
-//     I48BE6,
-//     I48LE8,
-//     I48BE8,
-//     I64LE,
-//     I64BE,
-//     U8,
-//     U16LE,
-//     U16BE,
-//     U24LE3,
-//     U24BE3,
-//     U24LE4,
-//     U24BE4,
-//     U32LE,
-//     U32BE,
-//     U48LE6,
-//     U48BE6,
-//     U48LE8,
-//     U48BE8,
-//     U64LE,
-//     U64BE,
-//     F32LE,
-//     F32BE,
-//     F64LE,
-//     F64BE,
-// }
+impl SizedSample for f32 {
+    const FORMAT: SampleFormat = SampleFormat::F32;
+}
+
+impl SizedSample for f64 {
+    const FORMAT: SampleFormat = SampleFormat::F64;
+}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,8 +3,8 @@
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, PauseStreamError,
-    PlayStreamError, Sample, SampleFormat, StreamConfig, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError,
+    PlayStreamError, SampleFormat, StreamConfig, StreamError, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError, SizedSample,
 };
 
 /// A **Host** provides access to the available audio devices on the system.
@@ -122,7 +122,7 @@ pub trait DeviceTrait {
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
+        T: SizedSample,
         D: FnMut(&[T], &InputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
@@ -148,7 +148,7 @@ pub trait DeviceTrait {
         error_callback: E,
     ) -> Result<Self::Stream, BuildStreamError>
     where
-        T: Sample,
+        T: SizedSample,
         D: FnMut(&mut [T], &OutputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,8 +3,8 @@
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, PauseStreamError,
-    PlayStreamError, SampleFormat, StreamConfig, StreamError, SupportedStreamConfig,
-    SupportedStreamConfigRange, SupportedStreamConfigsError, SizedSample,
+    PlayStreamError, SampleFormat, SizedSample, StreamConfig, StreamError, SupportedStreamConfig,
+    SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
 
 /// A **Host** provides access to the available audio devices on the system.


### PR DESCRIPTION
This is an attempt to fix https://github.com/RustAudio/cpal/issues/488
In the course of migrating to `dasp_module` I also unlocked `i8`, `u8`, `i32`, `u32`, `i64`, `u64` and `f64`. I did not extend this to `i24`, `u24`, `i48`, `u48` because I felt there are open question regarding the memory layout.

So far I did run the tests for ALSA. I might need some help to adjust the implementation for other platforms.