### PR TITLE
remove nix as a dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.25"
 libc = "0.2.65"
 parking_lot = "0.12"
 jack = { version = "0.9", optional = true }


### PR DESCRIPTION
It seems `nix` is not needed as a direct dependency, as `alsa` is re-exporting everything `cpal` needs from it