### PR TITLE
Added WASAPI exclusive host

### DIFF
--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -26,5 +26,7 @@ pub(crate) mod null;
 pub(crate) mod oboe;
 #[cfg(windows)]
 pub(crate) mod wasapi;
+#[cfg(windows)]
+pub(crate) mod wasapi_exclusive;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 pub(crate) mod webaudio;

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -15,13 +15,13 @@ use std::sync::OnceLock;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
-use super::com;
+use super::{com, ShareMode};
 use super::{windows_err_to_cpal_err, windows_err_to_cpal_err_message};
 use windows::core::ComInterface;
 use windows::core::GUID;
 use windows::Win32::Devices::Properties;
 use windows::Win32::Foundation;
-use windows::Win32::Media::Audio::IAudioRenderClient;
+use windows::Win32::Media::Audio::{IAudioRenderClient, AUDCLNT_SHAREMODE};
 use windows::Win32::Media::{Audio, KernelStreaming, Multimedia};
 use windows::Win32::System::Com;
 use windows::Win32::System::Com::{StructuredStorage, STGM_READ};
@@ -44,6 +44,7 @@ unsafe impl Sync for IAudioClientWrapper {}
 #[derive(Clone)]
 pub struct Device {
     device: Audio::IMMDevice,
+    share_mode: ShareMode,
     /// We cache an uninitialized `IAudioClient` so that we can call functions from it without
     /// having to create/destroy audio clients all the time.
     future_audio_client: Arc<Mutex<Option<IAudioClientWrapper>>>, // TODO: add NonZero around the ptr
@@ -90,7 +91,7 @@ impl DeviceTrait for Device {
         D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let stream_inner = self.build_input_stream_raw_inner(config, sample_format)?;
+        let stream_inner = self.build_stream(config, sample_format, true)?;
         Ok(Stream::new_input(
             stream_inner,
             data_callback,
@@ -110,7 +111,7 @@ impl DeviceTrait for Device {
         D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
         E: FnMut(StreamError) + Send + 'static,
     {
-        let stream_inner = self.build_output_stream_raw_inner(config, sample_format)?;
+        let stream_inner = self.build_stream(config, sample_format, false)?;
         Ok(Stream::new_output(
             stream_inner,
             data_callback,
@@ -149,12 +150,13 @@ unsafe fn data_flow_from_immendpoint(endpoint: &Audio::IMMEndpoint) -> Audio::ED
 // Given the audio client and format, returns whether or not the format is supported.
 pub unsafe fn is_format_supported(
     client: &Audio::IAudioClient,
+    share_mode: ShareMode,
     waveformatex_ptr: *const Audio::WAVEFORMATEX,
 ) -> Result<bool, SupportedStreamConfigsError> {
     // Check if the given format is supported.
     let is_supported = |waveformatex_ptr, closest_waveformatex_ptr| {
         let result = client.IsFormatSupported(
-            Audio::AUDCLNT_SHAREMODE_SHARED,
+            to_winapi_share_mode(share_mode),
             waveformatex_ptr,
             Some(closest_waveformatex_ptr),
         );
@@ -278,6 +280,13 @@ unsafe fn format_from_waveformatex_ptr(
 unsafe impl Send for Device {}
 unsafe impl Sync for Device {}
 
+fn to_winapi_share_mode(share_mode: ShareMode) -> AUDCLNT_SHAREMODE {
+    match share_mode {
+        ShareMode::Shared => Audio::AUDCLNT_SHAREMODE_SHARED,
+        ShareMode::Exclusive => Audio::AUDCLNT_SHAREMODE_EXCLUSIVE,
+    }
+}
+
 impl Device {
     pub fn name(&self) -> Result<String, DeviceNameError> {
         unsafe {
@@ -332,10 +341,11 @@ impl Device {
     }
 
     #[inline]
-    fn from_immdevice(device: Audio::IMMDevice) -> Self {
+    fn from_immdevice(device: Audio::IMMDevice, share_mode: ShareMode) -> Self {
         Device {
             device,
             future_audio_client: Arc::new(Mutex::new(None)),
+            share_mode,
         }
     }
 
@@ -402,7 +412,9 @@ impl Device {
                 .map_err(windows_err_to_cpal_err::<SupportedStreamConfigsError>)?;
 
             // If the default format can't succeed we have no hope of finding other formats.
-            if !is_format_supported(client, default_waveformatex_ptr.0)? {
+            if self.share_mode == ShareMode::Shared
+                && !is_format_supported(client, self.share_mode, default_waveformatex_ptr.0)?
+            {
                 let description =
                     "Could not determine support for default `WAVEFORMATEX`".to_string();
                 let err = BackendSpecificError { description };
@@ -446,13 +458,14 @@ impl Device {
                     ) {
                         if is_format_supported(
                             client,
+                            self.share_mode,
                             &waveformat.Format as *const Audio::WAVEFORMATEX,
                         )? {
                             supported_formats.push(SupportedStreamConfigRange {
                                 channels: format.channels,
                                 min_sample_rate: sample_rate,
                                 max_sample_rate: sample_rate,
-                                buffer_size: format.buffer_size.clone(),
+                                buffer_size: format.buffer_size,
                                 sample_format,
                             })
                         }
@@ -512,8 +525,45 @@ impl Device {
                 .map(WaveFormatExPtr)
                 .map_err(windows_err_to_cpal_err::<DefaultStreamConfigError>)?;
 
-            format_from_waveformatex_ptr(format_ptr.0, client)
-                .ok_or(DefaultStreamConfigError::StreamTypeNotSupported)
+            // For exclusive mode the default mix sample format is probably not correct,
+            // so pick the supported sample format with the highest precision
+            if self.share_mode == ShareMode::Exclusive {
+                for sample_format in [
+                    SampleFormat::I64,
+                    SampleFormat::I32,
+                    SampleFormat::F32,
+                    SampleFormat::I16,
+                    SampleFormat::U8,
+                ] {
+                    if let Some(format) = config_to_waveformatextensible(
+                        &StreamConfig {
+                            channels: (*format_ptr.0).nChannels,
+                            sample_rate: SampleRate((*format_ptr.0).nSamplesPerSec),
+                            buffer_size: BufferSize::Default,
+                        },
+                        sample_format,
+                    ) {
+                        if is_format_supported(
+                            client,
+                            self.share_mode,
+                            &format.Format as *const Audio::WAVEFORMATEX,
+                        )
+                        .map_err(|_| DefaultStreamConfigError::DeviceNotAvailable)?
+                        {
+                            return format_from_waveformatex_ptr(
+                                &format.Format as *const _,
+                                client,
+                            )
+                            .ok_or(DefaultStreamConfigError::StreamTypeNotSupported);
+                        }
+                    }
+                }
+
+                Err(DefaultStreamConfigError::StreamTypeNotSupported)
+            } else {
+                format_from_waveformatex_ptr(format_ptr.0, client)
+                    .ok_or(DefaultStreamConfigError::StreamTypeNotSupported)
+            }
         }
     }
 
@@ -539,10 +589,11 @@ impl Device {
         }
     }
 
-    pub(crate) fn build_input_stream_raw_inner(
+    fn build_stream(
         &self,
         config: &StreamConfig,
         sample_format: SampleFormat,
+        is_capture: bool,
     ) -> Result<StreamInner, BuildStreamError> {
         unsafe {
             // Making sure that COM is initialized.
@@ -563,168 +614,58 @@ impl Device {
             };
 
             let buffer_duration =
-                buffer_size_to_duration(&config.buffer_size, config.sample_rate.0);
+                buffer_size_to_duration(&audio_client, &config.buffer_size, config.sample_rate.0)
+                    .map_err(|_| BuildStreamError::DeviceNotAvailable)?;
 
             let mut stream_flags = Audio::AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
 
-            if self.data_flow() == Audio::eRender {
+            if is_capture
+                && self.share_mode == ShareMode::Shared
+                && self.data_flow() == Audio::eRender
+            {
                 stream_flags |= Audio::AUDCLNT_STREAMFLAGS_LOOPBACK;
             }
 
+            let share_mode = to_winapi_share_mode(self.share_mode);
+
             // Computing the format and initializing the device.
-            let waveformatex = {
-                let format_attempt = config_to_waveformatextensible(config, sample_format)
-                    .ok_or(BuildStreamError::StreamConfigNotSupported)?;
-                let share_mode = Audio::AUDCLNT_SHAREMODE_SHARED;
+            let format = config_to_waveformatextensible(config, sample_format)
+                .ok_or(BuildStreamError::StreamConfigNotSupported)?;
 
-                // Ensure the format is supported.
-                match super::device::is_format_supported(&audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::StreamConfigNotSupported),
-                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
-                    _ => (),
-                }
+            // Ensure the format is supported.
+            match super::device::is_format_supported(&audio_client, self.share_mode, &format.Format)
+            {
+                Ok(false) => return Err(BuildStreamError::StreamConfigNotSupported),
+                Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
+                _ => (),
+            }
 
-                // Finally, initializing the audio client
-                let hresult = audio_client.Initialize(
-                    share_mode,
-                    stream_flags,
-                    buffer_duration,
-                    0,
-                    &format_attempt.Format,
-                    None,
-                );
-                match hresult {
-                    Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
-                        return Err(BuildStreamError::DeviceNotAvailable);
-                    }
-                    Err(e) => {
-                        let description = format!("{}", e);
-                        let err = BackendSpecificError { description };
-                        return Err(err.into());
-                    }
-                    Ok(()) => (),
-                };
-
-                format_attempt.Format
+            let periodicity = if self.share_mode == ShareMode::Shared {
+                0
+            } else {
+                buffer_duration
             };
 
-            // obtaining the size of the samples buffer in number of frames
-            let max_frames_in_buffer = audio_client
-                .GetBufferSize()
-                .map_err(windows_err_to_cpal_err::<BuildStreamError>)?;
+            // Finally, initializing the audio client
+            let hresult = audio_client.Initialize(
+                share_mode,
+                stream_flags,
+                buffer_duration,
+                periodicity,
+                &format.Format,
+                None,
+            );
 
-            // Creating the event that will be signalled whenever we need to submit some samples.
-            let event = {
-                let event =
-                    Threading::CreateEventA(None, false, false, windows::core::PCSTR(ptr::null()))
-                        .map_err(|e| {
-                            let description = format!("failed to create event: {}", e);
-                            let err = BackendSpecificError { description };
-                            BuildStreamError::from(err)
-                        })?;
-
-                if let Err(e) = audio_client.SetEventHandle(event) {
-                    let description = format!("failed to call SetEventHandle: {}", e);
+            match hresult {
+                Err(ref e) if e.code() == Audio::AUDCLNT_E_DEVICE_INVALIDATED => {
+                    return Err(BuildStreamError::DeviceNotAvailable);
+                }
+                Err(e) => {
+                    let description = format!("{}", e);
                     let err = BackendSpecificError { description };
                     return Err(err.into());
                 }
-
-                event
-            };
-
-            // Building a `IAudioCaptureClient` that will be used to read captured samples.
-            let capture_client = audio_client
-                .GetService::<Audio::IAudioCaptureClient>()
-                .map_err(|e| {
-                    windows_err_to_cpal_err_message::<BuildStreamError>(
-                        e,
-                        "failed to build capture client: ",
-                    )
-                })?;
-
-            // Once we built the `StreamInner`, we add a command that will be picked up by the
-            // `run()` method and added to the `RunContext`.
-            let client_flow = AudioClientFlow::Capture { capture_client };
-
-            let audio_clock = get_audio_clock(&audio_client)?;
-
-            Ok(StreamInner {
-                audio_client,
-                audio_clock,
-                client_flow,
-                event,
-                playing: false,
-                max_frames_in_buffer,
-                bytes_per_frame: waveformatex.nBlockAlign,
-                config: config.clone(),
-                sample_format,
-            })
-        }
-    }
-
-    pub(crate) fn build_output_stream_raw_inner(
-        &self,
-        config: &StreamConfig,
-        sample_format: SampleFormat,
-    ) -> Result<StreamInner, BuildStreamError> {
-        unsafe {
-            // Making sure that COM is initialized.
-            // It's not actually sure that this is required, but when in doubt do it.
-            com::com_initialized();
-
-            // Obtaining a `IAudioClient`.
-            let audio_client = self
-                .build_audioclient()
-                .map_err(windows_err_to_cpal_err::<BuildStreamError>)?;
-
-            let buffer_duration =
-                buffer_size_to_duration(&config.buffer_size, config.sample_rate.0);
-
-            // Computing the format and initializing the device.
-            let waveformatex = {
-                let format_attempt = config_to_waveformatextensible(config, sample_format)
-                    .ok_or(BuildStreamError::StreamConfigNotSupported)?;
-                let share_mode = Audio::AUDCLNT_SHAREMODE_SHARED;
-
-                // Ensure the format is supported.
-                match super::device::is_format_supported(&audio_client, &format_attempt.Format) {
-                    Ok(false) => return Err(BuildStreamError::StreamConfigNotSupported),
-                    Err(_) => return Err(BuildStreamError::DeviceNotAvailable),
-                    _ => (),
-                }
-
-                // Finally, initializing the audio client
-                audio_client
-                    .Initialize(
-                        share_mode,
-                        Audio::AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
-                        buffer_duration,
-                        0,
-                        &format_attempt.Format,
-                        None,
-                    )
-                    .map_err(windows_err_to_cpal_err::<BuildStreamError>)?;
-
-                format_attempt.Format
-            };
-
-            // Creating the event that will be signalled whenever we need to submit some samples.
-            let event = {
-                let event =
-                    Threading::CreateEventA(None, false, false, windows::core::PCSTR(ptr::null()))
-                        .map_err(|e| {
-                            let description = format!("failed to create event: {}", e);
-                            let err = BackendSpecificError { description };
-                            BuildStreamError::from(err)
-                        })?;
-
-                if let Err(e) = audio_client.SetEventHandle(event) {
-                    let description = format!("failed to call SetEventHandle: {}", e);
-                    let err = BackendSpecificError { description };
-                    return Err(err.into());
-                }
-
-                event
+                Ok(()) => (),
             };
 
             // obtaining the size of the samples buffer in number of frames
@@ -735,19 +676,55 @@ impl Device {
                 )
             })?;
 
-            // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
-            let render_client = audio_client
-                .GetService::<IAudioRenderClient>()
-                .map_err(|e| {
-                    windows_err_to_cpal_err_message::<BuildStreamError>(
-                        e,
-                        "failed to build render client: ",
-                    )
-                })?;
+            // Creating the event that will be signalled whenever we need to submit some samples.
+            let event = {
+                let event =
+                    Threading::CreateEventA(None, false, false, windows::core::PCSTR(ptr::null()))
+                        .map_err(|e| {
+                            let description = format!("failed to create event: {}", e);
+                            let err = BackendSpecificError { description };
+                            BuildStreamError::from(err)
+                        })?;
 
-            // Once we built the `StreamInner`, we add a command that will be picked up by the
-            // `run()` method and added to the `RunContext`.
-            let client_flow = AudioClientFlow::Render { render_client };
+                if let Err(e) = audio_client.SetEventHandle(event) {
+                    let description = format!("failed to call SetEventHandle: {}", e);
+                    let err = BackendSpecificError { description };
+                    return Err(err.into());
+                }
+
+                event
+            };
+
+            let client_flow = if is_capture {
+                // Building a `IAudioCaptureClient` that will be used to read captured samples.
+                let capture_client = audio_client
+                    .GetService::<Audio::IAudioCaptureClient>()
+                    .map_err(|e| {
+                        windows_err_to_cpal_err_message::<BuildStreamError>(
+                            e,
+                            "failed to build capture client: ",
+                        )
+                    })?;
+
+                // Once we built the `StreamInner`, we add a command that will be picked up by the
+                // `run()` method and added to the `RunContext`.
+                AudioClientFlow::Capture { capture_client }
+            } else {
+                // Building a `IAudioRenderClient` that will be used to fill the samples buffer.
+                let render_client =
+                    audio_client
+                        .GetService::<IAudioRenderClient>()
+                        .map_err(|e| {
+                            windows_err_to_cpal_err_message::<BuildStreamError>(
+                                e,
+                                "failed to build render client: ",
+                            )
+                        })?;
+
+                // Once we built the `StreamInner`, we add a command that will be picked up by the
+                // `run()` method and added to the `RunContext`.
+                AudioClientFlow::Render { render_client }
+            };
 
             let audio_clock = get_audio_clock(&audio_client)?;
 
@@ -758,9 +735,10 @@ impl Device {
                 event,
                 playing: false,
                 max_frames_in_buffer,
-                bytes_per_frame: waveformatex.nBlockAlign,
+                bytes_per_frame: format.Format.nBlockAlign,
                 config: config.clone(),
                 sample_format,
+                share_mode: self.share_mode,
             })
         }
     }
@@ -864,12 +842,13 @@ unsafe impl Sync for Enumerator {}
 /// WASAPI implementation for `Devices`.
 pub struct Devices {
     collection: Audio::IMMDeviceCollection,
+    share_mode: ShareMode,
     total_count: u32,
     next_item: u32,
 }
 
 impl Devices {
-    pub fn new() -> Result<Self, DevicesError> {
+    pub(crate) fn new(share_mode: ShareMode) -> Result<Self, DevicesError> {
         unsafe {
             // can fail because of wrong parameters (should never happen) or out of memory
             let collection = get_enumerator()
@@ -881,6 +860,7 @@ impl Devices {
 
             Ok(Devices {
                 collection,
+                share_mode,
                 total_count: count,
                 next_item: 0,
             })
@@ -902,7 +882,7 @@ impl Iterator for Devices {
         unsafe {
             let device = self.collection.Item(self.next_item).unwrap();
             self.next_item += 1;
-            Some(Device::from_immdevice(device))
+            Some(Device::from_immdevice(device, self.share_mode))
         }
     }
 
@@ -914,23 +894,23 @@ impl Iterator for Devices {
     }
 }
 
-fn default_device(data_flow: Audio::EDataFlow) -> Option<Device> {
+fn default_device(data_flow: Audio::EDataFlow, share_mode: ShareMode) -> Option<Device> {
     unsafe {
         let device = get_enumerator()
             .0
             .GetDefaultAudioEndpoint(data_flow, Audio::eConsole)
             .ok()?;
         // TODO: check specifically for `E_NOTFOUND`, and panic otherwise
-        Some(Device::from_immdevice(device))
+        Some(Device::from_immdevice(device, share_mode))
     }
 }
 
-pub fn default_input_device() -> Option<Device> {
-    default_device(Audio::eCapture)
+pub fn default_input_device(share_mode: ShareMode) -> Option<Device> {
+    default_device(Audio::eCapture, share_mode)
 }
 
-pub fn default_output_device() -> Option<Device> {
-    default_device(Audio::eRender)
+pub fn default_output_device(share_mode: ShareMode) -> Option<Device> {
+    default_device(Audio::eRender, share_mode)
 }
 
 /// Get the audio clock used to produce `StreamInstant`s.
@@ -1009,10 +989,27 @@ fn config_to_waveformatextensible(
     Some(waveformatextensible)
 }
 
-fn buffer_size_to_duration(buffer_size: &BufferSize, sample_rate: u32) -> i64 {
+fn buffer_size_to_duration(
+    audio_client: &Audio::IAudioClient,
+    buffer_size: &BufferSize,
+    sample_rate: u32,
+) -> Result<i64, StreamError> {
     match buffer_size {
-        BufferSize::Fixed(frames) => *frames as i64 * (1_000_000_000 / 100) / sample_rate as i64,
-        BufferSize::Default => 0,
+        BufferSize::Fixed(frames) => {
+            Ok(*frames as i64 * (1_000_000_000 / 100) / sample_rate as i64)
+        }
+
+        BufferSize::Default => {
+            let mut default_device_period = 0;
+
+            unsafe {
+                audio_client
+                    .GetDevicePeriod(Some(&mut default_device_period as *mut _), None)
+                    .map_err(windows_err_to_cpal_err::<StreamError>)?;
+            }
+
+            Ok(default_device_period)
+        }
     }
 }
 

--- a/src/host/wasapi/mod.rs
+++ b/src/host/wasapi/mod.rs
@@ -10,8 +10,14 @@ use std::io::Error as IoError;
 use windows::Win32::Media::Audio;
 
 mod com;
-mod device;
+pub(crate) mod device;
 mod stream;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ShareMode {
+    Shared,
+    Exclusive,
+}
 
 /// The WASAPI host, the default windows host type.
 ///
@@ -37,15 +43,15 @@ impl HostTrait for Host {
     }
 
     fn devices(&self) -> Result<Self::Devices, DevicesError> {
-        Devices::new()
+        Devices::new(ShareMode::Shared)
     }
 
     fn default_input_device(&self) -> Option<Self::Device> {
-        default_input_device()
+        default_input_device(ShareMode::Shared)
     }
 
     fn default_output_device(&self) -> Option<Self::Device> {
-        default_output_device()
+        default_output_device(ShareMode::Shared)
     }
 }
 

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -1,4 +1,4 @@
-use super::windows_err_to_cpal_err;
+use super::{windows_err_to_cpal_err, ShareMode};
 use crate::traits::StreamTrait;
 use crate::{
     BackendSpecificError, Data, InputCallbackInfo, OutputCallbackInfo, PauseStreamError,
@@ -75,6 +75,9 @@ pub struct StreamInner {
     pub bytes_per_frame: u16,
     // The configuration with which the stream was created.
     pub config: crate::StreamConfig,
+
+    pub share_mode: ShareMode,
+
     // The sample format with which the stream was created.
     pub sample_format: SampleFormat,
 }
@@ -267,6 +270,15 @@ fn get_available_frames(stream: &StreamInner) -> Result<u32, StreamError> {
     }
 }
 
+fn get_buffer_size(stream: &StreamInner) -> Result<u32, StreamError> {
+    unsafe {
+        stream
+            .audio_client
+            .GetBufferSize()
+            .map_err(windows_err_to_cpal_err::<StreamError>)
+    }
+}
+
 fn run_input(
     mut run_ctxt: RunContext,
     data_callback: &mut dyn FnMut(&Data, &InputCallbackInfo),
@@ -303,25 +315,36 @@ fn run_output(
 ) {
     boost_current_thread_priority();
 
+    // If exclusive mode make sure we fill first buffer before start is called
+    let mut skip_commands = run_ctxt.stream.share_mode == ShareMode::Exclusive;
+
     loop {
-        match process_commands_and_await_signal(&mut run_ctxt, error_callback) {
-            Some(ControlFlow::Break) => break,
-            Some(ControlFlow::Continue) => continue,
-            None => (),
+        if !skip_commands {
+            match process_commands_and_await_signal(&mut run_ctxt, error_callback) {
+                Some(ControlFlow::Break) => break,
+                Some(ControlFlow::Continue) => continue,
+                None => (),
+            }
         }
-        let render_client = match run_ctxt.stream.client_flow {
-            AudioClientFlow::Render { ref render_client } => render_client.clone(),
+
+        match &run_ctxt.stream.client_flow {
+            AudioClientFlow::Render { render_client } => {
+                let res = process_output(
+                    &run_ctxt.stream,
+                    render_client,
+                    data_callback,
+                    error_callback,
+                );
+
+                if matches!(res, ControlFlow::Break) {
+                    break;
+                }
+            }
+
             _ => unreachable!(),
-        };
-        match process_output(
-            &run_ctxt.stream,
-            render_client,
-            data_callback,
-            error_callback,
-        ) {
-            ControlFlow::Break => break,
-            ControlFlow::Continue => continue,
         }
+
+        skip_commands = false;
     }
 }
 
@@ -445,12 +468,17 @@ fn process_input(
 // The loop for writing output data.
 fn process_output(
     stream: &StreamInner,
-    render_client: Audio::IAudioRenderClient,
+    render_client: &Audio::IAudioRenderClient,
     data_callback: &mut dyn FnMut(&mut Data, &OutputCallbackInfo),
     error_callback: &mut dyn FnMut(StreamError),
 ) -> ControlFlow {
+    let frame_count = match stream.share_mode {
+        ShareMode::Shared => get_available_frames(stream),
+        ShareMode::Exclusive => get_buffer_size(stream),
+    };
+
     // The number of frames available for writing.
-    let frames_available = match get_available_frames(stream) {
+    let frames_available = match frame_count {
         Ok(0) => return ControlFlow::Continue, // TODO: Can this happen?
         Ok(n) => n,
         Err(err) => {

--- a/src/host/wasapi_exclusive/mod.rs
+++ b/src/host/wasapi_exclusive/mod.rs
@@ -1,0 +1,149 @@
+use std::time::Duration;
+
+pub use crate::host::wasapi::device::{SupportedInputConfigs, SupportedOutputConfigs};
+use crate::traits::DeviceTrait;
+use crate::traits::HostTrait;
+use crate::traits::StreamTrait;
+use crate::DevicesError;
+
+use super::wasapi;
+use super::wasapi::ShareMode;
+
+/// The WASAPI exclusive host.
+///
+/// In exclusive mode only one stream can be opened per device, no mixing of multiple streams are performed.
+#[derive(Debug)]
+pub struct Host;
+
+impl Host {
+    pub fn new() -> Result<Self, crate::HostUnavailable> {
+        Ok(Host)
+    }
+}
+
+impl HostTrait for Host {
+    type Devices = Devices;
+    type Device = Device;
+
+    fn is_available() -> bool {
+        // Assume WASAPI is always available on Windows.
+        true
+    }
+
+    fn devices(&self) -> Result<Self::Devices, DevicesError> {
+        wasapi::Devices::new(ShareMode::Exclusive).map(Devices)
+    }
+
+    fn default_input_device(&self) -> Option<Self::Device> {
+        wasapi::default_input_device(ShareMode::Exclusive).map(Device)
+    }
+
+    fn default_output_device(&self) -> Option<Self::Device> {
+        wasapi::default_output_device(ShareMode::Exclusive).map(Device)
+    }
+}
+
+pub struct Devices(wasapi::Devices);
+
+impl Iterator for Devices {
+    type Item = Device;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(Device)
+    }
+}
+
+#[derive(Clone)]
+pub struct Device(wasapi::Device);
+
+impl DeviceTrait for Device {
+    type SupportedInputConfigs = <wasapi::Device as DeviceTrait>::SupportedInputConfigs;
+    type SupportedOutputConfigs = <wasapi::Device as DeviceTrait>::SupportedOutputConfigs;
+    type Stream = Stream;
+
+    fn name(&self) -> Result<String, crate::DeviceNameError> {
+        self.0.name()
+    }
+
+    fn supported_input_configs(
+        &self,
+    ) -> Result<Self::SupportedInputConfigs, crate::SupportedStreamConfigsError> {
+        self.0.supported_input_configs()
+    }
+
+    fn supported_output_configs(
+        &self,
+    ) -> Result<Self::SupportedOutputConfigs, crate::SupportedStreamConfigsError> {
+        self.0.supported_output_configs()
+    }
+
+    fn default_input_config(
+        &self,
+    ) -> Result<crate::SupportedStreamConfig, crate::DefaultStreamConfigError> {
+        self.0.default_input_config()
+    }
+
+    fn default_output_config(
+        &self,
+    ) -> Result<crate::SupportedStreamConfig, crate::DefaultStreamConfigError> {
+        self.0.default_output_config()
+    }
+
+    fn build_input_stream_raw<D, E>(
+        &self,
+        config: &crate::StreamConfig,
+        sample_format: crate::SampleFormat,
+        data_callback: D,
+        error_callback: E,
+        timeout: Option<Duration>,
+    ) -> Result<Self::Stream, crate::BuildStreamError>
+    where
+        D: FnMut(&crate::Data, &crate::InputCallbackInfo) + Send + 'static,
+        E: FnMut(crate::StreamError) + Send + 'static,
+    {
+        self.0
+            .build_input_stream_raw(
+                config,
+                sample_format,
+                data_callback,
+                error_callback,
+                timeout,
+            )
+            .map(Stream)
+    }
+
+    fn build_output_stream_raw<D, E>(
+        &self,
+        config: &crate::StreamConfig,
+        sample_format: crate::SampleFormat,
+        data_callback: D,
+        error_callback: E,
+        timeout: Option<Duration>,
+    ) -> Result<Self::Stream, crate::BuildStreamError>
+    where
+        D: FnMut(&mut crate::Data, &crate::OutputCallbackInfo) + Send + 'static,
+        E: FnMut(crate::StreamError) + Send + 'static,
+    {
+        self.0
+            .build_output_stream_raw(
+                config,
+                sample_format,
+                data_callback,
+                error_callback,
+                timeout,
+            )
+            .map(Stream)
+    }
+}
+
+pub struct Stream(wasapi::Stream);
+
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), crate::PlayStreamError> {
+        self.0.play()
+    }
+
+    fn pause(&self) -> Result<(), crate::PauseStreamError> {
+        self.0.pause()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl SupportedStreamConfigRange {
 
 #[test]
 fn test_cmp_default_heuristics() {
-    let mut formats = vec![
+    let mut formats = [
         SupportedStreamConfigRange {
             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
             channels: 2,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -667,8 +667,9 @@ mod platform_impl {
         Stream as WasapiStream, SupportedInputConfigs as WasapiSupportedInputConfigs,
         SupportedOutputConfigs as WasapiSupportedOutputConfigs,
     };
+    pub use crate::host::wasapi_exclusive::Host as WasapiExclusiveHost;
 
-    impl_platform_host!(#[cfg(feature = "asio")] Asio asio "ASIO", Wasapi wasapi "WASAPI");
+    impl_platform_host!(#[cfg(feature = "asio")] Asio asio "ASIO", Wasapi wasapi "WASAPI", WasapiExclusive wasapi_exclusive "WASAPI_exclusive");
 
     /// The default host for the current compilation target platform.
     pub fn default_host() -> Host {


### PR DESCRIPTION
In exclusive mode only one stream can be opened per device. This is different from the ASIO host which does its own mixing of multiple streams using the sample format of the device. I don't think this is a good idea because it can lead to audio artifacts like lack of precision and overflow. So it's better to let the application do the mixing, preferably using f32 or f64 samples which are then converted to the device sample format.

Also removed duplicated code in the WASAPI `Device` methods for creating input/output streams.