### PR TITLE
Support i32 for asio

### DIFF
--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -209,13 +209,8 @@ pub(crate) fn convert_data_type(ty: &sys::AsioSampleType) -> Option<SampleFormat
         sys::AsioSampleType::ASIOSTInt16LSB => SampleFormat::I16,
         sys::AsioSampleType::ASIOSTFloat32MSB => SampleFormat::F32,
         sys::AsioSampleType::ASIOSTFloat32LSB => SampleFormat::F32,
-        // NOTE: While ASIO does not support these formats directly, the stream callback created by
-        // CPAL supports converting back and forth between the following. This is because many ASIO
-        // drivers only support `Int32` formats, while CPAL does not support this format at all. We
-        // allow for this implicit conversion temporarily until CPAL gets support for an `I32`
-        // format.
-        sys::AsioSampleType::ASIOSTInt32MSB => SampleFormat::I16,
-        sys::AsioSampleType::ASIOSTInt32LSB => SampleFormat::I16,
+        sys::AsioSampleType::ASIOSTInt32MSB => SampleFormat::I32,
+        sys::AsioSampleType::ASIOSTInt32LSB => SampleFormat::I32,
         _ => return None,
     };
     Some(fmt)

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -605,7 +605,7 @@ fn check_config(
     }
     // unsigned formats are not supported by asio
     match sample_format {
-        SampleFormat::I16 | SampleFormat::F32 => (),
+        SampleFormat::I16 | SampleFormat::I32 | SampleFormat::F32 => (),
         _ => return Err(BuildStreamError::StreamConfigNotSupported),
     }
     if *channels > num_asio_channels {


### PR DESCRIPTION
## Add `SampleFormat::I32` support for ASIO

Hi, I was testing out asio and to get it working with ASIO I had to make these changes to allow ASIO to use i32.
I think the comment explaining why `ASIOSTInt32` is mapped to `SampleFormat::I16` is not relevant any more seeing as `SampleFormat::I32` has been added.

Note:
I also had to apply https://github.com/RustAudio/cpal/pull/626 to get cpal to work without segfault.