### PR TITLE
fix: asio failed by timeinfo flags type

### DIFF
--- a/asio-sys/src/bindings/mod.rs
+++ b/asio-sys/src/bindings/mod.rs
@@ -1047,7 +1047,7 @@ extern "C" fn buffer_switch(double_buffer_index: c_long, direct_process: c_long)
                 //	kSampleRateChanged      = 1 << 4,
                 //	kClockSourceChanged     = 1 << 5
                 // } AsioTimeInfoFlags;
-                .0;
+                .0 as _;
         }
         time
     };


### PR DESCRIPTION
This may fix failure when enable asio under windows-gnu and windows-msvc build.
https://github.com/RustAudio/cpal/issues/860