### PR TITLE
Use an action to publish the crate

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -50,28 +50,28 @@ jobs:
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    env:
-      CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - name: Install rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
     - name: Update apt
       run: sudo apt update
     - name: Install alsa
       run: sudo apt-get install libasound2-dev
-    - name: Run cargo publish for cpal
-      continue-on-error: true
-      run: |
-        CPAL_TMP=$(mktemp /tmp/cpalXXX.txt) || echo "::error::mktemp error"
-        echo "CPAL_TMP=$CPAL_TMP" >> $GITHUB_ENV
-        cargo publish --token $CRATESIO_TOKEN 2> $CPAL_TMP
-    - name: Check if cpal is already published
-      run: |
-        empty=0
-        CPAL_TMP="${{ env.CPAL_TMP }}"
-        grep -q '[^[:space:]]' < $CPAL_TMP || empty=1
-        [ $empty -eq 0 ] && cat $CPAL_TMP
-        [ $empty -eq 1 ] || grep -q "is already uploaded" < $CPAL_TMP
+    - name: Verify publish crate
+      uses: katyo/publish-crates@v1
+      with:
+        dry-run: true
+    - name: Publish crate
+      uses: katyo/publish-crates@v1
+      with:
+        ignore-unpublished-changes: true
+        registry-token: ${{ secrets.CRATESIO_TOKEN }}
 
   ubuntu-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR removes the old and complex way to publish `cpal` on crates.io with a much simpler action