### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -1,4 +1,3 @@
-use anyhow;
 use clap::Parser;
 use cpal::{
     traits::{DeviceTrait, HostTrait, StreamTrait},

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -883,13 +883,13 @@ fn set_sample_rate(
 
 #[derive(Clone)]
 pub struct Stream {
-    inner: Rc<Mutex<StreamInner>>,
+    inner: Arc<Mutex<StreamInner>>,
 }
 
 impl Stream {
     fn new(inner: StreamInner) -> Self {
         Self {
-            inner: Rc::new(Mutex::new(inner)),
+            inner: Arc::new(Mutex::new(inner)),
         }
     }
 }

--- a/src/host/coreaudio/macos/property_listener.rs
+++ b/src/host/coreaudio/macos/property_listener.rs
@@ -8,7 +8,7 @@ use crate::BuildStreamError;
 
 /// A double-indirection to be able to pass a closure (a fat pointer)
 /// via a single c_void.
-struct PropertyListenerCallbackWrapper(Box<dyn FnMut() -> ()>);
+struct PropertyListenerCallbackWrapper(Box<dyn FnMut()>);
 
 /// Maintain an audio object property listener.
 /// The listener will be removed when this type is dropped.
@@ -21,7 +21,7 @@ pub struct AudioObjectPropertyListener {
 
 impl AudioObjectPropertyListener {
     /// Attach the provided callback as a audio object property listener.
-    pub fn new<F: FnMut() -> () + 'static>(
+    pub fn new<F: FnMut() + 'static>(
         audio_object_id: AudioObjectID,
         property_address: AudioObjectPropertyAddress,
         callback: F,

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -52,8 +52,8 @@ fn asbd_from_config(
     let frames_per_packet = 1;
     let bytes_per_packet = frames_per_packet * bytes_per_frame;
     let format_flags = match sample_format {
-        SampleFormat::F32 => (kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked) as u32,
-        _ => kAudioFormatFlagIsPacked as u32,
+        SampleFormat::F32 => kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+        _ => kAudioFormatFlagIsPacked,
     };
     AudioStreamBasicDescription {
         mBitsPerChannel: bits_per_channel as _,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,7 +742,7 @@ impl SupportedStreamConfigRange {
 
 #[test]
 fn test_cmp_default_heuristics() {
-    let mut formats = vec![
+    let mut formats = [
         SupportedStreamConfigRange {
             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
             channels: 2,


### PR DESCRIPTION
fix clippy warnings

<details>

```rs
warning: unneeded unit return type
  --> src/host/coreaudio/macos/property_listener.rs:11:55
   |
11 | struct PropertyListenerCallbackWrapper(Box<dyn FnMut() -> ()>);
   |                                                       ^^^^^^ help: remove the `-> ()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit
   = note: `#[warn(clippy::unused_unit)]` on by default

warning: unneeded unit return type
  --> src/host/coreaudio/macos/property_listener.rs:24:26
   |
24 |     pub fn new<F: FnMut() -> () + 'static>(
   |                          ^^^^^^ help: remove the `-> ()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unused_unit

warning: using `clone` on type `SupportedBufferSize` which implements the `Copy` trait
   --> src/host/coreaudio/macos/mod.rs:309:34
    |
309 |                     buffer_size: buffer_size.clone(),
    |                                  ^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `buffer_size`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default

warning: casting raw pointers to the same type and constness is unnecessary (`*const host::coreaudio::coreaudio::coreaudio_sys::AudioBuffer` -> `*const host::coreaudio::coreaudio::coreaudio_sys::AudioBuffer`)
   --> src/host/coreaudio/macos/mod.rs:571:23
    |
571 |             let ptr = (*args.data.data).mBuffers.as_ptr() as *const AudioBuffer;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(*args.data.data).mBuffers.as_ptr()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast
    = note: `#[warn(clippy::unnecessary_cast)]` on by default

warning: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/host/coreaudio/macos/mod.rs:583:23
    |
583 |             let len = (data_byte_size as usize / bytes_per_channel) as usize;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(data_byte_size as usize / bytes_per_channel)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: casting to the same type is unnecessary (`usize` -> `usize`)
   --> src/host/coreaudio/macos/mod.rs:688:23
    |
688 |             let len = (data_byte_size as usize / bytes_per_channel) as usize;
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(data_byte_size as usize / bytes_per_channel)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: usage of an `Arc` that is not `Send` and `Sync`
   --> src/host/coreaudio/macos/mod.rs:891:20
    |
891 |             inner: Arc::new(Mutex::new(inner)),
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `Arc<Mutex<StreamInner>>` is not `Send` and `Sync` as:
    = note: - the trait `Send` is not implemented for `Mutex<StreamInner>`
    = note: - the trait `Sync` is not implemented for `Mutex<StreamInner>`
    = help: consider using an `Rc` instead. `Arc` does not provide benefits for non `Send` and `Sync` types
    = note: if you intend to use `Arc` with `Send` and `Sync` traits
    = note: wrap the inner type with a `Mutex` or implement `Send` and `Sync` for `Mutex<StreamInner>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
    = note: `#[warn(clippy::arc_with_non_send_sync)]` on by default

warning: casting to the same type is unnecessary (`u32` -> `u32`)
  --> src/host/coreaudio/mod.rs:55:30
   |
55 |         SampleFormat::F32 => (kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked) as u32,
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `(kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: casting to the same type is unnecessary (`u32` -> `u32`)
  --> src/host/coreaudio/mod.rs:56:14
   |
56 |         _ => kAudioFormatFlagIsPacked as u32,
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `kAudioFormatFlagIsPacked`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_cast

warning: `cpal` (lib) generated 9 warnings (run `cargo clippy --fix --lib -p cpal` to apply 7 suggestions)
```

</details>

<details>

```
warning: useless use of `vec!`
   --> src/lib.rs:745:23
    |
745 |       let mut formats = vec![
    |  _______________________^
746 | |         SupportedStreamConfigRange {
747 | |             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
748 | |             channels: 2,
...   |
780 | |         },
781 | |     ];
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec
    = note: `#[warn(clippy::useless_vec)]` on by default
help: you can use an array directly
    |
745 ~     let mut formats = [SupportedStreamConfigRange {
746 +             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
747 +             channels: 2,
748 +             min_sample_rate: SampleRate(1),
749 +             max_sample_rate: SampleRate(96000),
750 +             sample_format: SampleFormat::F32,
751 +         },
752 +         SupportedStreamConfigRange {
753 +             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
754 +             channels: 1,
755 +             min_sample_rate: SampleRate(1),
756 +             max_sample_rate: SampleRate(96000),
757 +             sample_format: SampleFormat::F32,
758 +         },
759 +         SupportedStreamConfigRange {
760 +             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
761 +             channels: 2,
762 +             min_sample_rate: SampleRate(1),
763 +             max_sample_rate: SampleRate(96000),
764 +             sample_format: SampleFormat::I16,
765 +         },
766 +         SupportedStreamConfigRange {
767 +             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
768 +             channels: 2,
769 +             min_sample_rate: SampleRate(1),
770 +             max_sample_rate: SampleRate(96000),
771 +             sample_format: SampleFormat::U16,
772 +         },
773 +         SupportedStreamConfigRange {
774 +             buffer_size: SupportedBufferSize::Range { min: 256, max: 512 },
775 +             channels: 2,
776 +             min_sample_rate: SampleRate(1),
777 +             max_sample_rate: SampleRate(22050),
778 +             sample_format: SampleFormat::F32,
779 ~         }];
    |

warning: `cpal` (lib test) generated 1 warning (run `cargo clippy --fix --lib -p cpal --tests` to apply 1 suggestion)
warning: this import is redundant
 --> examples/beep.rs:1:1
  |
1 | use anyhow;
  | ^^^^^^^^^^^ help: remove it entirely
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports
  = note: `#[warn(clippy::single_component_path_imports)]` on by default
```

</details>