### PR TITLE
CI: Set no-verify to true for publish job

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -68,6 +68,7 @@ jobs:
       with:
         dry-run: true
         check-repo: false
+        no-verify: true
     - name: Publish crate
       uses: katyo/publish-crates@v1
       with:


### PR DESCRIPTION
This PR sets `no-verify` parameter to `true` not to fail the publish job 