### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -111,9 +111,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Setup Emscripten toolchain
-      uses: mymindstorm/setup-emsdk@v10
-      with:
-        version: 2.0.9 # https://github.com/rust-lang/rust/issues/85821
+      uses: mymindstorm/setup-emsdk@v14
     - name: Install stable
       uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -47,12 +47,12 @@ jobs:
     - name: Install alsa
       run: sudo apt-get install libasound2-dev
     - name: Verify publish crate
-      uses: katyo/publish-crates@v1
+      uses: katyo/publish-crates@v2
       with:
         dry-run: true
         ignore-unpublished-changes: true
     - name: Publish crate
-      uses: katyo/publish-crates@v1
+      uses: katyo/publish-crates@v2
       with:
         ignore-unpublished-changes: true
         registry-token: ${{ secrets.CRATESIO_TOKEN }}

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -7,7 +7,7 @@ jobs:
   clippy-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Update apt
       run: sudo apt update
     - name: Install alsa
@@ -36,7 +36,7 @@ jobs:
   rustfmt-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
@@ -54,7 +54,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
@@ -79,7 +79,7 @@ jobs:
   ubuntu-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Update apt
       run: sudo apt update
     - name: Install alsa
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -154,7 +154,7 @@ jobs:
         target: [asmjs-unknown-emscripten, wasm32-unknown-emscripten]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup Emscripten toolchain
       uses: mymindstorm/setup-emsdk@v10
       with:
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
@@ -196,7 +196,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
@@ -212,7 +212,7 @@ jobs:
         version: [x86_64, i686]
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install ASIO SDK
       env:
         LINK: https://www.steinberg.net/asiosdk
@@ -241,7 +241,7 @@ jobs:
   macos-test:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install llvm and clang
       run: brew install llvm
     - name: Install stable
@@ -260,7 +260,7 @@ jobs:
   android-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install stable
       uses: actions-rs/toolchain@v1
       with:
@@ -282,7 +282,7 @@ jobs:
   android-apk-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Android targets
       run: |
         rustup target add armv7-linux-androideabi
@@ -300,7 +300,7 @@ jobs:
   ios-build:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install llvm and clang
       run: brew install llvm
     - name: Install stable
@@ -323,7 +323,7 @@ jobs:
     # It does not test the javascript/web integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Target
         run: rustup target add wasm32-unknown-unknown
       - name: Cargo Build

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -39,10 +39,7 @@ jobs:
       with:
         components: rustfmt
     - name: Run rustfmt
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
+      run: cargo fmt --all -- --check
 
   cargo-publish:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
@@ -79,15 +76,9 @@ jobs:
     - name: Install stable
       uses: dtolnay/rust-toolchain@stable
     - name: Run without features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --no-default-features --verbose
+      run: cargo test --all --no-default-features --verbose
     - name: Run all features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all --all-features --verbose
+      run: cargo test --all --all-features --verbose
 
   linux-check-and-test-armv7:
     runs-on: ubuntu-latest
@@ -103,33 +94,20 @@ jobs:
       - name: Build image
         run: docker build -t cross/cpal_armv7:v1 ./
 
+      - name: Install cross
+        run: cargo install cross
+
       - name: Check without features for armv7
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          use-cross: true
-          args: --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
+        run: cross check --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
 
       - name: Test without features for armv7
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          use-cross: true
-          args: --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
+        run: cross test --target armv7-unknown-linux-gnueabihf --workspace --no-default-features --verbose
 
       - name: Check all features for armv7
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          use-cross: true
-          args: --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
+        run: cross check --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
 
       - name: Test all features for armv7
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          use-cross: true
-          args: --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
+        run: cross test --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
 
   asmjs-wasm32-test:
     strategy:

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -15,11 +15,8 @@ jobs:
     - name: Install libjack
       run: sudo apt-get install libjack-jackd2-dev libjack-jackd2-0
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: clippy
         target: armv7-linux-androideabi
     - name: Run clippy
@@ -38,11 +35,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         components: rustfmt
     - name: Run rustfmt
       uses: actions-rs/cargo@v1
@@ -56,11 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Update apt
       run: sudo apt update
     - name: Install alsa
@@ -87,11 +77,7 @@ jobs:
     - name: Install libjack
       run: sudo apt-get install libjack-jackd2-dev libjack-jackd2-0
     - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Run without features
       uses: actions-rs/cargo@v1
       with:
@@ -110,12 +96,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           target: armv7-unknown-linux-gnueabihf
-          override: true
 
       - name: Build image
         run: docker build -t cross/cpal_armv7:v1 ./
@@ -160,10 +143,8 @@ jobs:
       with:
         version: 2.0.9 # https://github.com/rust-lang/rust/issues/85821
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
         target: ${{ matrix.target }}
     - name: Build beep example
       run: cargo build --example beep --release --target ${{ matrix.target }}
@@ -179,10 +160,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           target: ${{ matrix.target }}
       - name: Build beep example
         run: cargo build --example beep --target ${{ matrix.target }} --features=wasm-bindgen
@@ -198,10 +177,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
           target: ${{ matrix.target }}
       - name: Build beep example
         run: cargo build --example beep --target ${{ matrix.target }}
@@ -225,12 +202,9 @@ jobs:
     - name: Install llvm and clang
       run: choco install llvm
     - name: Install stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
         target: ${{ matrix.version }}-pc-windows-msvc
-        override: true
     - name: Run without features
       run: cargo test --all --no-default-features --verbose
     - name: Run all features
@@ -245,11 +219,7 @@ jobs:
     - name: Install llvm and clang
       run: brew install llvm
     - name: Install stable
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+      uses: dtolnay/rust-toolchain@stable
     - name: Build beep example
       run: cargo build --example beep
     - name: Run without features
@@ -261,12 +231,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
+    - name: Install stable (Android target)
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
         target: armv7-linux-androideabi
     - name: Check android
       run: cargo check --example android --target armv7-linux-androideabi --features oboe/fetch-prebuilt --verbose
@@ -283,12 +250,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install Android targets
-      run: |
-        rustup target add armv7-linux-androideabi
-        rustup target add aarch64-linux-android
-        rustup target add i686-linux-android
-        rustup target add x86_64-linux-android
+    - name: Install stable (Android targets)
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: armv7-linux-androideabi,aarch64-linux-android,i686-linux-android,x86_64-linux-android
     - name: Set Up Android tools
       run: |
         ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT --install "platforms;android-30"
@@ -303,14 +268,10 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install llvm and clang
       run: brew install llvm
-    - name: Install stable
-      uses: actions-rs/toolchain@v1
+    - name: Install stable (iOS targets)
+      uses: dtolnay/rust-toolchain@stable
       with:
-        profile: minimal
-        toolchain: stable
-        override: true
-    - name: Add iOS targets
-      run: rustup target add aarch64-apple-ios x86_64-apple-ios
+        targets: aarch64-apple-ios,x86_64-apple-ios
     - name: Install cargo lipo
       run: cargo install cargo-lipo
     - name: Build iphonesimulator feedback example
@@ -324,8 +285,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Target
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install stable (wasm32 target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
       - name: Cargo Build
         working-directory: ./examples/wasm-beep
         run: cargo build --target wasm32-unknown-unknown

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -20,15 +20,9 @@ jobs:
         components: clippy
         target: armv7-linux-androideabi
     - name: Run clippy
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all --all-features
+      run: cargo clippy --all --all-features
     - name: Run clippy for Android target
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all --features asio --features oboe/fetch-prebuilt --target armv7-linux-androideabi
+      run: cargo clippy --all --features asio --features oboe/fetch-prebuilt --target armv7-linux-androideabi
 
   rustfmt-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Even on a successful run, GitHub actions have a lot of warnings:

<img width="942" alt="Screenshot 2024-01-25 at 06 42 38" src="https://github.com/RustAudio/cpal/assets/8672791/d5b75fe5-187f-45dc-bc21-cb91201038a6">

This PR updates actions:
- switch all `actions/checkout` to the latest v4
- replace `actions-rs/toolchain` by `dtolnay/rust-toolchain`. also use it instead of manual target installs at some places
- replace `actions-rs/cargo` by running the cargo command
- replace `actions-rs/clippy-check` by running clippy
- update `mymindstorm/seup-emsdk` to the latest v14 (and also don't depend on an old version of emscripten as the bug linked as been fixed)
- update `katyo/publish-crates` to the latest v2 (I couldn't test this one)

`actions-rs` actions have not been updated for 3 years and were archived in October 2023