### PR TITLE
bump asio-sys crate

### DIFF
--- a/asio-sys/Cargo.toml
+++ b/asio-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asio-sys"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Tom Gowan <tomrgowan@gmail.com>"]
 description = "Low-level interface and binding generation for the steinberg ASIO SDK."
 repository = "https://github.com/RustAudio/cpal/"


### PR DESCRIPTION
Bump asio-sys crate to 0.2.2

# Changelog
- Remove one_cell in `asio-sys`. Added call to `ASIOOutputReady`.
- Automate `asio-sys` build.
- Fix aio-sys build failure. Update `bindgen` in `asyo-sys` to 0.64.