### PR TITLE
Added must use to stream. Fixes issue #589

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -68,7 +68,7 @@ macro_rules! impl_platform_host {
         // functions within the callback.
         //
         // TODO: Confirm this and add more specific detail and references.
-        #[must_use = "If the stream is not used it will not play."]
+        #[must_use = "If the stream is not stored it will not play."]
         pub struct Stream(StreamInner, crate::platform::NotSendSyncAcrossAllPlatforms);
 
         /// The `SupportedInputConfigs` iterator associated with the platform's dynamically

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -68,7 +68,7 @@ macro_rules! impl_platform_host {
         // functions within the callback.
         //
         // TODO: Confirm this and add more specific detail and references.
-        #[must_use = "If the stream is not assigned it will not play."]
+        #[must_use = "If the stream is not used it will not play."]
         pub struct Stream(StreamInner, crate::platform::NotSendSyncAcrossAllPlatforms);
 
         /// The `SupportedInputConfigs` iterator associated with the platform's dynamically

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -68,6 +68,7 @@ macro_rules! impl_platform_host {
         // functions within the callback.
         //
         // TODO: Confirm this and add more specific detail and references.
+        #[must_use = "If the stream is not assigned it will not play."]
         pub struct Stream(StreamInner, crate::platform::NotSendSyncAcrossAllPlatforms);
 
         /// The `SupportedInputConfigs` iterator associated with the platform's dynamically


### PR DESCRIPTION
This fixes issue #589.
This warning makes is such that if a function returns a Stream it gives a warning if the stream is not assigned.
It also works for `Result(Stream, Box<dyn Error>)` so using the `?` operator will still give a warning about an unused stream even if the result is unwrapped.
The is an abbreviated example:
```rust
fn run<T>(device: &Device, config: &StreamConfig) -> Result<Stream, Box<dyn Error>>{
    let stream = device.build_output_stream(
            config,
            next_value,
            err_fn,
            None,
        )?;
    stream.play()?;
    Ok(stream)
}

let main() -> Result<(), Box<dyn Error>> {
    let _stream = run(&device, &config)?; // will work and will output sound until `_stream` is dropped

    // Previously didn't do anything on success. Now it will warn that it won't do anything.
    run(&device, &config)?;
}
```
