### PR TITLE
Remove once_cell dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ documentation = "https://docs.rs/cpal"
 license = "Apache-2.0"
 keywords = ["audio", "sound"]
 edition = "2021"
+rust-version = "1.70"
 
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ windows = { version = "0.48.0", features = [
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
 parking_lot = "0.12"
-once_cell = "1.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.7"

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -5,7 +5,7 @@ use crate::{
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError, COMMON_SAMPLE_RATES,
 };
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 use std::ffi::OsString;
 use std::fmt;
 use std::mem;
@@ -880,23 +880,27 @@ impl Endpoint {
     }
 }
 
-static ENUMERATOR: Lazy<Enumerator> = Lazy::new(|| {
-    // COM initialization is thread local, but we only need to have COM initialized in the
-    // thread we create the objects in
-    com::com_initialized();
+static ENUMERATOR: OnceLock<Enumerator> = OnceLock::new();
 
-    // building the devices enumerator object
-    unsafe {
-        let enumerator = Com::CoCreateInstance::<_, Audio::IMMDeviceEnumerator>(
-            &Audio::MMDeviceEnumerator,
-            None,
-            Com::CLSCTX_ALL,
-        )
-        .unwrap();
+fn get_enumerator() -> &'static Enumerator {
+    ENUMERATOR.get_or_init(|| {
+        // COM initialization is thread local, but we only need to have COM initialized in the
+        // thread we create the objects in
+        com::com_initialized();
 
-        Enumerator(enumerator)
-    }
-});
+        // building the devices enumerator object
+        unsafe {
+            let enumerator = Com::CoCreateInstance::<_, Audio::IMMDeviceEnumerator>(
+                &Audio::MMDeviceEnumerator,
+                None,
+                Com::CLSCTX_ALL,
+            )
+            .unwrap();
+
+            Enumerator(enumerator)
+        }
+    })
+}
 
 /// Send/Sync wrapper around `IMMDeviceEnumerator`.
 struct Enumerator(Audio::IMMDeviceEnumerator);
@@ -915,7 +919,7 @@ impl Devices {
     pub fn new() -> Result<Self, DevicesError> {
         unsafe {
             // can fail because of wrong parameters (should never happen) or out of memory
-            let collection = ENUMERATOR
+            let collection = get_enumerator()
                 .0
                 .EnumAudioEndpoints(Audio::eAll, Audio::DEVICE_STATE_ACTIVE)
                 .map_err(BackendSpecificError::from)?;
@@ -959,7 +963,7 @@ impl Iterator for Devices {
 
 fn default_device(data_flow: Audio::EDataFlow) -> Option<Device> {
     unsafe {
-        let device = ENUMERATOR
+        let device = get_enumerator()
             .0
             .GetDefaultAudioEndpoint(data_flow, Audio::eConsole)
             .ok()?;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -5,7 +5,6 @@ use crate::{
     SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError, COMMON_SAMPLE_RATES,
 };
-use std::sync::OnceLock;
 use std::ffi::OsString;
 use std::fmt;
 use std::mem;
@@ -13,6 +12,7 @@ use std::ops::{Deref, DerefMut};
 use std::os::windows::ffi::OsStringExt;
 use std::ptr;
 use std::slice;
+use std::sync::OnceLock;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 


### PR DESCRIPTION
Removes the `once_cell` dependency, using `std::sync::OnceLock` instead.

This bumps the MSRV of the crate from 1.60 to 1.70. Given that #277 is currently unresolved, is this acceptable?