### PR TITLE
CI: Ignore unpublished changes for the publish action

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -67,8 +67,7 @@ jobs:
       uses: katyo/publish-crates@v1
       with:
         dry-run: true
-        check-repo: false
-        no-verify: true
+        ignore-unpublished-changes: true
     - name: Publish crate
       uses: katyo/publish-crates@v1
       with:


### PR DESCRIPTION
This option ignores unpublished changes and remove useless options