### PR TITLE
Fix compile issues in wasm-beep example

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -313,8 +313,8 @@ jobs:
     - name: Build iphonesimulator feedback example
       run: cd examples/ios-feedback && xcodebuild -scheme cpal-ios-example -configuration Debug -derivedDataPath build -sdk iphonesimulator
 
-  wasm-beep-check:
-    # this only checks that the Rust source builds
+  wasm-beep-build:
+    # this only confirms that the Rust source builds
     # and checks to prevent regressions like #721.
     #
     # It does not test the javascript/web integration
@@ -323,5 +323,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cargo Check
         working-directory: ./examples/wasm-beep
-        run: cargo check
+        run: cargo build --example beep --target wasm32-unknown-unknown --features=wasm-bindgen
 

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -321,7 +321,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Cargo Check
+      - name: Install Target
+        run: rustup taret add wasm32-unknown-unknown
+      - name: Cargo Build
         working-directory: ./examples/wasm-beep
         run: cargo build --target wasm32-unknown-unknown
 

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -313,3 +313,15 @@ jobs:
     - name: Build iphonesimulator feedback example
       run: cd examples/ios-feedback && xcodebuild -scheme cpal-ios-example -configuration Debug -derivedDataPath build -sdk iphonesimulator
 
+  wasm-beep-check:
+    # this only checks that the Rust source builds
+    # and checks to prevent regressions like #721.
+    #
+    # It does not test the javascript/web integration
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cargo Check
+        working-directory: ./examples/wasm-beep
+        run: cargo check
+

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -323,5 +323,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Cargo Check
         working-directory: ./examples/wasm-beep
-        run: cargo build --example beep --target wasm32-unknown-unknown --features=wasm-bindgen
+        run: cargo build --target wasm32-unknown-unknown
 

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -322,7 +322,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Target
-        run: rustup taret add wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
       - name: Cargo Build
         working-directory: ./examples/wasm-beep
         run: cargo build --target wasm32-unknown-unknown

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -43,7 +43,7 @@ pub fn beep() -> Handle {
 
 fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Stream
 where
-    T: cpal::Sample,
+    T: cpal::Sample + cpal::SizedSample,
 {
     let sample_rate = config.sample_rate.0 as f32;
     let channels = config.channels as usize;

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -43,7 +43,7 @@ pub fn beep() -> Handle {
 
 fn run<T>(device: &cpal::Device, config: &cpal::StreamConfig) -> Stream
 where
-    T: cpal::Sample + cpal::SizedSample,
+    T: cpal::Sample + cpal::SizedSample + cpal::FromSample<f32>,
 {
     let sample_rate = config.sample_rate.0 as f32;
     let channels = config.channels as usize;
@@ -71,10 +71,11 @@ where
 
 fn write_data<T>(output: &mut [T], channels: usize, next_sample: &mut dyn FnMut() -> f32)
 where
-    T: cpal::Sample,
+    T: cpal::Sample + cpal::FromSample<f32>,
 {
     for frame in output.chunks_mut(channels) {
-        let value: T = <dyn cpal::Sample>::from::<f32>(&next_sample());
+        let sample = next_sample();
+        let value = T::from_sample::<f32>(sample);
         for sample in frame.iter_mut() {
             *sample = value;
         }

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -74,7 +74,7 @@ where
     T: cpal::Sample,
 {
     for frame in output.chunks_mut(channels) {
-        let value: T = cpal::Sample::from::<f32>(&next_sample());
+        let value: T = <dyn cpal::Sample>::from::<f32>(&next_sample());
         for sample in frame.iter_mut() {
             *sample = value;
         }

--- a/examples/wasm-beep/src/lib.rs
+++ b/examples/wasm-beep/src/lib.rs
@@ -38,6 +38,7 @@ pub fn beep() -> Handle {
         cpal::SampleFormat::F32 => run::<f32>(&device, &config.into()),
         cpal::SampleFormat::I16 => run::<i16>(&device, &config.into()),
         cpal::SampleFormat::U16 => run::<u16>(&device, &config.into()),
+        _ => panic!("unsupported sample format"),
     })
 }
 


### PR DESCRIPTION
Fixes #721 

Changes to a dependency library broke compilation of the example. Changes needed to get the example working and warning-free include:

1. specifying additional type constraints in local implementations
2. using the `FromSample` trait to convert samples in the handler
3. adding a default matcher in response to the non-exhaustive attribute on `SampleFormat`

