### PR TITLE
CI: Set check-repo to false

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -67,6 +67,7 @@ jobs:
       uses: katyo/publish-crates@v1
       with:
         dry-run: true
+        check-repo: false
     - name: Publish crate
       uses: katyo/publish-crates@v1
       with:


### PR DESCRIPTION
Do not fail on package verification during the publish job