### PR TITLE
disable ndk default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOption
 
 [target.'cfg(target_os = "android")'.dependencies]
 oboe = { version = "0.5", features = [ "java-interface" ] }
-ndk = "0.8"
+ndk = { version = "0.8", default-features = false }
 ndk-context = "0.1"
 jni = "0.19"
 


### PR DESCRIPTION
disable ndk default features

the only default one is `rwh_0.6` which pulls version 0.6 of raw-window-handle but is unused by this crate. removing it let consumers decide which version of the crate they'll depend on