### PR TITLE
Fix runtime errors on Android targets

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,13 @@
 use std::env;
-
 const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
 fn main() {
     println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
+
+    // This avoids runtime errors on Android targets.
+    if std::env::var("TARGET").unwrap().contains("android") {
+        println!("cargo:rustc-link-lib=c++_shared");
+    }
 
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag


### PR DESCRIPTION
When developing an Android app using `cpal` for sound effects I had to configure my `build.rs` to do this to avoid crashes at startup on certain phones. I figured I should help people avoid having to do the same debugging / work (it took many hours to figure this out) by adding the necessary code to `cpal`'s `build.rs`. 