### PR TITLE
Implement `Send` for `Stream` on certain platforms

### DIFF
--- a/src/platform/maybe_send.rs
+++ b/src/platform/maybe_send.rs
@@ -1,0 +1,23 @@
+//! The following zero-sized type is for applying [`Send`]/[`Sync`]` restrictions to ensure
+//! consistent behaviour across different platforms. The verbosely named type is used
+//! (rather than using the markers directly) in the hope of making the compile errors
+//! slightly more helpful.
+
+// TODO: Remove this in favour of using negative trait bounds if they stabilise.
+
+/// A marker used to remove the `Send` and `Sync` traits.
+pub(crate) struct NotSendSyncAcrossAllPlatforms(std::marker::PhantomData<*mut ()>);
+
+impl Default for NotSendSyncAcrossAllPlatforms {
+    fn default() -> Self {
+        NotSendSyncAcrossAllPlatforms(std::marker::PhantomData)
+    }
+}
+
+// TODO: Implement Send on platforms which support it.
+
+#[cfg(any(
+    // Windows with WASAPI allows for a Send Stream
+    all(windows, not(feature = "asio")),
+))]
+unsafe impl Send for NotSendSyncAcrossAllPlatforms {}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -4,6 +4,10 @@
 //! type and its associated [`Device`], [`Stream`] and other associated types. These
 //! types are useful in the case that users require switching between audio host APIs at runtime.
 
+mod maybe_send;
+
+pub(crate) use maybe_send::*;
+
 #[doc(inline)]
 pub use self::platform_impl::*;
 
@@ -722,21 +726,5 @@ mod platform_impl {
         NullHost::new()
             .expect("the default host should always be available")
             .into()
-    }
-}
-
-// The following zero-sized types are for applying Send/Sync restrictions to ensure
-// consistent behaviour across different platforms. These verbosely named types are used
-// (rather than using the markers directly) in the hope of making the compile errors
-// slightly more helpful.
-//
-// TODO: Remove these in favour of using negative trait bounds if they stabilise.
-
-// A marker used to remove the `Send` and `Sync` traits.
-struct NotSendSyncAcrossAllPlatforms(std::marker::PhantomData<*mut ()>);
-
-impl Default for NotSendSyncAcrossAllPlatforms {
-    fn default() -> Self {
-        NotSendSyncAcrossAllPlatforms(std::marker::PhantomData)
     }
 }


### PR DESCRIPTION
# Objective

- Implement feature in request #818

## Solution

Moved `NotSendSyncAcrossAllPlatforms` into its own module, `maybe_send` (for clarity) and implemented `Send` for an instance where (I believe) it is safe to do so. I've deliberately left the `cfg` statement controlling this implementation verbose to make it clear how other platforms could be included where it is confirmed to be safe to do so:

```rust
#[cfg(any(
    // Windows with WASAPI allows for a Send Stream
    all(windows, not(feature = "asio"))
))]
unsafe impl Send for NotSendSyncAcrossAllPlatforms {}
```

To add this support to Linux but only on FreeBSD using Jack (as an example) then a single statement can be added without modifying any of the others:

```rust
#[cfg(any(
    // Windows with WASAPI allows for a Send Stream
    all(windows, not(feature = "asio"))
    // FreeBSD using Jack allows for a Send Stream
    all(target_os = "freebsd", feature = "jack"),
))]
unsafe impl Send for NotSendSyncAcrossAllPlatforms {}
```

I have deliberately only implemented `Send` on Windows under WASAPI in this pull request as I believe it is known to be `Send` safe and should be relatively straight-forward to test. I would encourage others to test on platforms they can also confirm the behaviour on and then make follow-up PRs to increase support.

## Motivation

I personally ran into this issue myself when working with Bevy and thought it was a little annoying. Not a deal breaker by any stretch of the imagination, the workarounds are well documented and perfectly reasonable. This is more of a quality of life improvement than anything else.
