### PR TITLE
emscripten: directly return Option instead of WasmOption

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_
 coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio", "audio_toolbox"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-wasm-bindgen = { version = "0.2.58" }
+wasm-bindgen = { version = "0.2.89" }
 wasm-bindgen-futures = "0.4.33"
 js-sys = { version = "0.3.35" }
 web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ impl wasm_bindgen::describe::WasmDescribe for BufferSize {
 
 #[cfg(target_os = "emscripten")]
 impl wasm_bindgen::convert::IntoWasmAbi for BufferSize {
-    type Abi = wasm_bindgen::convert::WasmOption<u32>;
+    type Abi = Option<u32>;
     fn into_abi(self) -> Self::Abi {
         match self {
             Self::Default => None,


### PR DESCRIPTION
Since `wasm-bindgen` 0.2.88 (which was yanked) and https://github.com/rustwasm/wasm-bindgen/pull/3595, it supports `Option` directly instead of `WasmOption`