### PR TITLE
bump windows dependency to 0.46

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.0", features = ["derive"] }
 ndk-glue = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.44.0", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
+windows = { version = "0.46.0", features = ["Win32_Media_Audio", "Win32_Foundation", "Win32_System_Com", "Win32_Devices_Properties", "Win32_Media_KernelStreaming", "Win32_System_Com_StructuredStorage", "Win32_System_Ole", "Win32_System_Threading", "Win32_Security", "Win32_System_SystemServices", "Win32_System_WindowsProgramming", "Win32_Media_Multimedia", "Win32_UI_Shell_PropertiesSystem"]}
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.12"

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use super::com;
 use super::{windows_err_to_cpal_err, windows_err_to_cpal_err_message};
-use windows::core::Interface;
+use windows::core::ComInterface;
 use windows::core::GUID;
 use windows::Win32::Devices::Properties;
 use windows::Win32::Foundation;


### PR DESCRIPTION
The current version of `cpal` requires Rust `1.64` to compile on Windows. This updates the `windows` dependency, which hopefully reduces the MSRV again because of https://github.com/microsoft/windows-rs/pull/2318.