### PR TITLE
Improve asio sys build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CPAL - Cross-Platform Audio Library
 
 [![Actions Status](https://github.com/RustAudio/cpal/workflows/cpal/badge.svg)](https://github.com/RustAudio/cpal/actions)
- [![Crates.io](https://img.shields.io/crates/v/cpal.svg)](https://crates.io/crates/cpal) [![docs.rs](https://docs.rs/cpal/badge.svg)](https://docs.rs/cpal/)
+[![Crates.io](https://img.shields.io/crates/v/cpal.svg)](https://crates.io/crates/cpal) [![docs.rs](https://docs.rs/cpal/badge.svg)](https://docs.rs/cpal/)
 
 Low-level library for audio input and output in pure Rust.
 
@@ -51,19 +51,20 @@ WASAPI including access to large numbers of channels and lower-latency audio
 processing.
 
 CPAL allows for using the ASIO SDK as the audio host on Windows instead of
-WASAPI. 
+WASAPI.
 
 ### Locating the ASIO SDK
 
 The location of ASIO SDK is exposed to CPAL by setting the `CPAL_ASIO_DIR` environment variable.
 
-The build script will try to find the ASIO SDK by following these steps in order:  
+The build script will try to find the ASIO SDK by following these steps in order:
+
 1. Check if `CPAL_ASIO_DIR` is set and if so use the path to point to the SDK.
 2. Check if the ASIO SDK is already installed in the temporary directory, if so use that and set the path of `CPAL_ASIO_DIR` to the output of `std::env::temp_dir().join("asio_sdk")`.
 3. If the ASIO SDK is not already installed, download it from <https://www.steinberg.net/asiosdk> and install it in the temporary directory. The path of `CPAL_ASIO_DIR` will be set to the output of `std::env::temp_dir().join("asio_sdk")`.
 
 In an ideal situation you don't need to worry about this step.
- 
+
 ### Preparing the build environment
 
 1. `bindgen`, the library used to generate bindings to the C++ SDK, requires
@@ -80,28 +81,33 @@ In an ideal situation you don't need to worry about this step.
    and install ASIO4ALL**](http://www.asio4all.org/). Be sure to enable the
    "offline" feature during installation despite what the installer says about
    it being useless.
-4. Our build script assumes that Microsoft Visual Studio is installed. The script will try to find `vcvarsall.bat` 
-   and execute it with the right machine architecture regardless of the Microsoft Visual Studio version. 
-   If there are any errors encountered in this process which is unlikely, 
-   you may find the `vcvarsall.bat` manually and execute it with your machine architecture as an argument. 
+4. Our build script assumes that Microsoft Visual Studio is installed if the host OS for compilation is Windows. The script will try to find `vcvarsall.bat`
+   and execute it with the right host and target machine architecture regardless of the Microsoft Visual Studio version.
+   If there are any errors encountered in this process which is unlikely,
+   you may find the `vcvarsall.bat` manually and execute it with your machine architecture as an argument.
    The script will detect this and skip the step.
-   
+
    A manually executed command example for 64 bit machines:
+
    ```
    "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" amd64
    ```
+
+   For more information please refer to the documentation of [`vcvarsall.bat``](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax).
+
 5. Select the ASIO host at the start of our program with the following code:
 
    ```rust
    let host;
    #[cfg(target_os = "windows")]
    {
-       host = cpal::host_from_id(cpal::HostId::Asio).expect("failed to initialise ASIO host");
+      host = cpal::host_from_id(cpal::HostId::Asio).expect("failed to initialise ASIO host");
    }
    ```
 
    If you run into compilations errors produced by `asio-sys` or `bindgen`, make
    sure that `CPAL_ASIO_DIR` is set correctly and try `cargo clean`.
+
 6. Make sure to enable the `asio` feature when building CPAL:
 
    ```
@@ -114,5 +120,23 @@ In an ideal situation you don't need to worry about this step.
    ```toml
    cpal = { version = "*", features = ["asio"] }
    ```
-   
-*Updated as of ASIO version 2.3.3.*
+
+_Updated as of ASIO version 2.3.3._
+
+### Cross compilation
+
+When Windows is the host and the target OS, the build script of `asio-sys` supports all cross compilation targets
+which are supported by the MSVC compiler. An exhaustive list of combinations could be found [here](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax) with the addition of undocumented `arm64`, `arm64_x86`, `arm64_amd64` and `arm64_arm` targets. (5.11.2023)
+
+It is also possible to compile Windows applications with ASIO support on Linux and macOS.
+
+For both platforms the common way to do this is to use the [MinGW-w64](https://www.mingw-w64.org/) toolchain.
+
+Make sure that you have included the `MinGW-w64` include directory in your `CPLUS_INCLUDE_PATH` environment variable.
+Make sure that LLVM is installed and include directory is also included in your `CPLUS_INCLUDE_PATH` environment variable.
+
+Example for macOS for the target of `x86_64-pc-windows-gnu` where `mingw-w64` is installed via brew:
+
+```
+export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/opt/homebrew/Cellar/mingw-w64/11.0.1/toolchain-x86_64/x86_64-w64-mingw32/include"
+```

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -9,12 +9,18 @@ license = "Apache-2.0"
 keywords = ["audio", "sound", "asio", "steinberg"]
 build = "build.rs"
 
-[target.'cfg(any(target_os = "windows"))'.build-dependencies]
-bindgen = "0.68"
+[build-dependencies]
+bindgen = "0.69"
 walkdir = "2"
 cc = "1.0.83"
+parse_cfg = "4.1.1"
 
 [dependencies]
 once_cell = "1.12"
-num-derive = "0.3"
+num-derive = "0.4"
 num-traits = "0.2"
+
+
+
+
+

--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -19,8 +19,3 @@ parse_cfg = "4.1.1"
 once_cell = "1.12"
 num-derive = "0.4"
 num-traits = "0.2"
-
-
-
-
-

--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -421,7 +421,7 @@ fn search_vcvars_all_bat() -> PathBuf {
     }
 
     // Define search paths for vcvarsall.bat based on architecture
-    let paths = vec![
+    let paths = &[
         // Visual Studio 2022+
         "C:\\Program Files\\Microsoft Visual Studio\\",
         // <= Visual Studio 2019
@@ -533,8 +533,9 @@ fn guess_vcvars_all_bat() -> Option<PathBuf> {
 /// Because of this there is no native or cross compilation is supported for 32 bit arm processors.
 fn determine_vcvarsall_bat_arch_arg() -> String {
     let host_architecture = std::env::consts::ARCH;
+    let target_architecture = std::env::var("CARGO_CFG_TARGET_ARCH").expect("Target not set.");
 
-    let arch_arg = if cfg!(target_arch = "x86_64") {
+    let arch_arg = if target_architecture == "x86_64" {
         if host_architecture == "x86" {
             // Arg for cross compilation from x86 to x64
             "x86_amd64"
@@ -547,7 +548,7 @@ fn determine_vcvarsall_bat_arch_arg() -> String {
         } else {
             panic!("Unsupported host architecture {}", host_architecture);
         }
-    } else if cfg!(target_arch = "x86") {
+    } else if target_architecture == "x86" {
         if host_architecture == "x86" {
             // Arg for native compilation from x86 to x86
             "x86"
@@ -560,7 +561,7 @@ fn determine_vcvarsall_bat_arch_arg() -> String {
         } else {
             panic!("Unsupported host architecture {}", host_architecture);
         }
-    } else if cfg!(target_arch = "arm") {
+    } else if target_architecture == "arm" {
         if host_architecture == "x86" {
             // Arg for cross compilation from x86 to arm
             "x86_arm"
@@ -573,7 +574,7 @@ fn determine_vcvarsall_bat_arch_arg() -> String {
         } else {
             panic!("Unsupported host architecture {}", host_architecture);
         }
-    } else if cfg!(target_arch = "aarch64") {
+    } else if target_architecture == "aarch64" {
         if host_architecture == "x86" {
             // Arg for cross compilation from x86 to arm
             "x86_arm64"

--- a/asio-sys/build.rs
+++ b/asio-sys/build.rs
@@ -1,9 +1,11 @@
 extern crate bindgen;
 extern crate cc;
+extern crate parse_cfg;
 extern crate walkdir;
 
+use parse_cfg::*;
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use walkdir::WalkDir;
 
@@ -13,6 +15,30 @@ const ASIO_SDK_URL: &str = "https://www.steinberg.net/asiosdk";
 const ASIO_HEADER: &str = "asio.h";
 const ASIO_SYS_HEADER: &str = "asiosys.h";
 const ASIO_DRIVERS_HEADER: &str = "asiodrivers.h";
+
+/// Checks if the host OS is Windows
+fn host_os_is_windows() -> bool {
+    std::env::consts::OS == "windows"
+}
+
+/// Checks if the target env is MSVC
+fn is_msvc() -> bool {
+    let target: Target = std::env::var("TARGET")
+        .expect("Target not set.")
+        .parse()
+        .expect("Unable to parse target.");
+
+    let target_env = match target {
+        Target::Triple { env, .. } => env,
+        Target::Cfg(_) => panic!("cfg targets not supported"),
+    };
+
+    if let Some(env) = target_env {
+        env.contains("msvc")
+    } else {
+        false
+    }
+}
 
 fn main() {
     println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
@@ -29,9 +55,8 @@ fn main() {
     let mut lib_path = out_dir.clone();
     lib_path.push("libasio.a");
     if !lib_path.exists() {
-        if !vcvars_set() {
-            println!("VCINSTALLDIR is not set. Attempting to invoke vcvarsall.bat..");
-            invoke_vcvars();
+        if is_msvc() {
+            invoke_vcvars_if_not_set();
         }
         create_lib(&cpal_asio_dir);
     }
@@ -48,19 +73,18 @@ fn main() {
     let mut binding_path = out_dir.clone();
     binding_path.push("asio_bindings.rs");
     if !binding_path.exists() {
-        if !vcvars_set() {
-            println!("VCINSTALLDIR is not set. Attempting to invoke vcvarsall.bat..");
-            invoke_vcvars();
+        if is_msvc() {
+            invoke_vcvars_if_not_set();
         }
         create_bindings(&cpal_asio_dir);
     }
 }
 
-fn create_lib(cpal_asio_dir: &PathBuf) {
+fn create_lib(cpal_asio_dir: &Path) {
     let mut cpp_paths: Vec<PathBuf> = Vec::new();
-    let mut host_dir = cpal_asio_dir.clone();
-    let mut pc_dir = cpal_asio_dir.clone();
-    let mut common_dir = cpal_asio_dir.clone();
+    let mut host_dir = cpal_asio_dir.to_path_buf();
+    let mut pc_dir = cpal_asio_dir.to_path_buf();
+    let mut common_dir = cpal_asio_dir.to_path_buf();
     host_dir.push("host");
     common_dir.push("common");
     pc_dir.push("host/pc");
@@ -112,7 +136,7 @@ fn create_bindings(cpal_asio_dir: &PathBuf) {
     let mut asio_drivers_header = None;
 
     // Recursively walk given cpal dir to find required headers
-    for entry in WalkDir::new(&cpal_asio_dir) {
+    for entry in WalkDir::new(cpal_asio_dir) {
         let entry = match entry {
             Err(_) => continue,
             Ok(entry) => entry,
@@ -206,12 +230,23 @@ fn create_bindings(cpal_asio_dir: &PathBuf) {
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_path = PathBuf::from(env::var("OUT_DIR").expect("bad path"));
-    //panic!("path: {}", out_path.display());
+
     bindings
         .write_to_file(out_path.join("asio_bindings.rs"))
         .expect("Couldn't write bindings!");
 }
 
+/// Gets the ASIO SDK directory
+///
+/// If the CPAL_ASIO_DIR env var is set, it will use that.
+///
+/// If not set, it will check the temp directory for the ASIO SDK.
+///
+/// If not found, it will download the ASIO SDK to the temp directory.
+///
+/// It will then move the contents of the inner directory to the temp directory.
+///
+/// It will then return the path to the ASIO SDK directory.
 fn get_asio_dir() -> PathBuf {
     // Check if CPAL_ASIO_DIR env var is set
     if let Ok(path) = env::var(CPAL_ASIO_DIR) {
@@ -230,42 +265,7 @@ fn get_asio_dir() -> PathBuf {
     // If not found, download ASIO SDK using PowerShell's Invoke-WebRequest
     println!("CPAL_ASIO_DIR is not set or contents are cached downloading from {ASIO_SDK_URL}",);
 
-    let asio_zip_path = temp_dir.join("asio_sdk.zip");
-    let status = Command::new("powershell")
-        .args(&[
-            "-NoProfile",
-            "-Command",
-            &format!(
-                "Invoke-WebRequest -Uri {ASIO_SDK_URL} -OutFile {}",
-                asio_zip_path.display()
-            ),
-        ])
-        .status()
-        .expect("Failed to execute PowerShell command");
-
-    if !status.success() {
-        panic!("Failed to download ASIO SDK");
-    }
-    println!("Downloaded ASIO SDK successfully");
-
-    // Unzip using PowerShell's Expand-Archive
-    println!("Extracting ASIO SDK..");
-    let status = Command::new("powershell")
-        .args(&[
-            "-NoProfile",
-            "-Command",
-            &format!(
-                "Expand-Archive -Path {} -DestinationPath {} -Force",
-                asio_zip_path.display(),
-                temp_dir.display()
-            ),
-        ])
-        .status()
-        .expect("Failed to execute PowerShell command for extracting ASIO SDK");
-
-    if !status.success() {
-        panic!("Failed to extract ASIO SDK");
-    }
+    download_asio_sdk_to_temp_dir(&temp_dir);
 
     // Move the contents of the inner directory to asio_dir
     for entry in walkdir::WalkDir::new(&temp_dir).min_depth(1).max_depth(1) {
@@ -279,37 +279,160 @@ fn get_asio_dir() -> PathBuf {
     asio_dir
 }
 
-fn invoke_vcvars() {
+/// Downloads the ASIO SDK to the temp directory of the host OS
+///
+/// It uses powershell's Invoke-WebRequest on Windows and curl on other platforms to download the SDK.
+///
+/// It then extracts the SDK using powershell's Expand-Archive on Windows and unzip on other platforms.
+fn download_asio_sdk_to_temp_dir(temp_dir: &Path) {
+    let asio_zip_path = temp_dir.join("asio_sdk.zip");
+    if host_os_is_windows() {
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "Invoke-WebRequest -Uri {ASIO_SDK_URL} -OutFile {}",
+                    asio_zip_path.display()
+                ),
+            ])
+            .status()
+            .expect("Failed to execute PowerShell command");
+
+        if !status.success() {
+            panic!("Failed to download ASIO SDK");
+        }
+        println!("Downloaded ASIO SDK successfully");
+
+        // Unzip using PowerShell's Expand-Archive
+        println!("Extracting ASIO SDK..");
+        let status = Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "Expand-Archive -Path {} -DestinationPath {} -Force",
+                    asio_zip_path.display(),
+                    temp_dir.display()
+                ),
+            ])
+            .status()
+            .expect("Failed to execute PowerShell command for extracting ASIO SDK");
+
+        if !status.success() {
+            panic!("Failed to extract ASIO SDK");
+        }
+    } else {
+        let status = Command::new("sh")
+            .arg("-c")
+            .arg(&format!(
+                "curl -L --fail --output {} {}",
+                asio_zip_path.display(),
+                "https://www.steinberg.net/asiosdk" // Replace with the actual ASIO SDK URL
+            ))
+            .status()
+            .expect("Failed to execute curl command");
+
+        if !status.success() {
+            panic!("Failed to download ASIO SDK");
+        }
+        println!("Downloaded ASIO SDK successfully");
+
+        // Extract using `unzip`
+        println!("Extracting ASIO SDK..");
+        let status = Command::new("unzip")
+            .args([
+                "-o",
+                asio_zip_path.to_str().unwrap(),
+                "-d",
+                temp_dir.to_str().unwrap(),
+            ])
+            .status()
+            .expect("Failed to execute unzip command for extracting ASIO SDK");
+
+        if !status.success() {
+            panic!("Failed to extract ASIO SDK");
+        }
+    }
+}
+
+/// Invokes `vcvarsall.bat` to initialize the environment for building with MSVC
+///
+/// This function is only meant to be called when the host OS is Windows.
+fn invoke_vcvars_if_not_set() {
+    if vcvars_set() {
+        return;
+    }
+    println!("VCINSTALLDIR is not set. Attempting to invoke vcvarsall.bat..");
+
     println!("Invoking vcvarsall.bat..");
     println!("Determining system architecture..");
 
-    // Determine the system architecture to be used as an argument to vcvarsall.bat
-    let arch = if cfg!(target_arch = "x86_64") {
-        "amd64"
-    } else if cfg!(target_arch = "x86") {
-        "x86"
-    } else if cfg!(target_arch = "arm") {
-        "arm"
-    } else if cfg!(target_arch = "aarch64") {
-        "arm64"
-    } else {
-        panic!("Unsupported architecture");
-    };
+    let arch_arg = determine_vcvarsall_bat_arch_arg();
+    println!(
+        "Host architecture is detected as {}.",
+        std::env::consts::ARCH
+    );
+    println!("Architecture argument for vcvarsall.bat will be used as: {arch_arg}.");
 
-    println!("Architecture detected as {arch}.");
+    let vcvars_all_bat_path = search_vcvars_all_bat();
+
+    println!(
+        "Found vcvarsall.bat at {}. Initializing environment..",
+        vcvars_all_bat_path.display()
+    );
+
+    // Invoke vcvarsall.bat
+    let output = Command::new("cmd")
+        .args([
+            "/c",
+            vcvars_all_bat_path.to_str().unwrap(),
+            &arch_arg,
+            "&&",
+            "set",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        // Filters the output of vcvarsall.bat to only include lines of the form "VARNAME=VALUE"
+        let parts: Vec<&str> = line.splitn(2, '=').collect();
+        if parts.len() == 2 {
+            env::set_var(parts[0], parts[1]);
+            println!("{}={}", parts[0], parts[1]);
+        }
+    }
+}
+
+/// Checks if vcvarsall.bat has been invoked
+/// Assumes that it is very unlikely that the user would set `VCINSTALLDIR` manually
+fn vcvars_set() -> bool {
+    env::var("VCINSTALLDIR").is_ok()
+}
+
+/// Searches for vcvarsall.bat in the default installation directories
+///
+/// If it is not found, it will search for it in the Program Files directories
+///
+/// If it is still not found, it will panic.
+fn search_vcvars_all_bat() -> PathBuf {
+    if let Some(path) = guess_vcvars_all_bat() {
+        return path;
+    }
 
     // Define search paths for vcvarsall.bat based on architecture
-    let paths = if arch == "amd64" {
-        vec![
-            "C:\\Program Files (x86)\\Microsoft Visual Studio\\",
-            "C:\\Program Files\\Microsoft Visual Studio\\",
-        ]
-    } else {
-        vec!["C:\\Program Files\\Microsoft Visual Studio\\"]
-    };
+    let paths = vec![
+        // Visual Studio 2022+
+        "C:\\Program Files\\Microsoft Visual Studio\\",
+        // <= Visual Studio 2019
+        "C:\\Program Files (x86)\\Microsoft Visual Studio\\",
+    ];
 
     // Search for vcvarsall.bat using walkdir
     println!("Searching for vcvarsall.bat in {paths:?}");
+
+    let mut found = None;
+
     for path in paths.iter() {
         for entry in WalkDir::new(path)
             .into_iter()
@@ -317,34 +440,155 @@ fn invoke_vcvars() {
             .filter(|e| !e.file_type().is_dir())
         {
             if entry.path().ends_with("vcvarsall.bat") {
-                println!(
-                    "Found vcvarsall.bat at {}. Initializing environment..",
-                    entry.path().display()
-                );
-
-                // Invoke vcvarsall.bat
-                let output = Command::new("cmd")
-                    .args(&["/c", entry.path().to_str().unwrap(), &arch, "&&", "set"])
-                    .output()
-                    .expect("Failed to execute command");
-
-                for line in String::from_utf8_lossy(&output.stdout).lines() {
-                    // Filters the output of vcvarsall.bat to only include lines of the form "VARNAME=VALUE"
-                    let parts: Vec<&str> = line.splitn(2, '=').collect();
-                    if parts.len() == 2 {
-                        env::set_var(parts[0], parts[1]);
-                        println!("{}={}", parts[0], parts[1]);
-                    }
-                }
-                return;
+                found.replace(entry.path().to_path_buf());
             }
         }
     }
 
-    panic!("Could not find vcvarsall.bat. Please install the latest version of Visual Studio.");
+    match found {
+        Some(path) => path,
+        None => panic!(
+            "Could not find vcvarsall.bat. Please install the latest version of Visual Studio."
+        ),
+    }
 }
-// Checks if vcvarsall.bat has been invoked
-// Assumes that it is very unlikely that the user would set VCINSTALLDIR manually
-fn vcvars_set() -> bool {
-    env::var("VCINSTALLDIR").is_ok()
+
+/// Guesses the location of vcvarsall.bat by searching it with certain heuristics.
+///
+/// It is meant to be executed before a top level search over Microsoft Visual Studio directories
+/// to ensure faster execution in CI environments.
+fn guess_vcvars_all_bat() -> Option<PathBuf> {
+    /// Checks if a string is a year
+    fn is_year(s: Option<&str>) -> Option<String> {
+        let Some(s) = s else {
+            return None;
+        };
+
+        if s.len() == 4 && s.chars().all(|c| c.is_ascii_digit()) {
+            Some(s.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Checks if a string is an edition of Visual Studio
+    fn is_edition(s: Option<&str>) -> Option<String> {
+        let Some(s) = s else {
+            return None;
+        };
+
+        let editions = ["Enterprise", "Professional", "Community", "Express"];
+        if editions.contains(&s) {
+            Some(s.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Constructs a path to vcvarsall.bat based on a base path
+    fn construct_path(base: &Path) -> Option<PathBuf> {
+        let mut constructed = base.to_path_buf();
+        for entry in WalkDir::new(&constructed).max_depth(1) {
+            let entry = match entry {
+                Err(_) => continue,
+                Ok(entry) => entry,
+            };
+            if let Some(year) = is_year(entry.path().file_name().and_then(|s| s.to_str())) {
+                constructed = constructed.join(year);
+                for entry in WalkDir::new(&constructed).max_depth(1) {
+                    let entry = match entry {
+                        Err(_) => continue,
+                        Ok(entry) => entry,
+                    };
+                    if let Some(edition) =
+                        is_edition(entry.path().file_name().and_then(|s| s.to_str()))
+                    {
+                        constructed = constructed
+                            .join(edition)
+                            .join("VC")
+                            .join("Auxiliary")
+                            .join("Build")
+                            .join("vcvarsall.bat");
+
+                        return Some(constructed);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    let vs_2022_and_onwards_base = PathBuf::from("C:\\Program Files\\Microsoft Visual Studio\\");
+    let vs_2019_and_2017_base = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\");
+
+    construct_path(&vs_2022_and_onwards_base).map_or_else(
+        || construct_path(&vs_2019_and_2017_base).map_or_else(|| None, Some),
+        Some,
+    )
+}
+
+/// Determines the right argument to pass to `vcvarsall.bat` based on the host and target architectures.
+///
+/// Windows on ARM is not supporting 32 bit arm processors.
+/// Because of this there is no native or cross compilation is supported for 32 bit arm processors.
+fn determine_vcvarsall_bat_arch_arg() -> String {
+    let host_architecture = std::env::consts::ARCH;
+
+    let arch_arg = if cfg!(target_arch = "x86_64") {
+        if host_architecture == "x86" {
+            // Arg for cross compilation from x86 to x64
+            "x86_amd64"
+        } else if host_architecture == "x86_64" {
+            // Arg for native compilation from x64 to x64
+            "amd64"
+        } else if host_architecture == "aarch64" {
+            // Arg for cross compilation from arm64 to amd64
+            "arm64_amd64"
+        } else {
+            panic!("Unsupported host architecture {}", host_architecture);
+        }
+    } else if cfg!(target_arch = "x86") {
+        if host_architecture == "x86" {
+            // Arg for native compilation from x86 to x86
+            "x86"
+        } else if host_architecture == "x86_64" {
+            // Arg for cross compilation from x64 to x86
+            "amd64_x86"
+        } else if host_architecture == "aarch64" {
+            // Arg for cross compilation from arm64 to x86
+            "arm64_x86"
+        } else {
+            panic!("Unsupported host architecture {}", host_architecture);
+        }
+    } else if cfg!(target_arch = "arm") {
+        if host_architecture == "x86" {
+            // Arg for cross compilation from x86 to arm
+            "x86_arm"
+        } else if host_architecture == "x86_64" {
+            // Arg for cross compilation from x64 to arm
+            "amd64_arm"
+        } else if host_architecture == "aarch64" {
+            // Arg for cross compilation from arm64 to arm
+            "arm64_arm"
+        } else {
+            panic!("Unsupported host architecture {}", host_architecture);
+        }
+    } else if cfg!(target_arch = "aarch64") {
+        if host_architecture == "x86" {
+            // Arg for cross compilation from x86 to arm
+            "x86_arm64"
+        } else if host_architecture == "x86_64" {
+            // Arg for cross compilation from x64 to arm
+            "amd64_arm64"
+        } else if host_architecture == "aarch64" {
+            // Arg for native compilation from arm64 to arm64
+            "arm64"
+        } else {
+            panic!("Unsupported host architecture {}", host_architecture);
+        }
+    } else {
+        panic!("Unsupported target architecture.");
+    };
+
+    arch_arg.to_owned()
 }

--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -1022,7 +1022,26 @@ extern "C" fn buffer_switch(double_buffer_index: c_long, direct_process: c_long)
         if let Ok(()) = asio_result!(res) {
             time.time_info.flags = (ai::AsioTimeInfoFlags::kSystemTimeValid
                 | ai::AsioTimeInfoFlags::kSamplePositionValid)
-                .0;
+                // Context about the cast:
+                //
+                // Cast was required to successfully compile with MinGW-w64.
+                //
+                // The flags defined will not create a value that exceeds the maximum value of an i32.
+                // The flags are intended to be non-negative, so the sign bit will not be used.
+                // The c_uint (flags) is being cast to i32 which is safe as long as the actual value fits within the i32 range, which is true in this case.
+                //
+                // The actual flags in asio sdk are defined as:
+                // typedef enum AsioTimeInfoFlags
+                // {
+                //	kSystemTimeValid        = 1,            // must always be valid
+                //	kSamplePositionValid    = 1 << 1,       // must always be valid
+                //	kSampleRateValid        = 1 << 2,
+                //	kSpeedValid             = 1 << 3,
+                //
+                //	kSampleRateChanged      = 1 << 4,
+                //	kClockSourceChanged     = 1 << 5
+                // } AsioTimeInfoFlags;
+                .0 as i32;
         }
         time
     };


### PR DESCRIPTION
# Improvements

- `vcvarsall.bat` is executed exhaustively for any supported host and target architecture combinations now. 
-  Downloading the ASIO SDK is working on all platforms now which enables cross compilation. 
-  A section on the `README.md` is added which explains cross compilation scenarios for `cpal` with the `asio` feature.
-  `vcvarsall.bat` search is improved greatly to execute smarter and faster to cover for CI scenarios where the disk I/O might be a bottle neck. 
-  A type mismatch bug which was apparent on using the `mingw-w64` tool chain is fixed. 

With these changes I want to enable:
- Better building experience in CI
- Improve existing changes to be cross compilation ready.

What I have tried:

- macOS aarch64 (host) -> windows x86, x86_64 (target) ✅ 
- linux (ubuntu) aarch64 (host) -> windows x86, x86_64 (target) ✅ 
- windows aarch64 (host)-> windows x86, x86_64, aarch64 (target) ✅ 
- windows x86_64 (host)-> windows x86, x86_64, aarch64 (target) ✅ 

If I missed something, I'll correct it along the way.
Thank you for the last merge, and I look forward to your review 🙏 