### PR TITLE
Remove parking_lot dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,18 +41,15 @@ windows = { version = "0.52.0", features = [
 ]}
 asio-sys = { version = "0.2", path = "asio-sys", optional = true }
 num-traits = { version = "0.2.6", optional = true }
-parking_lot = "0.12"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.8"
 libc = "0.2"
-parking_lot = "0.12"
 jack = { version = "0.11", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.
 mach2 = "0.4" # For access to mach_timebase type.
-parking_lot = "0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 coreaudio-rs = { version = "0.11", default-features = false, features = ["audio_unit", "core_audio"] }

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,8 +1,7 @@
 use super::alsa;
-use super::parking_lot::Mutex;
 use super::{Device, DeviceHandles};
 use crate::{BackendSpecificError, DevicesError};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// ALSA's implementation for `Devices`.
 pub struct Devices {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1,9 +1,7 @@
 extern crate alsa;
 extern crate libc;
-extern crate parking_lot;
 
 use self::alsa::poll::Descriptors;
-use self::parking_lot::Mutex;
 use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, ChannelCount, Data,
@@ -14,7 +12,7 @@ use crate::{
 };
 use std::cmp;
 use std::convert::TryInto;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use std::vec::IntoIter as VecIntoIter;
@@ -252,6 +250,7 @@ impl Device {
         let handle_result = self
             .handles
             .lock()
+            .unwrap()
             .take(&self.name, stream_type)
             .map_err(|e| (e, e.errno()));
 
@@ -311,7 +310,7 @@ impl Device {
         &self,
         stream_t: alsa::Direction,
     ) -> Result<VecIntoIter<SupportedStreamConfigRange>, SupportedStreamConfigsError> {
-        let mut guard = self.handles.lock();
+        let mut guard = self.handles.lock().unwrap();
         let handle_result = guard
             .get_mut(&self.name, stream_t)
             .map_err(|e| (e, e.errno()));

--- a/src/host/asio/device.rs
+++ b/src/host/asio/device.rs
@@ -1,7 +1,6 @@
 pub type SupportedInputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
 pub type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
 
-use super::parking_lot::Mutex;
 use super::sys;
 use crate::BackendSpecificError;
 use crate::DefaultStreamConfigError;
@@ -15,7 +14,7 @@ use crate::SupportedStreamConfigRange;
 use crate::SupportedStreamConfigsError;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::AtomicI32;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// A ASIO Device
 #[derive(Clone)]

--- a/src/host/asio/mod.rs
+++ b/src/host/asio/mod.rs
@@ -1,5 +1,4 @@
 extern crate asio_sys as sys;
-extern crate parking_lot;
 
 use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
 use crate::{

--- a/src/host/asio/stream.rs
+++ b/src/host/asio/stream.rs
@@ -2,14 +2,13 @@ extern crate asio_sys as sys;
 extern crate num_traits;
 
 use self::num_traits::PrimInt;
-use super::parking_lot::Mutex;
 use super::Device;
 use crate::{
     BackendSpecificError, BufferSize, BuildStreamError, Data, InputCallbackInfo,
     OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat, StreamConfig, StreamError,
 };
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub struct Stream {
@@ -77,7 +76,7 @@ impl Device {
             }
 
             // There is 0% chance of lock contention the host only locks when recreating streams.
-            let stream_lock = asio_streams.lock();
+            let stream_lock = asio_streams.lock().unwrap();
             let asio_stream = match stream_lock.input {
                 Some(ref asio_stream) => asio_stream,
                 None => return,
@@ -281,7 +280,7 @@ impl Device {
             }
 
             // There is 0% chance of lock contention the host only locks when recreating streams.
-            let mut stream_lock = asio_streams.lock();
+            let mut stream_lock = asio_streams.lock().unwrap();
             let asio_stream = match stream_lock.output {
                 Some(ref mut asio_stream) => asio_stream,
                 None => return,
@@ -518,7 +517,7 @@ impl Device {
             Err(_) => Err(BuildStreamError::StreamConfigNotSupported),
         }?;
         let num_channels = config.channels as usize;
-        let mut streams = self.asio_streams.lock();
+        let mut streams = self.asio_streams.lock().unwrap();
 
         let buffer_size = match config.buffer_size {
             BufferSize::Fixed(v) => Some(v as i32),
@@ -565,7 +564,7 @@ impl Device {
             Err(_) => Err(BuildStreamError::StreamConfigNotSupported),
         }?;
         let num_channels = config.channels as usize;
-        let mut streams = self.asio_streams.lock();
+        let mut streams = self.asio_streams.lock().unwrap();
 
         let buffer_size = match config.buffer_size {
             BufferSize::Fixed(v) => Some(v as i32),

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -1,5 +1,4 @@
 extern crate coreaudio;
-extern crate parking_lot;
 
 use self::coreaudio::sys::{
     kAudioFormatFlagIsFloat, kAudioFormatFlagIsPacked, kAudioFormatLinearPCM,

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -386,7 +386,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
             self.temp_input_buffer = vec![0.0; self.in_ports.len() * new_size];
             self.temp_output_buffer = vec![0.0; self.out_ports.len() * new_size];
             let description = format!("buffer size changed to: {}", new_size);
-            if let Ok(mut mutex_guard) = self.error_callback_ptr.lock() {
+            if let Ok(mut mutex_guard) = self.error_callback_ptr.lock().unwrap() {
                 let err = &mut *mutex_guard;
                 err(BackendSpecificError { description }.into());
             }
@@ -428,7 +428,7 @@ impl JackNotificationHandler {
 
     fn send_error(&mut self, description: String) {
         // This thread isn't the audio thread, it's fine to block
-        if let Ok(mut mutex_guard) = self.error_callback_ptr.lock() {
+        if let Ok(mut mutex_guard) = self.error_callback_ptr.lock().unwrap() {
             let err = &mut *mutex_guard;
             err(BackendSpecificError { description }.into());
         }

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -386,7 +386,7 @@ impl jack::ProcessHandler for LocalProcessHandler {
             self.temp_input_buffer = vec![0.0; self.in_ports.len() * new_size];
             self.temp_output_buffer = vec![0.0; self.out_ports.len() * new_size];
             let description = format!("buffer size changed to: {}", new_size);
-            if let Ok(mut mutex_guard) = self.error_callback_ptr.lock().unwrap() {
+            if let Ok(mut mutex_guard) = self.error_callback_ptr.lock() {
                 let err = &mut *mutex_guard;
                 err(BackendSpecificError { description }.into());
             }
@@ -428,7 +428,7 @@ impl JackNotificationHandler {
 
     fn send_error(&mut self, description: String) {
         // This thread isn't the audio thread, it's fine to block
-        if let Ok(mut mutex_guard) = self.error_callback_ptr.lock().unwrap() {
+        if let Ok(mut mutex_guard) = self.error_callback_ptr.lock() {
             let err = &mut *mutex_guard;
             err(BackendSpecificError { description }.into());
         }


### PR DESCRIPTION
The standard library is using a similar implementation to parking_lot now. Other than APIs that are unstable, there shouldn't be that much of a reason to rely on parking_lot anymore. Parts of the cpal codebase already are using std locks. This PR removes the remaining parking_lot uses and replaces them with the standard library's.