### PR TITLE
Cargo.toml: drop dependency on nix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.6"
-nix = "0.25"
 libc = "0.2.65"
 parking_lot = "0.12"
 jack = { version = "0.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cpal"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["The CPAL contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Low-level cross-platform audio I/O library in pure Rust."
 repository = "https://github.com/rustaudio/cpal"


### PR DESCRIPTION
It is not used directly, only reexported version from alsa

Direct use of `nix` crate was removed back in 214403f 