### PR TITLE
Update `windows-rs` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Update `windows-rs` dependency
+
 # Version 0.14.1 (2022-10-23)
 
 - Support the 0.6.1 release of `alsa-rs`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4.0", features = ["derive"] }
 ndk-glue = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.37", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
+windows = { version = "0.43.0", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.12"

--- a/src/host/wasapi/com.rs
+++ b/src/host/wasapi/com.rs
@@ -2,7 +2,6 @@
 
 use super::IoError;
 use std::marker::PhantomData;
-use std::ptr;
 
 use windows::Win32::Foundation::RPC_E_CHANGED_MODE;
 use windows::Win32::System::Com::{CoInitializeEx, CoUninitialize, COINIT_APARTMENTTHREADED};
@@ -15,7 +14,7 @@ thread_local!(static COM_INITIALIZED: ComInitialized = {
         // This call can fail with RPC_E_CHANGED_MODE if another library initialized COM with MTA.
         // That's OK though since COM ensures thread-safety/compatibility through marshalling when
         // necessary.
-        let result = CoInitializeEx(ptr::null_mut(), COINIT_APARTMENTTHREADED);
+        let result = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
         match result.clone().map_err(|e| e.code()) {
             Ok(_) |
             Err(RPC_E_CHANGED_MODE) => {


### PR DESCRIPTION
## Description/motivation
It would be nice to get the windows crate dependency updated to the latest version to avoid duplicated dependencies like this one: https://github.com/bevyengine/bevy/actions/runs/3451394906/jobs/5760584454

This is my attempt to help with that. Feedback is welcome!

## Code review notes
A lot of the changes were just changing null pointer arguments to None which should be straightforward. 

There are a couple places I don't fully understand the consequences and just did what I needed to satisfy the type checker. If anyone more familiar with FFI and/or the Windows API can confirm it looks correct that would be much appreciated.
Especially around this section here with the pointer to a pointer, that was definitely something I don't deal with often: https://github.com/paul-hansen/cpal/blob/1c1c29ea1b627e433b5dea47343d0c63b4cc85a1/src/host/wasapi/device.rs#L225-L236