### PR TITLE
Bump linux deps, simplify examples, remove nix dep

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -12,6 +12,8 @@ jobs:
       run: sudo apt update
     - name: Install alsa
       run: sudo apt-get install libasound2-dev
+    - name: Install libjack
+      run: sudo apt-get install libjack-jackd2-dev libjack-jackd2-0
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2021"
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
 
 [dependencies]
-thiserror = "1.0.37"
-dasp_sample = "0.11.0"
+thiserror = "1.0"
+dasp_sample = "0.11"
 
 [dev-dependencies]
-anyhow = "1.0.65"
-hound = "3.5.0"
-ringbuf = "0.3.1"
+anyhow = "1.0"
+hound = "3.5"
+ringbuf = "0.3"
 clap = { version = "4.0", features = ["derive"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.25"
+nix = "^0.23"
 libc = "0.2"
 parking_lot = "0.12"
 jack = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ thiserror = "1.0.37"
 dasp_sample = "0.11.0"
 
 [dev-dependencies]
-ringbuf = "0.2"
 anyhow = "1.0.65"
 hound = "3.5.0"
+ringbuf = "0.3.1"
 clap = { version = "3.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
 
 [dependencies]
-thiserror = "1.0.2"
+thiserror = "1.0.37"
 dasp_sample = "0.11.0"
 
 [dev-dependencies]
@@ -35,9 +35,9 @@ once_cell = "1.12"
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
 nix = "0.25"
-libc = "0.2.65"
+libc = "0.2.135"
 parking_lot = "0.12"
-jack = { version = "0.9", optional = true }
+jack = { version = "0.10", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "^0.23"
+nix = "0.23.1"
 libc = "0.2"
 parking_lot = "0.12"
 jack = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.25"
 libc = "0.2"
 parking_lot = "0.12"
 jack = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ thiserror = "1.0.37"
 dasp_sample = "0.11.0"
 
 [dev-dependencies]
-anyhow = "1.0.12"
-hound = "3.4"
 ringbuf = "0.2"
+anyhow = "1.0.65"
+hound = "3.5.0"
 clap = { version = "3.1", default-features = false, features = ["std"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dasp_sample = "0.11.0"
 anyhow = "1.0.65"
 hound = "3.5.0"
 ringbuf = "0.3.1"
-clap = { version = "3.1", default-features = false, features = ["std"] }
+clap = { version = "4.0", features = ["derive"] }
 
 [target.'cfg(target_os = "android")'.dev-dependencies]
 ndk-glue = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.12"
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
 nix = "0.25"
-libc = "0.2.135"
+libc = "0.2"
 parking_lot = "0.12"
 jack = { version = "0.10", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.23.1"
+nix = "0.25"
 libc = "0.2"
 parking_lot = "0.12"
 jack = { version = "0.10", optional = true }

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,16 +1,18 @@
-extern crate anyhow;
-extern crate clap;
-extern crate cpal;
-
-use clap::arg;
+use anyhow;
+use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample,
+    FromSample, Sample, SizedSample,
 };
-use cpal::{FromSample, Sample};
 
-#[derive(Debug)]
+#[derive(Parser, Debug)]
+#[command(version, about = "CPAL beep example", long_about = None)]
 struct Opt {
+    /// The audio device to use
+    #[arg(short, long, default_value_t = String::from("default"))]
+    device: String,
+
+    /// Use the JACK host
     #[cfg(all(
         any(
             target_os = "linux",
@@ -20,56 +22,13 @@ struct Opt {
         ),
         feature = "jack"
     ))]
+    #[arg(short, long)]
+    #[allow(dead_code)]
     jack: bool,
-
-    device: String,
-}
-
-impl Opt {
-    fn from_args() -> Self {
-        let app = clap::Command::new("beep").arg(arg!([DEVICE] "The audio device to use"));
-        #[cfg(all(
-            any(
-                target_os = "linux",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "netbsd"
-            ),
-            feature = "jack"
-        ))]
-        let app = app.arg(arg!(-j --jack "Use the JACK host"));
-        let matches = app.get_matches();
-        let device = matches.value_of("DEVICE").unwrap_or("default").to_string();
-
-        #[cfg(all(
-            any(
-                target_os = "linux",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "netbsd"
-            ),
-            feature = "jack"
-        ))]
-        return Opt {
-            jack: matches.is_present("jack"),
-            device,
-        };
-
-        #[cfg(any(
-            not(any(
-                target_os = "linux",
-                target_os = "dragonfly",
-                target_os = "freebsd",
-                target_os = "netbsd"
-            )),
-            not(feature = "jack")
-        ))]
-        Opt { device }
-    }
 }
 
 fn main() -> anyhow::Result<()> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     // Conditionally compile with jack if the feature is specified.
     #[cfg(all(

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -14,7 +14,7 @@ extern crate ringbuf;
 use anyhow::Context;
 use clap::arg;
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use ringbuf::RingBuffer;
+use ringbuf::HeapRb;
 
 #[derive(Debug)]
 struct Opt {
@@ -159,7 +159,7 @@ fn main() -> anyhow::Result<()> {
     let latency_samples = latency_frames as usize * config.channels as usize;
 
     // The buffer to share samples
-    let ring = RingBuffer::new(latency_samples * 2);
+    let ring = HeapRb::<f32>::new(latency_samples * 2);
     let (mut producer, mut consumer) = ring.split();
 
     // Fill the samples with 0.0 equal to the length of the delay.


### PR DESCRIPTION
Bumps most linux dependencies. Moves examples to clap 4.0 and changes them to use clap_derive. This simplifies the examples and let them focus on the real content they offer.