### PR TITLE
Add extra devices iterator type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,11 +182,14 @@ pub mod platform;
 mod samples_formats;
 pub mod traits;
 
+/// Iterator of devices wrapped in a filter to only include certain device types
+pub type DevicesFiltered<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>;
+
 /// A host's device iterator yielding only *input* devices.
-pub type InputDevices<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>;
+pub type InputDevices<I> = DevicesFiltered<I>;
 
 /// A host's device iterator yielding only *output* devices.
-pub type OutputDevices<I> = std::iter::Filter<I, fn(&<I as Iterator>::Item) -> bool>;
+pub type OutputDevices<I> = DevicesFiltered<I>;
 
 /// Number of channels.
 pub type ChannelCount = u16;


### PR DESCRIPTION
## Description

This change adds an additional type alias `DevicesFiltered` that the `InputDevices` and `OuputDevices` can both become aliases to since they are both the same type, rather than having the same type declared separately twice. 

This makes it easier for working with the functions in a case where you may be wanting to filter over *either* input or output devices using the same function like so:
```rust
type DevicesFn = fn(&Host) -> Result<DevicesFiltered, DevicesError>;

let devices_fn: DevicesFn = if output {
    Host::output_devices
} else {
    Host::input_devices
};
let devices_iter = devices_fn(host)
    .expect("Failed to load devices");
```

## Changes
- Add `DevicesFiltered` type alias shared by both `InputDevices` and `OuputDevices`