### PR TITLE
Update to use coreaudio-sys 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ mach = "0.3" # For access to mach_timebase type.
 parking_lot = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-coreaudio-rs = { version = "0.10", default-features = false, features = ["audio_unit", "core_audio"] }
+coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio"] }
 
 [target.'cfg(target_os = "ios")'.dependencies]
-coreaudio-rs = { version = "0.10", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
+coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
 wasm-bindgen = { version = "0.2.58" }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -388,9 +388,9 @@ impl Device {
                     _ => return Err(DefaultStreamConfigError::StreamTypeNotSupported),
                 };
                 let maybe_sample_format =
-                    coreaudio::audio_unit::SampleFormat::from_flags_and_bytes_per_frame(
+                    coreaudio::audio_unit::SampleFormat::from_flags_and_bits_per_sample(
                         flags,
-                        asbd.mBytesPerFrame,
+                        asbd.mBitsPerChannel,
                     );
                 match maybe_sample_format {
                     Some(coreaudio::audio_unit::SampleFormat::F32) => SampleFormat::F32,


### PR DESCRIPTION
https://github.com/RustAudio/coreaudio-rs/compare/1de4dc04a858dba3bc1b170ce980ee2e2825f864..163f1a09f0afdc80b01f3cba8956c207aa3a1cbd

Tentative, just updating the version & API usage.

This PR will bring a bug fix on `coreaudio-rs` (https://github.com/RustAudio/coreaudio-rs/pull/91)