### PR TITLE
Replace assert in WASAPI check with bubble'd error

### DIFF
--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -442,7 +442,7 @@ impl Device {
 
             // If the default format can't succeed we have no hope of finding other formats.
             if !is_format_supported(client, default_waveformatex_ptr.0)? {
-                let description = 
+                let description =
                     "Could not determine support for default `WAVEFORMATEX`".to_string();
                 let err = BackendSpecificError { description };
                 return Err(err.into());

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -441,7 +441,12 @@ impl Device {
                 .map_err(windows_err_to_cpal_err::<SupportedStreamConfigsError>)?;
 
             // If the default format can't succeed we have no hope of finding other formats.
-            assert!(is_format_supported(client, default_waveformatex_ptr.0)?);
+            if !is_format_supported(client, default_waveformatex_ptr.0)? {
+                let description = 
+                    "Could not determine support for default `WAVEFORMATEX`".to_string();
+                let err = BackendSpecificError { description };
+                return Err(err.into());
+            }
 
             // Copy the format to use as a test format (as to avoid mutating the original format).
             let mut test_format = {


### PR DESCRIPTION
This PR is following on to #796 regarding an `assert` in the wasapi layer.

This change just replaces it to bubble a backend specific error with an error message. For our use case, this stops a crash that pops up for some users who encounter this path and allows us to gracefully just not play audio and log a message elsewhere.

Lemme know if there's anything else besides the PR itself that needs adjusting or tending to - and thanks for the great library!