### PR TITLE
Adds `PartialOrd`, `Ord`, and `Hash` to the `#[derive(...)`] invocation on `SampleFormat`

### DIFF
--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -6,7 +6,7 @@ pub use dasp_sample::{FromSample, Sample, I24, I48, U24, U48};
 
 /// Format that each sample has.
 #[cfg_attr(target_os = "emscripten", wasm_bindgen)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum SampleFormat {
     /// `i8` with a valid range of 'u8::MIN..=u8::MAX' with `0` being the origin


### PR DESCRIPTION
Closes #863

[`PartialOrd`] is included as [`Ord`] depends on [`PartialOrd`]

[`PartialOrd`]: https://doc.rust-lang.org/nightly/std/cmp/trait.PartialOrd.html
[`Ord`]: https://doc.rust-lang.org/nightly/std/cmp/trait.Ord.html