### PR TITLE
Audio Unit initialization fix on macOS

### DIFF
--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -297,7 +297,7 @@ impl Device {
             let ranges: *mut AudioValueRange = ranges.as_mut_ptr() as *mut _;
             let ranges: &'static [AudioValueRange] = slice::from_raw_parts(ranges, n_ranges);
 
-            let audio_unit = audio_unit_from_device(self, true)?;
+            let audio_unit = audio_unit_from_device(self, scope == kAudioObjectPropertyScopeInput)?;
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             // Collect the supported formats for the device.


### PR DESCRIPTION
The current Audio Unit initialization logic produces errors when trying to use output devices as input Audio Units. This results in only some output devices being present when enumerating the host devices.