### PR TITLE
chore: fix a clippy warning

### DIFF
--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -452,7 +452,7 @@ impl Device {
                                 channels: format.channels,
                                 min_sample_rate: sample_rate,
                                 max_sample_rate: sample_rate,
-                                buffer_size: format.buffer_size.clone(),
+                                buffer_size: format.buffer_size,
                                 sample_format,
                             })
                         }


### PR DESCRIPTION
remove `.clone()` from  `format.buffer_size.clone()` to make clippy happy ;)

```log
warning: using `clone` on type `SupportedBufferSize` which implements the `Copy` trait                                                                                                                     
   --> src\host\wasapi\device.rs:455:46
    |
455 | ...                   buffer_size: format.buffer_size.clone(),
    |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try removing the `clone` call: `format.buffer_size`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
    = note: `#[warn(clippy::clone_on_copy)]` on by default
```