### PR TITLE
add timeout paramter to DeviceTrait stream builders

### DIFF
--- a/examples/android.rs
+++ b/examples/android.rs
@@ -60,6 +60,7 @@ where
             write_data(data, channels, &mut next_value)
         },
         err_fn,
+        None,
     )?;
     stream.play()?;
 

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -158,6 +158,7 @@ where
             write_data(data, channels, &mut next_value)
         },
         err_fn,
+        None,
     )?;
     stream.play()?;
 

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -202,8 +202,8 @@ fn main() -> anyhow::Result<()> {
         "Attempting to build both streams with f32 samples and `{:?}`.",
         config
     );
-    let input_stream = input_device.build_input_stream(&config, input_data_fn, err_fn)?;
-    let output_stream = output_device.build_output_stream(&config, output_data_fn, err_fn)?;
+    let input_stream = input_device.build_input_stream(&config, input_data_fn, err_fn, None)?;
+    let output_stream = output_device.build_output_stream(&config, output_data_fn, err_fn, None)?;
     println!("Successfully built streams.");
 
     // Play the streams.

--- a/examples/ios-feedback/src/feedback.rs
+++ b/examples/ios-feedback/src/feedback.rs
@@ -83,9 +83,9 @@ pub fn run_example() -> Result<(), anyhow::Error> {
         config
     );
     println!("Setup input stream");
-    let input_stream = input_device.build_input_stream(&config, input_data_fn, err_fn)?;
+    let input_stream = input_device.build_input_stream(&config, input_data_fn, err_fn, None)?;
     println!("Setup output stream");
-    let output_stream = output_device.build_output_stream(&config, output_data_fn, err_fn)?;
+    let output_stream = output_device.build_output_stream(&config, output_data_fn, err_fn, None)?;
     println!("Successfully built streams.");
 
     // Play the streams.

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -147,21 +147,25 @@ fn main() -> Result<(), anyhow::Error> {
             &config.into(),
             move |data, _: &_| write_input_data::<i8, i8>(data, &writer_2),
             err_fn,
+            None,
         )?,
         cpal::SampleFormat::I16 => device.build_input_stream(
             &config.into(),
             move |data, _: &_| write_input_data::<i16, i16>(data, &writer_2),
             err_fn,
+            None,
         )?,
         cpal::SampleFormat::I32 => device.build_input_stream(
             &config.into(),
             move |data, _: &_| write_input_data::<i32, i32>(data, &writer_2),
             err_fn,
+            None,
         )?,
         cpal::SampleFormat::F32 => device.build_input_stream(
             &config.into(),
             move |data, _: &_| write_input_data::<f32, f32>(data, &writer_2),
             err_fn,
+            None,
         )?,
         sample_format => {
             return Err(anyhow::Error::msg(format!(

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -107,6 +107,7 @@ where
             on_window(output, &mut request, on_sample)
         },
         err_fn,
+        None,
     )?;
 
     Ok(stream)

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -62,6 +62,7 @@ where
             config,
             move |data: &mut [T], _| write_data(data, channels, &mut next_value),
             err_fn,
+            None,
         )
         .unwrap();
     stream.play().unwrap();

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -563,7 +563,7 @@ struct StreamWorkerContext {
 
 impl StreamWorkerContext {
     fn new(poll_timeout: &Option<Duration>) -> Self {
-        let poll_timeout_i32: i32 = if let Some(d) = poll_timeout {
+        let poll_timeout: i32 = if let Some(d) = poll_timeout {
             d.as_millis().try_into().unwrap()
         } else {
             -1
@@ -572,7 +572,7 @@ impl StreamWorkerContext {
         Self {
             descriptors: Vec::new(),
             buffer: Vec::new(),
-            poll_timeout: poll_timeout_i32,
+            poll_timeout,
         }
     }
 }

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -16,6 +16,7 @@ use std::cmp;
 use std::convert::TryInto;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 use std::vec::IntoIter as VecIntoIter;
 
 pub use self::enumerate::{default_input_device, default_output_device, Devices};
@@ -92,6 +93,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -99,7 +101,12 @@ impl DeviceTrait for Device {
     {
         let stream_inner =
             self.build_stream_inner(conf, sample_format, alsa::Direction::Capture)?;
-        let stream = Stream::new_input(Arc::new(stream_inner), data_callback, error_callback);
+        let stream = Stream::new_input(
+            Arc::new(stream_inner),
+            data_callback,
+            error_callback,
+            timeout,
+        );
         Ok(stream)
     }
 
@@ -109,6 +116,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -116,7 +124,12 @@ impl DeviceTrait for Device {
     {
         let stream_inner =
             self.build_stream_inner(conf, sample_format, alsa::Direction::Playback)?;
-        let stream = Stream::new_output(Arc::new(stream_inner), data_callback, error_callback);
+        let stream = Stream::new_output(
+            Arc::new(stream_inner),
+            data_callback,
+            error_callback,
+            timeout,
+        );
         Ok(stream)
     }
 }
@@ -542,10 +555,26 @@ pub struct Stream {
     trigger: TriggerSender,
 }
 
-#[derive(Default)]
 struct StreamWorkerContext {
     descriptors: Vec<libc::pollfd>,
     buffer: Vec<u8>,
+    poll_timeout: i32,
+}
+
+impl StreamWorkerContext {
+    fn new(poll_timeout: &Option<Duration>) -> Self {
+        let poll_timeout_i32: i32 = if let Some(d) = poll_timeout {
+            d.as_millis().try_into().unwrap()
+        } else {
+            -1
+        };
+
+        Self {
+            descriptors: Vec::new(),
+            buffer: Vec::new(),
+            poll_timeout: poll_timeout_i32,
+        }
+    }
 }
 
 fn input_stream_worker(
@@ -553,8 +582,9 @@ fn input_stream_worker(
     stream: &StreamInner,
     data_callback: &mut (dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static),
     error_callback: &mut (dyn FnMut(StreamError) + Send + 'static),
+    timeout: Option<Duration>,
 ) {
-    let mut ctxt = StreamWorkerContext::default();
+    let mut ctxt = StreamWorkerContext::new(&timeout);
     loop {
         let flow =
             poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt).unwrap_or_else(|err| {
@@ -603,8 +633,9 @@ fn output_stream_worker(
     stream: &StreamInner,
     data_callback: &mut (dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static),
     error_callback: &mut (dyn FnMut(StreamError) + Send + 'static),
+    timeout: Option<Duration>,
 ) {
-    let mut ctxt = StreamWorkerContext::default();
+    let mut ctxt = StreamWorkerContext::new(&timeout);
     loop {
         let flow =
             poll_descriptors_and_prepare_buffer(&rx, stream, &mut ctxt).unwrap_or_else(|err| {
@@ -669,6 +700,7 @@ fn poll_descriptors_and_prepare_buffer(
     let StreamWorkerContext {
         ref mut descriptors,
         ref mut buffer,
+        ref poll_timeout,
     } = *ctxt;
 
     descriptors.clear();
@@ -694,7 +726,7 @@ fn poll_descriptors_and_prepare_buffer(
     debug_assert_eq!(filled, stream.num_descriptors);
 
     // Don't timeout, wait forever.
-    let res = alsa::poll::poll(descriptors, -1)?;
+    let res = alsa::poll::poll(descriptors, *poll_timeout)?;
     if res == 0 {
         let description = String::from("`alsa::poll()` spuriously returned");
         return Err(BackendSpecificError { description });
@@ -881,6 +913,7 @@ impl Stream {
         inner: Arc<StreamInner>,
         mut data_callback: D,
         mut error_callback: E,
+        timeout: Option<Duration>,
     ) -> Stream
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -892,7 +925,13 @@ impl Stream {
         let thread = thread::Builder::new()
             .name("cpal_alsa_in".to_owned())
             .spawn(move || {
-                input_stream_worker(rx, &stream, &mut data_callback, &mut error_callback);
+                input_stream_worker(
+                    rx,
+                    &stream,
+                    &mut data_callback,
+                    &mut error_callback,
+                    timeout,
+                );
             })
             .unwrap();
         Stream {
@@ -906,6 +945,7 @@ impl Stream {
         inner: Arc<StreamInner>,
         mut data_callback: D,
         mut error_callback: E,
+        timeout: Option<Duration>,
     ) -> Stream
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
@@ -917,7 +957,13 @@ impl Stream {
         let thread = thread::Builder::new()
             .name("cpal_alsa_out".to_owned())
             .spawn(move || {
-                output_stream_worker(rx, &stream, &mut data_callback, &mut error_callback);
+                output_stream_worker(
+                    rx,
+                    &stream,
+                    &mut data_callback,
+                    &mut error_callback,
+                    timeout,
+                );
             })
             .unwrap();
         Stream {

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -88,12 +88,20 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream_raw(self, config, sample_format, data_callback, error_callback)
+        Device::build_input_stream_raw(
+            self,
+            config,
+            sample_format,
+            data_callback,
+            error_callback,
+            timeout,
+        )
     }
 
     fn build_output_stream_raw<D, E>(
@@ -102,12 +110,20 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream_raw(self, config, sample_format, data_callback, error_callback)
+        Device::build_output_stream_raw(
+            self,
+            config,
+            sample_format,
+            data_callback,
+            error_callback,
+            timeout,
+        )
     }
 }
 

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -11,6 +11,7 @@ use crate::{
 pub use self::device::{Device, Devices, SupportedInputConfigs, SupportedOutputConfigs};
 pub use self::stream::Stream;
 use std::sync::Arc;
+use std::time::Duration;
 
 mod device;
 mod stream;

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -12,6 +12,7 @@ use crate::{
 use std;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 // Used to keep track of whether or not the current asio stream buffer requires
 // being silencing before summing audio.

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -48,6 +48,7 @@ impl Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -229,6 +230,7 @@ impl Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -174,6 +174,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         mut error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -256,6 +257,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         mut error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/coreaudio/ios/mod.rs
+++ b/src/host/coreaudio/ios/mod.rs
@@ -34,6 +34,7 @@ use self::enumerate::{
     SupportedOutputConfigs,
 };
 use std::slice;
+use std::time::Duration;
 
 pub mod enumerate;
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -116,12 +116,20 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_input_stream_raw(self, config, sample_format, data_callback, error_callback)
+        Device::build_input_stream_raw(
+            self,
+            config,
+            sample_format,
+            data_callback,
+            error_callback,
+            timeout,
+        )
     }
 
     fn build_output_stream_raw<D, E>(
@@ -130,12 +138,20 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        Device::build_output_stream_raw(self, config, sample_format, data_callback, error_callback)
+        Device::build_output_stream_raw(
+            self,
+            config,
+            sample_format,
+            data_callback,
+            error_callback,
+            timeout,
+        )
     }
 }
 
@@ -502,6 +518,7 @@ impl Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -611,6 +628,7 @@ impl Device {
         sample_format: SampleFormat,
         mut data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -1,6 +1,7 @@
 use std::mem;
 use std::os::raw::c_void;
 use std::slice::from_raw_parts;
+use std::time::Duration;
 use stdweb;
 use stdweb::unstable::TryInto;
 use stdweb::web::set_timeout;

--- a/src/host/emscripten/mod.rs
+++ b/src/host/emscripten/mod.rs
@@ -171,6 +171,7 @@ impl DeviceTrait for Device {
         _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -185,6 +186,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -177,6 +177,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -215,6 +216,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/jack/device.rs
+++ b/src/host/jack/device.rs
@@ -6,6 +6,7 @@ use crate::{
     SupportedStreamConfigsError,
 };
 use std::hash::{Hash, Hasher};
+use std::time::Duration;
 
 use super::stream::Stream;
 use super::JACK_SAMPLE_FORMAT;

--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
@@ -73,6 +75,7 @@ impl DeviceTrait for Device {
         _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -88,6 +91,7 @@ impl DeviceTrait for Device {
         _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -325,6 +325,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -398,6 +399,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::cmp;
 use std::convert::TryInto;
+use std::time::Duration;
 use std::vec::IntoIter as VecIntoIter;
 
 extern crate oboe;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -14,6 +14,7 @@ use std::os::windows::ffi::OsStringExt;
 use std::ptr;
 use std::slice;
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
 
 use super::com;
 use super::{windows_err_to_cpal_err, windows_err_to_cpal_err_message};

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -85,6 +85,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -104,6 +105,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
 
 /// Content is false if the iterator is empty.
 pub struct Devices(bool);

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -172,6 +172,7 @@ impl DeviceTrait for Device {
         _sample_format: SampleFormat,
         _data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -188,6 +189,7 @@ impl DeviceTrait for Device {
         sample_format: SampleFormat,
         data_callback: D,
         _error_callback: E,
+        _timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@
 //!     move |err| {
 //!         // react to errors here.
 //!     },
+//!     None // None=blocking, Some(Duration)=timeout
 //! );
 //! ```
 //!
@@ -97,9 +98,9 @@
 //! let sample_format = supported_config.sample_format();
 //! let config = supported_config.into();
 //! let stream = match sample_format {
-//!     SampleFormat::F32 => device.build_output_stream(&config, write_silence::<f32>, err_fn),
-//!     SampleFormat::I16 => device.build_output_stream(&config, write_silence::<i16>, err_fn),
-//!     SampleFormat::U16 => device.build_output_stream(&config, write_silence::<u16>, err_fn),
+//!     SampleFormat::F32 => device.build_output_stream(&config, write_silence::<f32>, err_fn, None),
+//!     SampleFormat::I16 => device.build_output_stream(&config, write_silence::<i16>, err_fn, None),
+//!     SampleFormat::U16 => device.build_output_stream(&config, write_silence::<u16>, err_fn, None),
 //!     sample_format => panic!("Unsupported sample format '{sample_format}'")
 //! }.unwrap();
 //!
@@ -122,7 +123,7 @@
 //! # let config = supported_config.into();
 //! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream_raw(&config, sample_format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&config, sample_format, data_fn, err_fn, None).unwrap();
 //! stream.play().unwrap();
 //! ```
 //!
@@ -138,7 +139,7 @@
 //! # let config = supported_config.into();
 //! # let data_fn = move |_data: &mut cpal::Data, _: &cpal::OutputCallbackInfo| {};
 //! # let err_fn = move |_err| {};
-//! # let stream = device.build_output_stream_raw(&config, sample_format, data_fn, err_fn).unwrap();
+//! # let stream = device.build_output_stream_raw(&config, sample_format, data_fn, err_fn, None).unwrap();
 //! stream.pause().unwrap();
 //! ```
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -360,6 +360,7 @@ macro_rules! impl_platform_host {
                 sample_format: crate::SampleFormat,
                 data_callback: D,
                 error_callback: E,
+                timeout: Option<std::time::Duration>,
             ) -> Result<Self::Stream, crate::BuildStreamError>
             where
                 D: FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static,
@@ -374,6 +375,7 @@ macro_rules! impl_platform_host {
                                 sample_format,
                                 data_callback,
                                 error_callback,
+                                timeout,
                             )
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),
@@ -387,6 +389,7 @@ macro_rules! impl_platform_host {
                 sample_format: crate::SampleFormat,
                 data_callback: D,
                 error_callback: E,
+                timeout: Option<std::time::Duration>,
             ) -> Result<Self::Stream, crate::BuildStreamError>
             where
                 D: FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static,
@@ -401,6 +404,7 @@ macro_rules! impl_platform_host {
                                 sample_format,
                                 data_callback,
                                 error_callback,
+                                timeout,
                             )
                             .map(StreamInner::$HostVariant)
                             .map(Stream::from),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,7 @@
 //! The suite of traits allowing CPAL to abstract over hosts, devices, event loops and stream IDs.
 
+use std::time::Duration;
+
 use crate::{
     BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, DevicesError,
     InputCallbackInfo, InputDevices, OutputCallbackInfo, OutputDevices, PauseStreamError,
@@ -120,6 +122,7 @@ pub trait DeviceTrait {
         config: &StreamConfig,
         mut data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         T: SizedSample,
@@ -137,6 +140,7 @@ pub trait DeviceTrait {
                 )
             },
             error_callback,
+            timeout,
         )
     }
 
@@ -146,6 +150,7 @@ pub trait DeviceTrait {
         config: &StreamConfig,
         mut data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         T: SizedSample,
@@ -163,6 +168,7 @@ pub trait DeviceTrait {
                 )
             },
             error_callback,
+            timeout,
         )
     }
 
@@ -173,6 +179,7 @@ pub trait DeviceTrait {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
@@ -185,6 +192,7 @@ pub trait DeviceTrait {
         sample_format: SampleFormat,
         data_callback: D,
         error_callback: E,
+        timeout: Option<Duration>,
     ) -> Result<Self::Stream, BuildStreamError>
     where
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,


### PR DESCRIPTION
This makes it possible for the library client to handle situations where the host takes too long to respond or even blocks forever, eg. a retry can be applied.

if the timeout passed is "None" the current behaviour is applied, eg. blocking forever. if the timeout passed is a Duration then it will be applied to the Device Streams. This is only implemented for ALSA, the other hosts will ignore the parameter for now.

Signed-off-by: Marc Bodmer <marc.bodmer@securiton.ch>