### PR TITLE
Fix synth_tones frequency

### DIFF
--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -35,7 +35,7 @@ pub struct Oscillator {
 
 impl Oscillator {
     fn advance_sample(&mut self) {
-        self.current_sample_index = (self.current_sample_index + 1.0) % self.sample_rate;
+        self.current_sample_index = self.current_sample_index + 1.0;
     }
 
     fn set_waveform(&mut self, waveform: Waveform) {

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -35,7 +35,7 @@ pub struct Oscillator {
 
 impl Oscillator {
     fn advance_sample(&mut self) {
-        self.current_sample_index = self.current_sample_index + 1.0;
+        self.current_sample_index = (self.current_sample_index + 1.0) % self.sample_rate;
     }
 
     fn set_waveform(&mut self, waveform: Waveform) {

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -81,7 +81,6 @@ impl Oscillator {
     }
 
     fn tick(&mut self) -> f32 {
-        self.advance_sample();
         match self.waveform {
             Waveform::Sine => self.sine_wave(),
             Waveform::Square => self.square_wave(),

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -76,6 +76,8 @@ impl Oscillator {
         self.generative_waveform(1, 1.0)
     }
 
+    // DO NOT SUBMIT: PR discussion to be had on generative_waveform(), and
+    // triangle_wave() is not producing anything triangular.
     fn triangle_wave(&mut self) -> f32 {
         self.generative_waveform(2, 2.0)
     }

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -76,8 +76,6 @@ impl Oscillator {
         self.generative_waveform(1, 1.0)
     }
 
-    // DO NOT SUBMIT: PR discussion to be had on generative_waveform(), and
-    // triangle_wave() is not producing anything triangular.
     fn triangle_wave(&mut self) -> f32 {
         self.generative_waveform(2, 2.0)
     }


### PR DESCRIPTION
Each *_wave() function calls advance_sample(). Having tick() also call it results in skipping every second sample.

Given the name "tick()", one could argue whether advance_sample() rather belongs in this function than in *_wave().

More interesting to me though: I wondered about generative_waveform() trying to build what are fairly simple waveforms out of a finite number of sine waves. It's an interesting demonstration, but it's also (a) an inaccurate approximation (e.g. why stop at the nyquist frequency, vs continuing to 2x or 3x the nyquist frequency? - that does in fact give cleaner results in the time domain), and (b) error prone, as per the triangle wave being wrong.

Here's a graph showing each of the three waveforms currently produced by synth_tones. I've plotted all of them in one plot, 2.5 cycles of a waveform at a time - and due to the hacky way I grabbed samples, I've plotted the sine wave twice. Note that what was supposed to be a triangular wave, somehow turned out to be closer to "circular"? Maybe this can be fixed by changing the parameters to generative_waveform(), but... is this indirect demonstration of the DFT valuable enough to keep, or should we not make this example simpler and just generate the waves directly and accurately in the time domain?
![NyquistOriginal](https://github.com/RustAudio/cpal/assets/17109322/5a6e64b3-e2aa-4e6d-b39b-cc53b4a32abf)
![NyquistOriginalTriangle](https://github.com/RustAudio/cpal/assets/17109322/0c3c4444-dece-4535-9554-1cce96a4abb4)
![NyquistOriginalSquareWave](https://github.com/RustAudio/cpal/assets/17109322/26a88213-4ecd-41cc-9c6f-6c87012c9afa)
![NyquistOriginalSaw](https://github.com/RustAudio/cpal/assets/17109322/0c9dc0bd-c01a-48e9-969f-c0959f514a8f)

And for curiosity's sake, a plot with generative_waveform() continuing to 4x the nyquist frequency:
![NyquistTimesFour](https://github.com/RustAudio/cpal/assets/17109322/5aeaa5ec-cc1b-4fab-bc3c-33d4bf88de4b)

I was indeed curious under which conditions the sampled nature of the signal could avoid the ringing caused by using a finite number of waves. It's not going to help that the usual sampling rates (both 44100 Hz and 48000 Hz) aren't multiples of 440 Hz: so each cycle, there's a little phase shift in where the theoretical/analytical waveform is sampled.