### PR TITLE
Re-run build script if CPAL_ASIO_DIR changes or the folder it points to does

### DIFF
--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -13,6 +13,8 @@ const ASIO_SYS_HEADER: &str = "asiosys.h";
 const ASIO_DRIVERS_HEADER: &str = "asiodrivers.h";
 
 fn main() {
+    println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
+    
     // If ASIO directory isn't set silently return early
     let cpal_asio_dir_var = match env::var(CPAL_ASIO_DIR) {
         Err(_) => return,

--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -14,7 +14,7 @@ const ASIO_DRIVERS_HEADER: &str = "asiodrivers.h";
 
 fn main() {
     println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
-    
+
     // If ASIO directory isn't set silently return early
     let cpal_asio_dir_var = match env::var(CPAL_ASIO_DIR) {
         Err(_) => return,
@@ -23,6 +23,7 @@ fn main() {
 
     // Asio directory
     let cpal_asio_dir = PathBuf::from(cpal_asio_dir_var);
+    println!("cargo:rerun-if-changed={}", cpal_asio_dir.display());
 
     // Directory where bindings and library are created
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("bad path"));

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
 fn main() {
     println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
-    
+
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag
     match env::var(CPAL_ASIO_DIR) {

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,8 @@ use std::env;
 const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
 fn main() {
+    println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
+    
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag
     match env::var(CPAL_ASIO_DIR) {


### PR DESCRIPTION
If this isn't done, then a `cargo clean` is required to toggle asio support on and off.