### PR TITLE
switch from mach to mach2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ jack = { version = "0.11", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
-mach = "0.3" # For access to mach_timebase type.
+mach2 = "0.4" # For access to mach_timebase type.
 parking_lot = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -72,8 +72,8 @@ fn asbd_from_config(
 fn host_time_to_stream_instant(
     m_host_time: u64,
 ) -> Result<crate::StreamInstant, BackendSpecificError> {
-    let mut info: mach::mach_time::mach_timebase_info = Default::default();
-    let res = unsafe { mach::mach_time::mach_timebase_info(&mut info) };
+    let mut info: mach2::mach_time::mach_timebase_info = Default::default();
+    let res = unsafe { mach2::mach_time::mach_timebase_info(&mut info) };
     check_os_status(res)?;
     let nanos = m_host_time * info.numer as u64 / info.denom as u64;
     let secs = nanos / 1_000_000_000;


### PR DESCRIPTION
crate `mach` is unmaintained and hasn't been updated in 4 years https://github.com/fitzgen/mach/issues/63

crate `mach2` is now the updated version https://github.com/JohnTitor/mach2

This works the same on my Mac 👍 
