### PR TITLE
Update synth_tones.rs example program

### DIFF
--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -6,11 +6,8 @@ extern crate anyhow;
 extern crate clap;
 extern crate cpal;
 
-use cpal::{
-    traits::{DeviceTrait, HostTrait, StreamTrait},
-    SizedSample,
-};
-use cpal::{FromSample, Sample};
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+use cpal::Sample;
 
 fn main() -> anyhow::Result<()> {
     let stream = stream_setup_for(sample_next)?;
@@ -47,23 +44,9 @@ where
     let (_host, device, config) = host_device_setup()?;
 
     match config.sample_format() {
-        cpal::SampleFormat::I8 => stream_make::<i8, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::I16 => stream_make::<i16, _>(&device, &config.into(), on_sample),
-        // cpal::SampleFormat::I24 => stream_make::<I24, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::I32 => stream_make::<i32, _>(&device, &config.into(), on_sample),
-        // cpal::SampleFormat::I48 => stream_make::<I48, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::I64 => stream_make::<i64, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::U8 => stream_make::<u8, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::U16 => stream_make::<u16, _>(&device, &config.into(), on_sample),
-        // cpal::SampleFormat::U24 => stream_make::<U24, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::U32 => stream_make::<u32, _>(&device, &config.into(), on_sample),
-        // cpal::SampleFormat::U48 => stream_make::<U48, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::U64 => stream_make::<u64, _>(&device, &config.into(), on_sample),
         cpal::SampleFormat::F32 => stream_make::<f32, _>(&device, &config.into(), on_sample),
-        cpal::SampleFormat::F64 => stream_make::<f64, _>(&device, &config.into(), on_sample),
-        sample_format => Err(anyhow::Error::msg(format!(
-            "Unsupported sample format '{sample_format}'"
-        ))),
     }
 }
 
@@ -88,7 +71,7 @@ pub fn stream_make<T, F>(
     on_sample: F,
 ) -> Result<cpal::Stream, anyhow::Error>
 where
-    T: SizedSample + FromSample<f32>,
+    T: Sample,
     F: FnMut(&mut SampleRequestOptions) -> f32 + std::marker::Send + 'static + Copy,
 {
     let sample_rate = config.sample_rate.0 as f32;
@@ -107,7 +90,6 @@ where
             on_window(output, &mut request, on_sample)
         },
         err_fn,
-        None,
     )?;
 
     Ok(stream)
@@ -115,11 +97,11 @@ where
 
 fn on_window<T, F>(output: &mut [T], request: &mut SampleRequestOptions, mut on_sample: F)
 where
-    T: Sample + FromSample<f32>,
+    T: Sample,
     F: FnMut(&mut SampleRequestOptions) -> f32 + std::marker::Send + 'static,
 {
     for frame in output.chunks_mut(request.nchannels) {
-        let value: T = T::from_sample(on_sample(request));
+        let value: T = T::from(&on_sample(request));
         for sample in frame.iter_mut() {
             *sample = value;
         }


### PR DESCRIPTION
The example for `synth_tones.rs` was slightly outdated and didn't compile for me on 0.14.2. This fixes the example so it works on the current version.
