### PR TITLE
Fixed wasapi thread panics involving the main(or other) thread(when Stream drops).

### DIFF
--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use std::mem;
 use std::ptr;
-use std::sync::mpsc::{channel, Receiver, Sender, SendError};
+use std::sync::mpsc::{channel, Receiver, SendError, Sender};
 use std::thread::{self, JoinHandle};
 use windows::Win32::Foundation;
 use windows::Win32::Foundation::WAIT_OBJECT_0;


### PR DESCRIPTION
## Problem
- when main(or other) thread(s) tries to drop Stream object, it would panic at [host/wasapi/stream.rs Stream::drop()](https://github.com/RustAudio/cpal/blob/e5ccc46afa4a420421c54f513dcd0ccd0202d70e/src/host/wasapi/stream.rs#L164) if wasapi thread is dead. 
- it's problematic when the user wants to do something after all the cpal objects have been dropped.
- main(or other) thread(s) can't know if wasapi thread's alive or dead.

## Suggestion
Let's add a return value to `push_command()`, and handle the errors where it is called.