### PR TITLE
Implement disconnection detection for CoreAudio on MacOS.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ jack = { version = "0.9", optional = true }
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
 mach = "0.3" # For access to mach_timebase type.
+parking_lot = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 coreaudio-rs = { version = "0.10", default-features = false, features = ["audio_unit", "core_audio"] }

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -447,7 +447,6 @@ where
             mElement: kAudioObjectPropertyElementMaster,
         },
         move || {
-            println!("Disconnecting.");
             let _ = stream_copy.pause();
             (error_callback.lock())(StreamError::DeviceNotAvailable);
         },

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -428,7 +428,7 @@ struct StreamInner {
 }
 
 /// Register the on-disconnect callback.
-/// This will both stop the stream and call the error callback DeviceNotAvailable.
+/// This will both stop the stream and call the error callback with DeviceNotAvailable.
 /// This function should only be called once per stream.
 fn add_disconnect_listener<E>(
     stream: &Stream,

--- a/src/host/coreaudio/macos/property_listener.rs
+++ b/src/host/coreaudio/macos/property_listener.rs
@@ -47,10 +47,10 @@ impl AudioObjectPropertyListener {
     /// Use this method if you need to explicitly handle failure to remove
     /// the property listener.
     pub fn remove(mut self) -> Result<(), BuildStreamError> {
-        self._remove()
+        self.remove_inner()
     }
 
-    fn _remove(&mut self) -> Result<(), BuildStreamError> {
+    fn remove_inner(&mut self) -> Result<(), BuildStreamError> {
         unsafe {
             coreaudio::Error::from_os_status(AudioObjectRemovePropertyListener(
                 self.audio_object_id,
@@ -67,7 +67,7 @@ impl AudioObjectPropertyListener {
 impl Drop for AudioObjectPropertyListener {
     fn drop(&mut self) {
         if !self.removed {
-            self._remove().ok();
+            let _ = self.remove_inner();
         }
     }
 }

--- a/src/host/coreaudio/macos/property_listener.rs
+++ b/src/host/coreaudio/macos/property_listener.rs
@@ -1,0 +1,85 @@
+//! Helper code for registering audio object property listeners.
+use super::coreaudio::sys::{
+    AudioObjectAddPropertyListener, AudioObjectID, AudioObjectPropertyAddress,
+    AudioObjectRemovePropertyListener, OSStatus,
+};
+
+use crate::BuildStreamError;
+
+/// A double-indirection to be able to pass a closure (a fat pointer)
+/// via a single c_void.
+struct PropertyListenerCallbackWrapper(Box<dyn FnMut() -> ()>);
+
+/// Maintain an audio object property listener.
+/// The listener will be removed when this type is dropped.
+pub struct AudioObjectPropertyListener {
+    callback: Box<PropertyListenerCallbackWrapper>,
+    property_address: AudioObjectPropertyAddress,
+    audio_object_id: AudioObjectID,
+    removed: bool,
+}
+
+impl AudioObjectPropertyListener {
+    /// Attach the provieded callback as a audio object property listener.
+    pub fn new<F: FnMut() -> () + 'static>(
+        audio_object_id: AudioObjectID,
+        property_address: AudioObjectPropertyAddress,
+        callback: F,
+    ) -> Result<Self, BuildStreamError> {
+        let callback = Box::new(PropertyListenerCallbackWrapper(Box::new(callback)));
+        unsafe {
+            coreaudio::Error::from_os_status(AudioObjectAddPropertyListener(
+                audio_object_id,
+                &property_address as *const _,
+                Some(property_listener_handler_shim),
+                &*callback as *const _ as *mut _,
+            ))?;
+        };
+        Ok(Self {
+            callback,
+            audio_object_id,
+            property_address,
+            removed: false,
+        })
+    }
+
+    /// Explicitly remove the property listener.
+    /// Use this method if you need to explicitly handle failure to remove
+    /// the property listener.
+    pub fn remove(mut self) -> Result<(), BuildStreamError> {
+        self._remove()
+    }
+
+    fn _remove(&mut self) -> Result<(), BuildStreamError> {
+        unsafe {
+            coreaudio::Error::from_os_status(AudioObjectRemovePropertyListener(
+                self.audio_object_id,
+                &self.property_address as *const _,
+                Some(property_listener_handler_shim),
+                &*self.callback as *const _ as *mut _,
+            ))?;
+        }
+        self.removed = true;
+        Ok(())
+    }
+}
+
+impl Drop for AudioObjectPropertyListener {
+    fn drop(&mut self) {
+        if !self.removed {
+            self._remove().ok();
+        }
+    }
+}
+
+/// Callback used to call user-provided closure as a property listener.
+unsafe extern "C" fn property_listener_handler_shim(
+    _: AudioObjectID,
+    _: u32,
+    _: *const AudioObjectPropertyAddress,
+    callback: *mut ::std::os::raw::c_void,
+) -> OSStatus {
+    let wrapper = callback as *mut PropertyListenerCallbackWrapper;
+    (*wrapper).0();
+    0
+}

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -1,4 +1,5 @@
 extern crate coreaudio;
+extern crate parking_lot;
 
 use self::coreaudio::sys::{
     kAudioFormatFlagIsFloat, kAudioFormatFlagIsPacked, kAudioFormatLinearPCM,


### PR DESCRIPTION
Relates to #704 and #373.  Implements a very basic mechanism for polling to determine if the device underlying a CoreAudio-backed stream has been disconnected.  This definitely works, but is obviously a very platform-dependent solution as you have to unpack the underlying stream type to access it.

Feedback extremely welcome.  The main thing I'm dissatisfied with here is that we must poll to determine if the device has dropped to then trigger some action.