### PR TITLE
make oboe's shared-stdcxx feature accessible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
+oboe-shared-stdcxx = ["oboe/shared-stdcxx"] # Only available on Android. See README for what it does.
 
 [dependencies]
 thiserror = "1.0"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Some audio backends are optional and will only be compiled with a [feature flag]
 - JACK (on Linux): `jack`
 - ASIO (on Windows): `asio`
 
+Oboe can either use a shared or static runtime. The static runtime is used by default, but activating the
+`oboe-shared-stdcxx` feature makes it use the shared runtime, which requires `libc++_shared.so` from the Android NDK to
+be present during execution.
+
 ## ASIO on Windows
 
 [ASIO](https://en.wikipedia.org/wiki/Audio_Stream_Input/Output) is an audio


### PR DESCRIPTION
This PR exposes oboes shared-stdcxx feature from cpal. Access to this was required for us to fix builds on a couple android targets