### PR TITLE
ci: Update docker images for arm

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -85,9 +85,6 @@ jobs:
         with:
           target: armv7-unknown-linux-gnueabihf
 
-      - name: Build image
-        run: docker build -t cross/cpal_armv7:v1 ./
-
       - name: Install cross
         run: cargo install cross
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.armv7-unknown-linux-gnueabihf]
-image = "cross/cpal_armv7:v1"
+dockerfile = "Dockerfile"
 
 [target.armv7-unknown-linux-gnueabihf.env]
 passthrough = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rustembedded/cross:armv7-unknown-linux-gnueabihf
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
 
 ENV PKG_CONFIG_ALLOW_CROSS 1
 ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/


### PR DESCRIPTION
Commit message body:
```
See https://github.com/cross-rs/cross/wiki/Configuration#builddockerfile
for context regarding the $CROSS_BASE_IMAGE environment variable. Here, it
resolves toghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:{{cross_version}}

Relies on docker caching instead of pre-building the image.

Cross made the change to the GHCR on https://github.com/cross-rs/cross/pull/609

Add newline at EOF for some files.
```

It could reasonably be considered to remove the dockerfile altogether and declare the 
environment variables [docs](https://github.com/cross-rs/cross/wiki/Configuration#targettargetenv) and apt installation script [docs](https://github.com/cross-rs/cross/wiki/Configuration#targettargetpre-build), [example](https://github.com/cross-rs/cross/wiki/Configuration#build) as part of the `Cross.toml` file. 

It's just changing a few lines more, besides deleting the dockerfile. If that's deemed a good
option, I would gladly push it to this PR branch.
