### PR TITLE
Fixed warnings in asio_sys

### DIFF
--- a/asio-sys/src/bindings/errors.rs
+++ b/asio-sys/src/bindings/errors.rs
@@ -39,7 +39,21 @@ pub enum AsioErrorWrapper {
 
 impl fmt::Display for LoadDriverError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        match *self {
+            LoadDriverError::LoadDriverFailed => {
+                write!(
+                    f,
+                    "{}",
+                    "ASIO `loadDriver` function returned `false` indicating failure"
+                )
+            }
+            LoadDriverError::InitializationFailed(ref err) => {
+                write!(f, "{}", err)
+            }
+            LoadDriverError::DriverAlreadyExists => {
+                write!(f, "{}", "ASIO only supports loading one driver at a time")
+            }
+        }
     }
 }
 
@@ -70,37 +84,8 @@ impl fmt::Display for AsioError {
     }
 }
 
-impl Error for LoadDriverError {
-    fn description(&self) -> &str {
-        match *self {
-            LoadDriverError::LoadDriverFailed => {
-                "ASIO `loadDriver` function returned `false` indicating failure"
-            }
-            LoadDriverError::InitializationFailed(ref err) => err.description(),
-            LoadDriverError::DriverAlreadyExists => {
-                "ASIO only supports loading one driver at a time"
-            }
-        }
-    }
-}
-
-impl Error for AsioError {
-    fn description(&self) -> &str {
-        match *self {
-            AsioError::NoDrivers => "hardware input or output is not present or available",
-            AsioError::HardwareMalfunction => {
-                "hardware is malfunctioning (can be returned by any ASIO function)"
-            }
-            AsioError::InvalidInput => "input parameter invalid",
-            AsioError::BadMode => "hardware is in a bad mode or used in a bad mode",
-            AsioError::HardwareStuck => "hardware is not running when sample position is inquired",
-            AsioError::NoRate => "sample clock or rate cannot be determined or is not present",
-            AsioError::ASE_NoMemory => "not enough memory for completing the request",
-            AsioError::InvalidBufferSize => "buffersize out of range for device",
-            AsioError::UnknownError => "Error not in SDK",
-        }
-    }
-}
+impl Error for LoadDriverError {}
+impl Error for AsioError {}
 
 impl From<AsioError> for LoadDriverError {
     fn from(err: AsioError) -> Self {

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -26,6 +26,7 @@ pub struct Stream {
     playing: Arc<AtomicBool>,
     // Ensure the `Driver` does not terminate until the last stream is dropped.
     driver: Arc<sys::Driver>,
+    #[allow(dead_code)]
     asio_streams: Arc<Mutex<sys::AsioStreams>>,
     callback_id: sys::CallbackId,
 }


### PR DESCRIPTION
From #775 [(comment)](https://github.com/RustAudio/cpal/pull/775#issuecomment-1500953921)

Fixed `asio-sys/src/bindings/errors.rs`
`std::Error::description()` has been deprecated.
It should be replaced with `std::fmt::Display`
I found some code duplication in the `std::fmt::Display` and `std::Error` trait, so I have combined the code in `std::fmt::Display`.
This will be a breaking change, is that OK?
The `std::Error` implementation of `LoadDriverError` and `AsioError` is empty, but I think this is necessary for error handling, so I left it.

Fixed `src/host/asio/stream.rs`
I wondered what to do with the `asio_stream` field, but decided to ignore the warning as it might be there to extend the lifetime.I am not 100% sure that this is the right way to do it.
