### PR TITLE
Fix some Edition 2021 warnings/errors

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -892,7 +892,7 @@ impl Stream {
         let thread = thread::Builder::new()
             .name("cpal_alsa_in".to_owned())
             .spawn(move || {
-                input_stream_worker(rx, &*stream, &mut data_callback, &mut error_callback);
+                input_stream_worker(rx, &stream, &mut data_callback, &mut error_callback);
             })
             .unwrap();
         Stream {
@@ -917,7 +917,7 @@ impl Stream {
         let thread = thread::Builder::new()
             .name("cpal_alsa_out".to_owned())
             .spawn(move || {
-                output_stream_worker(rx, &*stream, &mut data_callback, &mut error_callback);
+                output_stream_worker(rx, &stream, &mut data_callback, &mut error_callback);
             })
             .unwrap();
         Stream {

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -4,18 +4,18 @@ pub type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>
 
 use super::parking_lot::Mutex;
 use super::sys;
+use crate::BackendSpecificError;
+use crate::DefaultStreamConfigError;
+use crate::DeviceNameError;
+use crate::DevicesError;
+use crate::SampleFormat;
+use crate::SampleRate;
+use crate::SupportedBufferSize;
+use crate::SupportedStreamConfig;
+use crate::SupportedStreamConfigRange;
+use crate::SupportedStreamConfigsError;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use BackendSpecificError;
-use DefaultStreamConfigError;
-use DeviceNameError;
-use DevicesError;
-use SampleFormat;
-use SampleRate;
-use SupportedBufferSize;
-use SupportedStreamConfig;
-use SupportedStreamConfigRange;
-use SupportedStreamConfigsError;
 
 /// A ASIO Device
 pub struct Device {
@@ -68,7 +68,7 @@ impl Device {
 
         // Collect a config for every combination of supported sample rate and number of channels.
         let mut supported_configs = vec![];
-        for &rate in ::COMMON_SAMPLE_RATES {
+        for &rate in crate::COMMON_SAMPLE_RATES {
             if !self
                 .driver
                 .can_sample_rate(rate.0.into())
@@ -105,7 +105,7 @@ impl Device {
 
         // Collect a config for every combination of supported sample rate and number of channels.
         let mut supported_configs = vec![];
-        for &rate in ::COMMON_SAMPLE_RATES {
+        for &rate in crate::COMMON_SAMPLE_RATES {
             if !self
                 .driver
                 .can_sample_rate(rate.0.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,13 +319,13 @@ pub struct OutputStreamTimestamp {
 }
 
 /// Information relevant to a single call to the user's input stream data callback.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputCallbackInfo {
     timestamp: InputStreamTimestamp,
 }
 
 /// Information relevant to a single call to the user's output stream data callback.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputCallbackInfo {
     timestamp: OutputStreamTimestamp,
 }


### PR DESCRIPTION
Looks like there were some left-overs from the 2021 migration which this PR tries to fix.
I also sneaked in the removal of some dereferences and inconsequential implementation of `Partial/Eq` clippy was complaining about.

see also: https://github.com/RustAudio/cpal/pull/689#issuecomment-1250383218