### PR TITLE
Automate asio sys build

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,44 +51,46 @@ WASAPI including access to large numbers of channels and lower-latency audio
 processing.
 
 CPAL allows for using the ASIO SDK as the audio host on Windows instead of
-WASAPI. To do so, follow these steps:
+WASAPI. 
 
-1. **Download the ASIO SDK** `.zip` from [this
-   link](https://www.steinberg.net/en/company/developers.html). The version as
-   of writing this is 2.3.1.
-2. Extract the files and place the directory somewhere you are happy for it to stay
-   (e.g. `~/.asio`).
-3. Assign the full path of the directory (that contains the `readme`, `changes`,
-   `ASIO SDK 2.3` pdf, etc) to the `CPAL_ASIO_DIR` environment variable. This is
-   necessary for the `asio-sys` build script to build and bind to the SDK.
-4. `bindgen`, the library used to generate bindings to the C++ SDK, requires
+### Locating the ASIO SDK
+
+The location of ASIO SDK is exposed to CPAL by setting the `CPAL_ASIO_DIR` environment variable.
+
+The build script will try to find the ASIO SDK by following these steps in order:  
+1. Check if `CPAL_ASIO_DIR` is set and if so use the path to point to the SDK.
+2. Check if the ASIO SDK is already installed in the temporary directory, if so use that and set the path of `CPAL_ASIO_DIR` to the output of `std::env::temp_dir().join("asio_sdk")`.
+3. If the ASIO SDK is not already installed, download it from <https://www.steinberg.net/asiosdk> and install it in the temporary directory. The path of `CPAL_ASIO_DIR` will be set to the output of `std::env::temp_dir().join("asio_sdk")`.
+
+In an ideal situation you don't need to worry about this step.
+ 
+### Preparing the build environment
+
+1. `bindgen`, the library used to generate bindings to the C++ SDK, requires
    clang. **Download and install LLVM** from
    [here](http://releases.llvm.org/download.html) under the "Pre-Built Binaries"
-   section. The version as of writing this is 7.0.0.
-5. Add the LLVM `bin` directory to a `LIBCLANG_PATH` environment variable. If
+   section. The version as of writing this is 17.0.1.
+2. Add the LLVM `bin` directory to a `LIBCLANG_PATH` environment variable. If
    you installed LLVM to the default directory, this should work in the command
    prompt:
    ```
    setx LIBCLANG_PATH "C:\Program Files\LLVM\bin"
    ```
-6. If you don't have any ASIO devices or drivers available, you can [**download
+3. If you don't have any ASIO devices or drivers available, you can [**download
    and install ASIO4ALL**](http://www.asio4all.org/). Be sure to enable the
    "offline" feature during installation despite what the installer says about
    it being useless.
-7. **Loading VCVARS**. `rust-bindgen` uses the C++ tool-chain when generating
-   bindings to the ASIO SDK. As a result, it is necessary to load some
-   environment variables in the command prompt that we used to build our project.
-   On 64-bit machines run:
+4. Our build script assumes that Microsoft Visual Studio is installed. The script will try to find `vcvarsall.bat` 
+   and execute it with the right machine architecture regardless of the Microsoft Visual Studio version. 
+   If there are any errors encountered in this process which is unlikely, 
+   you may find the `vcvarsall.bat` manually and execute it with your machine architecture as an argument. 
+   The script will detect this and skip the step.
+   
+   A manually executed command example for 64 bit machines:
    ```
-   "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+   "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
    ```
-   On 32-bit machines run:
-   ```
-   "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
-   ```
-   Note that, depending on your version of Visual Studio, this script might be
-   in a slightly different location.
-8. Select the ASIO host at the start of our program with the following code:
+5. Select the ASIO host at the start of our program with the following code:
 
    ```rust
    let host;
@@ -100,7 +102,7 @@ WASAPI. To do so, follow these steps:
 
    If you run into compilations errors produced by `asio-sys` or `bindgen`, make
    sure that `CPAL_ASIO_DIR` is set correctly and try `cargo clean`.
-9. Make sure to enable the `asio` feature when building CPAL:
+6. Make sure to enable the `asio` feature when building CPAL:
 
    ```
    cargo build --features "asio"
@@ -112,8 +114,5 @@ WASAPI. To do so, follow these steps:
    ```toml
    cpal = { version = "*", features = ["asio"] }
    ```
-
-In the future we would like to work on automating this process to make it
-easier, but we are not familiar enough with the ASIO license to do so yet.
-
+   
 *Updated as of ASIO version 2.3.3.*

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["audio", "sound", "asio", "steinberg"]
 build = "build.rs"
 
 [target.'cfg(any(target_os = "windows"))'.build-dependencies]
-bindgen = "0.64"
+bindgen = "0.68"
 walkdir = "2"
 cc = "1.0.25"
 

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -12,7 +12,9 @@ build = "build.rs"
 [target.'cfg(any(target_os = "windows"))'.build-dependencies]
 bindgen = "0.68"
 walkdir = "2"
-cc = "1.0.25"
+cc = "1.0.83"
+reqwest = { version = "0.11" , features = ["blocking"] }
+zip = "0.6"
 
 [dependencies]
 once_cell = "1.12"

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -13,8 +13,6 @@ build = "build.rs"
 bindgen = "0.68"
 walkdir = "2"
 cc = "1.0.83"
-reqwest = { version = "0.11" , features = ["blocking"] }
-zip = "0.6"
 
 [dependencies]
 once_cell = "1.12"

--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -24,16 +24,15 @@ fn main() {
     // Directory where bindings and library are created
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("bad path"));
 
-    let mut vc_vars_invoked = false;
-
     // Check if library exists,
     // if it doesn't create it
     let mut lib_path = out_dir.clone();
     lib_path.push("libasio.a");
     if !lib_path.exists() {
-        // Set env vars from vcvarsall.bat before attempting to build
-        invoke_vcvars();
-        vc_vars_invoked = true;
+        if !vcvars_set() {
+            println!("VCINSTALLDIR is not set. Attempting to invoke vcvarsall.bat..");
+            invoke_vcvars();
+        }
         create_lib(&cpal_asio_dir);
     }
 
@@ -49,8 +48,8 @@ fn main() {
     let mut binding_path = out_dir.clone();
     binding_path.push("asio_bindings.rs");
     if !binding_path.exists() {
-        // Set env vars from vcvarsall.bat before attempting to build if not already done
-        if !vc_vars_invoked {
+        if !vcvars_set() {
+            println!("VCINSTALLDIR is not set. Attempting to invoke vcvarsall.bat..");
             invoke_vcvars();
         }
         create_bindings(&cpal_asio_dir);
@@ -216,7 +215,7 @@ fn create_bindings(cpal_asio_dir: &PathBuf) {
 fn get_asio_dir() -> PathBuf {
     // Check if CPAL_ASIO_DIR env var is set
     if let Ok(path) = env::var(CPAL_ASIO_DIR) {
-        println!("CPAL_ASIO_DIR is set at {}", path);
+        println!("CPAL_ASIO_DIR is set at {path}");
         return PathBuf::from(path);
     }
 
@@ -229,7 +228,7 @@ fn get_asio_dir() -> PathBuf {
     }
 
     // If not found, download ASIO SDK using PowerShell's Invoke-WebRequest
-    println!("CPAL_ASIO_DIR is not set or contents are cached downloading from {}", ASIO_SDK_URL);
+    println!("CPAL_ASIO_DIR is not set or contents are cached downloading from {ASIO_SDK_URL}",);
 
     let asio_zip_path = temp_dir.join("asio_sdk.zip");
     let status = Command::new("powershell")
@@ -237,8 +236,7 @@ fn get_asio_dir() -> PathBuf {
             "-NoProfile",
             "-Command",
             &format!(
-                "Invoke-WebRequest -Uri {} -OutFile {}",
-                ASIO_SDK_URL,
+                "Invoke-WebRequest -Uri {ASIO_SDK_URL} -OutFile {}",
                 asio_zip_path.display()
             ),
         ])
@@ -298,7 +296,7 @@ fn invoke_vcvars() {
         panic!("Unsupported architecture");
     };
 
-    println!("Architecture detected as {}.", arch);
+    println!("Architecture detected as {arch}.");
 
     // Define search paths for vcvarsall.bat based on architecture
     let paths = if arch == "amd64" {
@@ -343,7 +341,10 @@ fn invoke_vcvars() {
         }
     }
 
-    panic!(
-        "Could not find vcvarsall.bat. Please install the latest version of Visual Studio."
-    );
+    panic!("Could not find vcvarsall.bat. Please install the latest version of Visual Studio.");
+}
+// Checks if vcvarsall.bat has been invoked
+// Assumes that it is very unlikely that the user would set VCINSTALLDIR manually
+fn vcvars_set() -> bool {
+    env::var("VCINSTALLDIR").is_ok()
 }


### PR DESCRIPTION
Hello all,

Having a rather manual pre build preparation process for the windows ASIO support could be cumbersome for users who'd like to install applications we publish to crates.io which depends on `cpal` by `cargo install` method because `cargo install` builds from source. 

This PR is a suggestion to automate the two steps which is laid out in the [readme.](https://github.com/RustAudio/cpal#asio-on-windows).

- Automate the finding and retrieval of ASIO SDK. 
- Set the build environment by invoking `vcvarsall.bat`

Trying to install LLVM would be out of scope for this script in my opinion because that is more general and essential to have a development environment. If the build fails due to that, normally the user can easily derive the reason from the error message. 

I didn't update the `README.md` yet but if you find this PR welcome, I'd gladly do so.

Looking forward to your review!

*I've tested all the code paths on a x86_64 machine running Windows 10. 
*The PR is an adaptation of a ps1 script I use for my project to automate the process in https://github.com/RustAudio/cpal/issues/801