### PR TITLE
Add non-panicking variant of with_sample_rate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -633,15 +633,28 @@ impl SupportedStreamConfigRange {
     ///
     /// # Panics
     ///
-    /// Panics if the given `sample_rate` is outside the range specified within this
-    /// [`SupportedStreamConfigRange`] instance.
+    /// Panics if the given `sample_rate` is outside the range specified within
+    /// this [`SupportedStreamConfigRange`] instance. For a non-panicking
+    /// variant, use [`try_with_sample_rate`](#method.try_with_sample_rate).
     pub fn with_sample_rate(self, sample_rate: SampleRate) -> SupportedStreamConfig {
-        assert!(self.min_sample_rate <= sample_rate && sample_rate <= self.max_sample_rate);
-        SupportedStreamConfig {
-            channels: self.channels,
-            sample_rate,
-            sample_format: self.sample_format,
-            buffer_size: self.buffer_size,
+        self.try_with_sample_rate(sample_rate)
+            .expect("sample rate out of range")
+    }
+
+    /// Retrieve a [`SupportedStreamConfig`] with the given sample rate and buffer size.
+    ///
+    /// Returns `None` if the given sample rate is outside the range specified
+    /// within this [`SupportedStreamConfigRange`] instance.
+    pub fn try_with_sample_rate(self, sample_rate: SampleRate) -> Option<SupportedStreamConfig> {
+        if self.min_sample_rate <= sample_rate && sample_rate <= self.max_sample_rate {
+            Some(SupportedStreamConfig {
+                channels: self.channels,
+                sample_rate,
+                sample_format: self.sample_format,
+                buffer_size: self.buffer_size,
+            })
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
When trying to select a configuration that is compatible with a specific sample rate, `with_sample_rate` gets a bit clunky because you have to implement the range checking yourself to avoid the panic.

The non-panicking `try_with_sample_rate` is much nicer in comparison.

Before:

```rust
device.supported_output_configs()?
    .filter_map(|cfg| if target_rate >= cfg.min_sample_rate() && target_rate <= cfg.max_sample_rate() {
        Some(cfg.with_sample_rate(target_rate))
    } else {
        None
    })
```

After:

```rust
device.supported_output_configs()?
    .filter_map(|cfg| cfg.try_with_sample_rate(target_rate))
```
