### PR TITLE
WASM: Fix issues with `play`, `pause`, and browser autoplay blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,12 +52,12 @@ coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_
 wasm-bindgen = { version = "0.2.58" }
 wasm-bindgen-futures = "0.4.33"
 js-sys = { version = "0.3.35" }
-web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }
+web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Performance", "Window", "AudioContextState"] }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.58", optional = true }
 js-sys = { version = "0.3.35" }
-web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }
+web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Performance", "Window", "AudioContextState"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 oboe = { version = "0.5", features = [ "java-interface" ] }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     PlayStreamError, SampleFormat, SampleRate, StreamConfig, StreamError, SupportedBufferSize,
     SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError,
 };
+use std::cell::RefCell;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
@@ -27,9 +28,7 @@ pub struct Host;
 
 pub struct Stream {
     ctx: Arc<AudioContext>,
-    on_ended_closures: Vec<Arc<RwLock<Option<Closure<dyn FnMut()>>>>>,
-    config: StreamConfig,
-    buffer_size_frames: usize,
+    state: RefCell<StreamCallbackState>,
 }
 
 pub type SupportedInputConfigs = ::std::vec::IntoIter<SupportedStreamConfigRange>;
@@ -215,8 +214,6 @@ impl DeviceTrait for Device {
         let buffer_size_samples = buffer_size_frames * n_channels;
         let buffer_time_step_secs = buffer_time_step_secs(buffer_size_frames, config.sample_rate);
 
-        let data_callback = Arc::new(Mutex::new(Box::new(data_callback)));
-
         // Create the WebAudio stream.
         let mut stream_opts = AudioContextOptions::new();
         stream_opts.sample_rate(config.sample_rate.0 as f32);
@@ -237,127 +234,22 @@ impl DeviceTrait for Device {
             destination.set_channel_count(config.channels as u32);
         }
 
-        let ctx = Arc::new(ctx);
-
-        // A container for managing the lifecycle of the audio callbacks.
-        let mut on_ended_closures: Vec<Arc<RwLock<Option<Closure<dyn FnMut()>>>>> = Vec::new();
-
-        // A cursor keeping track of the current time at which new frames should be scheduled.
-        let time = Arc::new(RwLock::new(0f64));
-
-        // Create a set of closures / callbacks which will continuously fetch and schedule sample
-        // playback. Starting with two workers, e.g. a front and back buffer so that audio frames
-        // can be fetched in the background.
-        for _i in 0..2 {
-            let data_callback_handle = data_callback.clone();
-            let ctx_handle = ctx.clone();
-            let time_handle = time.clone();
-
-            // A set of temporary buffers to be used for intermediate sample transformation steps.
-            let mut temporary_buffer = vec![0f32; buffer_size_samples];
-            let mut temporary_channel_buffer = vec![0f32; buffer_size_frames];
-
-            // Create a webaudio buffer which will be reused to avoid allocations.
-            let ctx_buffer = ctx
-                .create_buffer(
-                    config.channels as u32,
-                    buffer_size_frames as u32,
-                    config.sample_rate.0 as f32,
-                )
-                .map_err(|err| -> BuildStreamError {
-                    let description = format!("{:?}", err);
-                    let err = BackendSpecificError { description };
-                    err.into()
-                })?;
-
-            // A self reference to this closure for passing to future audio event calls.
-            let on_ended_closure: Arc<RwLock<Option<Closure<dyn FnMut()>>>> =
-                Arc::new(RwLock::new(None));
-            let on_ended_closure_handle = on_ended_closure.clone();
-
-            on_ended_closure
-                .write()
-                .unwrap()
-                .replace(Closure::wrap(Box::new(move || {
-                    let now = ctx_handle.current_time();
-                    let time_at_start_of_buffer = {
-                        let time_at_start_of_buffer = time_handle
-                            .read()
-                            .expect("Unable to get a read lock on the time cursor");
-                        // Synchronise first buffer as necessary (eg. keep the time value
-                        // referenced to the context clock).
-                        if *time_at_start_of_buffer > 0.001 {
-                            *time_at_start_of_buffer
-                        } else {
-                            // 25ms of time to fetch the first sample data, increase to avoid
-                            // initial underruns.
-                            now + 0.025
-                        }
-                    };
-
-                    // Populate the sample data into an interleaved temporary buffer.
-                    {
-                        let len = temporary_buffer.len();
-                        let data = temporary_buffer.as_mut_ptr() as *mut ();
-                        let mut data = unsafe { Data::from_parts(data, len, sample_format) };
-                        let mut data_callback = data_callback_handle.lock().unwrap();
-                        let callback = crate::StreamInstant::from_secs_f64(now);
-                        let playback = crate::StreamInstant::from_secs_f64(time_at_start_of_buffer);
-                        let timestamp = crate::OutputStreamTimestamp { callback, playback };
-                        let info = OutputCallbackInfo { timestamp };
-                        (data_callback.deref_mut())(&mut data, &info);
-                    }
-
-                    // Deinterleave the sample data and copy into the audio context buffer.
-                    // We do not reference the audio context buffer directly e.g. getChannelData.
-                    // As wasm-bindgen only gives us a copy, not a direct reference.
-                    for channel in 0..n_channels {
-                        for i in 0..buffer_size_frames {
-                            temporary_channel_buffer[i] =
-                                temporary_buffer[n_channels * i + channel];
-                        }
-                        ctx_buffer
-                            .copy_to_channel(&mut temporary_channel_buffer, channel as i32)
-                            .expect("Unable to write sample data into the audio context buffer");
-                    }
-
-                    // Create an AudioBufferSourceNode, schedule it to playback the reused buffer
-                    // in the future.
-                    let source = ctx_handle
-                        .create_buffer_source()
-                        .expect("Unable to create a webaudio buffer source");
-                    source.set_buffer(Some(&ctx_buffer));
-                    source
-                        .connect_with_audio_node(&ctx_handle.destination())
-                        .expect(
-                        "Unable to connect the web audio buffer source to the context destination",
-                    );
-                    source.set_onended(Some(
-                        on_ended_closure_handle
-                            .read()
-                            .unwrap()
-                            .as_ref()
-                            .unwrap()
-                            .as_ref()
-                            .unchecked_ref(),
-                    ));
-
-                    source
-                        .start_with_when(time_at_start_of_buffer)
-                        .expect("Unable to start the webaudio buffer source");
-
-                    // Keep track of when the next buffer worth of samples should be played.
-                    *time_handle.write().unwrap() = time_at_start_of_buffer + buffer_time_step_secs;
-                }) as Box<dyn FnMut()>));
-
-            on_ended_closures.push(on_ended_closure);
-        }
+        let ctx_handle = Arc::new(ctx);
 
         Ok(Stream {
-            ctx,
-            on_ended_closures,
-            config: config.clone(),
-            buffer_size_frames,
+            ctx: ctx_handle.clone(),
+            state: RefCell::new(StreamCallbackState {
+                ctx: ctx_handle,
+                data_callback: Arc::new(Mutex::new(Box::new(data_callback))),
+                timings: Arc::default(),
+                on_ended_closures: Vec::new(),
+                playing: false,
+                config: config.clone(),
+                buffer_size_frames,
+                sample_format,
+                buffer_size_samples,
+                buffer_time_step_secs
+            }),
         })
     }
 }
@@ -372,48 +264,24 @@ impl Stream {
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
-        let window = web_sys::window().unwrap();
-        match self.ctx.resume() {
-            Ok(_) => {
-                // Begin webaudio playback, initially scheduling the closures to fire on a timeout
-                // event.
-                let mut offset_ms = 10;
-                let time_step_secs =
-                    buffer_time_step_secs(self.buffer_size_frames, self.config.sample_rate);
-                let time_step_ms = (time_step_secs * 1_000.0) as i32;
-                for on_ended_closure in self.on_ended_closures.iter() {
-                    window
-                        .set_timeout_with_callback_and_timeout_and_arguments_0(
-                            on_ended_closure
-                                .read()
-                                .unwrap()
-                                .as_ref()
-                                .unwrap()
-                                .as_ref()
-                                .unchecked_ref(),
-                            offset_ms,
-                        )
-                        .unwrap();
-                    offset_ms += time_step_ms;
-                }
-                Ok(())
-            }
-            Err(err) => {
-                let description = format!("{:?}", err);
-                let err = BackendSpecificError { description };
-                Err(err.into())
-            }
+        let mut state = self.state.borrow_mut();
+
+        if state.playing {
+            Ok(())
+        }
+        else {
+            state.play()
         }
     }
 
     fn pause(&self) -> Result<(), PauseStreamError> {
-        match self.ctx.suspend() {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                let description = format!("{:?}", err);
-                let err = BackendSpecificError { description };
-                Err(err.into())
-            }
+        let mut state = self.state.borrow_mut();
+
+        if state.playing {
+            state.pause()
+        }
+        else {
+            Ok(())
         }
     }
 }
@@ -479,4 +347,286 @@ fn valid_config(conf: &StreamConfig, sample_format: SampleFormat) -> bool {
 
 fn buffer_time_step_secs(buffer_size_frames: usize, sample_rate: SampleRate) -> f64 {
     buffer_size_frames as f64 / sample_rate.0 as f64
+}
+
+/// Allows for controlling the state of a stream's closures.
+struct StreamCallbackState {
+    /// A reference to the underlying audio context.
+    ctx: Arc<AudioContext>,
+    /// The data callback for gathering new frames of the stream.
+    data_callback: Arc<Mutex<Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send>>>,
+    /// The set of timings in use by the closures.
+    timings: Arc<RwLock<CallbackTimings>>,
+    /// The set of currently-running audio callbacks.
+    on_ended_closures: Vec<Arc<RwLock<Option<Closure<dyn FnMut()>>>>>,
+    /// Whether the stream is currently playing.
+    playing: bool,
+    /// The configuration of the stream
+    config: StreamConfig,
+    /// The number of frames in the stream's buffer.
+    buffer_size_frames: usize,
+    /// The format with which to take samples.
+    sample_format: SampleFormat,
+    /// The number of samples in the buffer.
+    buffer_size_samples: usize,
+    /// The timestep by which buffers should advance.
+    buffer_time_step_secs: f64
+}
+
+impl StreamCallbackState {
+    /// Attempts to resume the audio stream.
+    pub fn play(&mut self) -> Result<(), PlayStreamError> {
+        assert!(!self.playing, "Stream was already playing.");
+        
+        match self.ctx.resume() {
+            Ok(_) => {
+                if !self.timings.read().expect("Could not get read lock on stream timings.").context_played {
+                    if let Err(x) = self.create_ended_closures() {
+                        drop(self.ctx.suspend());
+                        return Err(x);
+                    }
+    
+                    self.start_closures();
+                }
+
+                self.playing = true;
+                Ok(())
+            }
+            Err(err) => {
+                let description = format!("{:?}", err);
+                let err = BackendSpecificError { description };
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Attempts to pause the audio stream.
+    pub fn pause(&mut self) -> Result<(), PauseStreamError> {
+        assert!(self.playing, "Stream was not playing.");
+
+        self.timings.write().expect("Could not get write lock on stream timings.").cancel_if_unplayed();
+
+        match self.ctx.suspend() {
+            Ok(_) => {
+                self.playing = false;
+                Ok(())
+            },
+            Err(err) => {
+                let description = format!("{:?}", err);
+                let err = BackendSpecificError { description };
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Creates asynchronous closures for reading audio frames and sending data to the context.
+    fn create_ended_closures(&mut self) -> Result<(), PlayStreamError> {
+        // A container for managing the lifecycle of the audio callbacks.
+        self.on_ended_closures = Vec::new();
+
+        // A struct keeping track of the start time and current time at which new frames should be scheduled.
+        self.timings = Arc::default();
+
+        // Create a set of closures / callbacks which will continuously fetch and schedule sample
+        // playback. Starting with two workers, e.g. a front and back buffer so that audio frames
+        // can be fetched in the background.
+        for _i in 0..2 {
+            let data_callback_handle = self.data_callback.clone();
+            let ctx_handle = self.ctx.clone();
+            let time_handle = self.timings.clone();
+
+            // A set of temporary buffers to be used for intermediate sample transformation steps.
+            let mut temporary_buffer = vec![0f32; self.buffer_size_samples];
+            let mut temporary_channel_buffer = vec![0f32; self.buffer_size_frames];
+
+            // Create a webaudio buffer which will be reused to avoid allocations.
+            let ctx_buffer = self.ctx
+                .create_buffer(
+                    self.config.channels as u32,
+                    self.buffer_size_frames as u32,
+                    self.config.sample_rate.0 as f32,
+                )
+                .map_err(|err| -> PlayStreamError {
+                    let description = format!("{:?}", err);
+                    let err = BackendSpecificError { description };
+                    err.into()
+                })?;
+
+            // A self reference to this closure for passing to future audio event calls.
+            let on_ended_closure: Arc<RwLock<Option<Closure<dyn FnMut()>>>> =
+                Arc::new(RwLock::new(None));
+            let on_ended_closure_handle = on_ended_closure.clone();
+
+            let sample_format = self.sample_format;
+            let n_channels = self.config.channels as usize;
+            let buffer_size_frames = self.buffer_size_frames;
+            let buffer_time_step_secs = self.buffer_time_step_secs;
+
+            on_ended_closure
+                .write()
+                .unwrap()
+                .replace(Closure::wrap(Box::new(move || {
+                    let mut timing = time_handle.write().expect("Unable to get a write lock on the timing struct");
+
+                    if timing.cancelled {
+                        return;
+                    }
+
+                    let mut diff = *timing.start_time.get_or_insert_with(|| Self::get_monotonic_time_secs());
+                    if !timing.context_played {
+                        diff = Self::get_monotonic_time_secs() - diff;
+                        match ctx_handle.state() {
+                            web_sys::AudioContextState::Running => {
+                                timing.context_played = true;
+                                timing.time = 0.0;
+                                timing.start_time = Some(diff);
+                            },
+                            _ => drop(ctx_handle.resume().unwrap())
+                        }
+                    }
+
+                    let now = if timing.context_played { ctx_handle.current_time() } else { diff };
+                    let time_at_start_of_buffer = {
+                        let time_at_start_of_buffer = timing.time;
+                        // Synchronise first buffer as necessary (eg. keep the time value
+                        // referenced to the context clock).
+                        if time_at_start_of_buffer > 0.001 {
+                            time_at_start_of_buffer
+                        } else {
+                            // 25ms of time to fetch the first sample data, increase to avoid
+                            // initial underruns.
+                            now + 0.025
+                        }
+                    };
+
+                    // Populate the sample data into an interleaved temporary buffer.
+                    {
+                        let len = temporary_buffer.len();
+                        let data = temporary_buffer.as_mut_ptr() as *mut ();
+                        let mut data = unsafe { Data::from_parts(data, len, sample_format) };
+                        let mut data_callback = data_callback_handle.lock().unwrap();
+                        let callback = crate::StreamInstant::from_secs_f64(now);
+                        let playback = crate::StreamInstant::from_secs_f64(time_at_start_of_buffer);
+                        let timestamp = crate::OutputStreamTimestamp { callback, playback };
+                        let info = OutputCallbackInfo { timestamp };
+                        (data_callback.deref_mut())(&mut data, &info);
+                    }
+
+                    // Deinterleave the sample data and copy into the audio context buffer.
+                    // We do not reference the audio context buffer directly e.g. getChannelData.
+                    // As wasm-bindgen only gives us a copy, not a direct reference.
+                    for channel in 0..n_channels {
+                        for i in 0..buffer_size_frames {
+                            temporary_channel_buffer[i] =
+                                temporary_buffer[n_channels * i + channel];
+                        }
+                        ctx_buffer
+                            .copy_to_channel(&mut temporary_channel_buffer, channel as i32)
+                            .expect("Unable to write sample data into the audio context buffer");
+                    }
+
+                    if timing.context_played {
+                        // Create an AudioBufferSourceNode, schedule it to playback the reused buffer
+                        // in the future.
+                        let source = ctx_handle
+                            .create_buffer_source()
+                            .expect("Unable to create a webaudio buffer source");
+                        source.set_buffer(Some(&ctx_buffer));
+                        source
+                            .connect_with_audio_node(&ctx_handle.destination())
+                            .expect(
+                            "Unable to connect the web audio buffer source to the context destination",
+                        );
+                        source.set_onended(Some(
+                            on_ended_closure_handle
+                                .read()
+                                .unwrap()
+                                .as_ref()
+                                .unwrap()
+                                .as_ref()
+                                .unchecked_ref(),
+                        ));
+    
+                        source
+                            .start_with_when(time_at_start_of_buffer)
+                            .expect("Unable to start the webaudio buffer source");
+                    }
+                    else {
+                        web_sys::window().unwrap()
+                            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                                on_ended_closure_handle
+                                    .read()
+                                    .unwrap()
+                                    .as_ref()
+                                    .unwrap()
+                                    .as_ref()
+                                    .unchecked_ref(),
+                                (1000.0 * buffer_time_step_secs) as i32,
+                            )
+                            .unwrap();
+                    }
+
+                    // Keep track of when the next buffer worth of samples should be played.
+                    timing.time = time_at_start_of_buffer + buffer_time_step_secs;
+                }) as Box<dyn FnMut()>));
+
+            self.on_ended_closures.push(on_ended_closure);
+        }
+
+        Ok(())
+    }
+
+    /// Initializes the audio closures by scheduling them to run as a timeout event.
+    fn start_closures(&mut self) {
+        let window = web_sys::window().expect("Could not obtain reference to window object.");
+
+        // Begin webaudio playback, initially scheduling the closures to fire on a timeout
+        // event.
+        let mut offset_ms = 10;
+        let time_step_secs =
+            buffer_time_step_secs(self.buffer_size_frames, self.config.sample_rate);
+        let time_step_ms = (time_step_secs * 1_000.0) as i32;
+        for on_ended_closure in self.on_ended_closures.iter() {
+            window
+                .set_timeout_with_callback_and_timeout_and_arguments_0(
+                    on_ended_closure
+                        .read()
+                        .unwrap()
+                        .as_ref()
+                        .unwrap()
+                        .as_ref()
+                        .unchecked_ref(),
+                    offset_ms,
+                )
+                .unwrap();
+            offset_ms += time_step_ms;
+        }
+    }
+
+    /// Obtains the time, in seconds, of a monotonically increasing clock.
+    fn get_monotonic_time_secs() -> f64 {
+        web_sys::window().unwrap().performance().unwrap().now() / 1000.0
+    }
+}
+
+/// Describes the current timing and state of the playback closures.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+struct CallbackTimings {
+    /// The current time of the audio context.
+    pub time: f64,
+    /// The time at which playback was started from Rust.
+    pub start_time: Option<f64>,
+    /// Whether audio playback was paused or stopped.
+    pub cancelled: bool,
+    /// Whether the browser has allowed the context to begin playing yet.
+    pub context_played: bool
+}
+
+impl CallbackTimings {
+    /// Cancels all of the audio callbacks if the stream was never allowed to start.
+    pub fn cancel_if_unplayed(&mut self) {
+        if !self.context_played {
+            self.cancelled = true;
+        }
+    }
 }

--- a/src/host/webaudio/mod.rs
+++ b/src/host/webaudio/mod.rs
@@ -288,6 +288,7 @@ impl StreamTrait for Stream {
 
 impl Drop for Stream {
     fn drop(&mut self) {
+        let _ = self.pause();
         let _ = self.ctx.close();
     }
 }


### PR DESCRIPTION
This PR improves the behavior of audio streams on WASM in the following ways:
- **Calling `play` multiple times on a `Stream` only calls `resume` on the underlying `AudioContext` a single time,** and only spawns background audio callbacks once. Previously, calling `play` from Rust multiple times in succession would spawn multiple closure instances and lead to stuttering audio.
- Browsers block audio playback until the user interacts with the webpage, and force the `AudioContext` to remain in the `Suspended` state. This is problematic for `cpal`'s WASM backend, because from the Rust side there is no way to determine whether audio playback has begun. **This PR causes the `Stream` to read and discard audio frames while the context is blocked, so it's as if the audio stream is always playing (but muted until the user interacts) once `play` is called.** Previously, the audio would simply hang if the user had not yet interacted with the page.
- **I've added support for running `cpal` with the `+atomics` target feature enabled.** This is accomplished by adding a secondary Javascript-side array into which frames are copied before they are played, since you cannot send frames to Javascript from a `SharedArrayBuffer` directly.

I'm happy to make any improvements necessary to get this PR merged! I would like to see all of these behaviors available in `cpal`, because they are the best fit for my use case.