### PR TITLE
PipeWire implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ num-traits = { version = "0.2.6", optional = true }
 alsa = "0.9"
 libc = "0.2"
 jack = { version = "0.11", optional = true }
+pipewire = { version = "0.8" }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -181,7 +181,7 @@ fn process_frame<SampleType>(
     SampleType: Sample + FromSample<f32>,
 {
     for frame in output.chunks_mut(num_channels) {
-        let value: SampleType = SampleType::from_sample(oscillator.tick());
+        let value: SampleType = SampleType::from_sample(oscillator.tick() * 0.01);
 
         // copy the same value to all channels
         for sample in frame.iter_mut() {

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -24,6 +24,16 @@ pub(crate) mod jack;
 pub(crate) mod null;
 #[cfg(target_os = "android")]
 pub(crate) mod oboe;
+/*#[cfg(all(
+#    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd"
+    ),
+    feature = "pipewire"
+))]*/
+pub(crate) mod pipewire;
 #[cfg(windows)]
 pub(crate) mod wasapi;
 #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -1,0 +1,141 @@
+use std::{
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use crate::{
+    traits::DeviceTrait, BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError,
+    InputCallbackInfo, OutputCallbackInfo, SampleFormat, SampleRate, StreamConfig, StreamError,
+    SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
+    SupportedStreamConfigsError,
+};
+
+use super::{Message, Stream, SupportedInputConfigs, SupportedOutputConfigs};
+
+static LAST_ID: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone)]
+pub struct Device {
+    pub(super) tx: pipewire::channel::Sender<Message>,
+}
+
+impl DeviceTrait for Device {
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
+    type Stream = Stream;
+
+    #[inline]
+    fn name(&self) -> Result<String, DeviceNameError> {
+        Ok("null".to_owned())
+    }
+
+    #[inline]
+    fn supported_input_configs(
+        &self,
+    ) -> Result<SupportedInputConfigs, SupportedStreamConfigsError> {
+        Ok(vec![SupportedStreamConfigRange {
+            channels: 2,
+            min_sample_rate: SampleRate(44100),
+            max_sample_rate: SampleRate(44100),
+            buffer_size: SupportedBufferSize::Range {
+                min: 15053,
+                max: 15053,
+            },
+            sample_format: SampleFormat::I16,
+        }]
+        .into_iter())
+    }
+
+    #[inline]
+    fn supported_output_configs(
+        &self,
+    ) -> Result<SupportedOutputConfigs, SupportedStreamConfigsError> {
+        Ok(vec![SupportedStreamConfigRange {
+            channels: 2,
+            min_sample_rate: SampleRate(44100),
+            max_sample_rate: SampleRate(44100),
+            buffer_size: SupportedBufferSize::Range {
+                min: 15053,
+                max: 15053,
+            },
+            sample_format: SampleFormat::I16,
+        }]
+        .into_iter())
+    }
+
+    #[inline]
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Ok(SupportedStreamConfig {
+            channels: 2,
+            sample_rate: SampleRate(44100),
+            buffer_size: SupportedBufferSize::Range {
+                min: 15053,
+                max: 15053,
+            },
+            sample_format: SampleFormat::I16,
+        })
+    }
+
+    #[inline]
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        Ok(SupportedStreamConfig {
+            channels: 2,
+            sample_rate: SampleRate(44100),
+            buffer_size: SupportedBufferSize::Range {
+                min: 15053,
+                max: 15053,
+            },
+            sample_format: SampleFormat::I16,
+        })
+    }
+
+    fn build_input_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: D,
+        _error_callback: E,
+        _timeout: Option<Duration>,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        let id = LAST_ID.fetch_add(1, Ordering::Relaxed);
+        self.tx.send(Message::CreateInputStream {
+            id,
+            config: config.clone(),
+            sample_format,
+            data_callback: Box::new(data_callback),
+        });
+        Ok(Stream {
+            id,
+            tx: self.tx.clone(),
+        })
+    }
+
+    fn build_output_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: D,
+        _error_callback: E,
+        _timeout: Option<Duration>,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        let id = LAST_ID.fetch_add(1, Ordering::Relaxed);
+        self.tx.send(Message::CreateOutputStream {
+            id,
+            config: config.clone(),
+            sample_format,
+            data_callback: Box::new(data_callback),
+        });
+        Ok(Stream {
+            id,
+            tx: self.tx.clone(),
+        })
+    }
+}

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,0 +1,236 @@
+use std::cell::RefCell;
+use std::collections::BTreeMap;
+use std::io::Cursor;
+use std::thread::{self, JoinHandle};
+
+use crate::traits::HostTrait;
+use crate::{
+    Data, DevicesError, InputCallbackInfo, OutputCallbackInfo, OutputStreamTimestamp, SampleFormat,
+    StreamConfig, StreamInstant, SupportedStreamConfigRange,
+};
+
+use pipewire::{properties::properties, spa};
+
+mod device;
+pub use self::device::Device;
+pub use self::stream::Stream;
+mod stream;
+
+pub type SupportedInputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type Devices = std::vec::IntoIter<Device>;
+
+pub struct Host {
+    tx: pipewire::channel::Sender<Message>,
+    thread: Option<JoinHandle<()>>,
+
+    devices_created: Vec<Device>,
+}
+
+impl Host {
+    #[allow(dead_code)]
+    pub fn new() -> Result<Self, crate::HostUnavailable> {
+        let (tx, rx) = pipewire::channel::channel::<Message>();
+        let thread = thread::spawn(|| pw_thread(rx));
+        Ok(Host {
+            tx: tx.clone(),
+            thread: Some(thread),
+            devices_created: vec![Device { tx }],
+        })
+    }
+}
+
+impl HostTrait for Host {
+    type Devices = Devices;
+    type Device = Device;
+
+    fn is_available() -> bool {
+        true
+    }
+
+    fn devices(&self) -> Result<Self::Devices, DevicesError> {
+        Ok(self.devices_created.clone().into_iter())
+    }
+
+    fn default_input_device(&self) -> Option<Self::Device> {
+        self.devices_created.first().cloned()
+    }
+
+    fn default_output_device(&self) -> Option<Self::Device> {
+        self.devices_created.first().cloned()
+    }
+}
+
+impl Drop for Host {
+    fn drop(&mut self) {
+        self.tx.send(Message::Destroy);
+        self.thread.take().unwrap().join().unwrap();
+    }
+}
+
+enum Message {
+    Destroy,
+    CreateOutputStream {
+        id: usize,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: Box<dyn FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static>,
+    },
+    CreateInputStream {
+        id: usize,
+        config: StreamConfig,
+        sample_format: SampleFormat,
+        data_callback: Box<dyn FnMut(&Data, &InputCallbackInfo) + Send + 'static>,
+    },
+    DestroyStream {
+        id: usize,
+    },
+}
+
+fn pw_thread(rx: pipewire::channel::Receiver<Message>) {
+    pipewire::init();
+
+    let main_loop = pipewire::main_loop::MainLoop::new(None).unwrap();
+    let context = pipewire::context::Context::new(&main_loop).unwrap();
+    let core = context.connect(None).unwrap();
+
+    let _receiver = rx.attach(main_loop.loop_(), {
+        let main_loop = main_loop.clone();
+        let core = core.clone();
+        let streams = RefCell::new(BTreeMap::new());
+
+        move |msg| match msg {
+            Message::Destroy => {
+                main_loop.quit();
+            }
+            Message::CreateOutputStream {
+                id,
+                config,
+                sample_format,
+                mut data_callback,
+            } => {
+                let stream = pipewire::stream::Stream::new(
+                    &core,
+                    "audio-src",
+                    properties! {
+                        *pipewire::keys::MEDIA_TYPE => "Audio",
+                        *pipewire::keys::MEDIA_ROLE => "Music",
+                        *pipewire::keys::MEDIA_CATEGORY => "Playback",
+                        *pipewire::keys::AUDIO_CHANNELS => "2",
+                    },
+                )
+                .unwrap();
+
+                let _listener = stream
+                    .add_local_listener::<()>()
+                    .process(move |stream, _| {
+                        let mut buffer = stream.dequeue_buffer().unwrap();
+                        let datas = buffer.datas_mut();
+                        let data = &mut datas[0];
+
+                        let mut time: pipewire::sys::pw_time = unsafe { std::mem::zeroed() };
+                        unsafe {
+                            pipewire::sys::pw_stream_get_time_n(
+                                stream.as_raw_ptr(),
+                                &mut time,
+                                std::mem::size_of_val(&time),
+                            )
+                        };
+
+                        let stride = sample_format.sample_size() * config.channels as usize;
+                        let sample_count = if let Some(data) = data.data() {
+                            let sample_count = data.len() / stride;
+                            let mut data = unsafe {
+                                Data::from_parts(
+                                    data.as_mut_ptr() as *mut (),
+                                    data.len() / sample_format.sample_size(),
+                                    sample_format,
+                                )
+                            };
+                            data_callback(
+                                &mut data,
+                                &OutputCallbackInfo {
+                                    timestamp: OutputStreamTimestamp {
+                                        callback: StreamInstant::from_nanos(0),
+                                        playback: StreamInstant::from_nanos(0),
+                                    },
+                                },
+                            );
+                            sample_count
+                        } else {
+                            0
+                        };
+
+                        let chunk = data.chunk_mut();
+                        *chunk.offset_mut() = 0;
+                        *chunk.stride_mut() = stride as _;
+                        *chunk.size_mut() = (stride * sample_count) as _;
+                    })
+                    .register()
+                    .unwrap();
+
+                let audio_info_pod = audio_info(config, sample_format);
+                stream
+                    .connect(
+                        spa::utils::Direction::Output,
+                        None,
+                        pipewire::stream::StreamFlags::AUTOCONNECT
+                            | pipewire::stream::StreamFlags::MAP_BUFFERS
+                            | pipewire::stream::StreamFlags::RT_PROCESS,
+                        &mut [pipewire::spa::pod::Pod::from_bytes(&audio_info_pod).unwrap()],
+                    )
+                    .unwrap();
+
+                streams.borrow_mut().insert(id, (stream, _listener));
+            }
+            Message::CreateInputStream {
+                id: _,
+                config: _,
+                sample_format: _,
+                data_callback: _,
+            } => {
+                todo!()
+            }
+            Message::DestroyStream { id } => {
+                streams.borrow_mut().remove(&id);
+            }
+        }
+    });
+
+    main_loop.run();
+}
+
+fn audio_info(stream_config: StreamConfig, sample_format: SampleFormat) -> Vec<u8> {
+    use pipewire::spa::{
+        param::audio::{AudioFormat, AudioInfoRaw},
+        pod::{serialize::PodSerializer, Object, Value},
+        sys::{SPA_PARAM_EnumFormat, SPA_TYPE_OBJECT_Format},
+    };
+
+    let mut audio_info = AudioInfoRaw::new();
+    audio_info.set_format(match sample_format {
+        SampleFormat::I8 => AudioFormat::S8,
+        SampleFormat::I16 => AudioFormat::S16LE,
+        SampleFormat::I32 => AudioFormat::S32LE,
+        SampleFormat::U8 => AudioFormat::U8,
+        SampleFormat::U16 => AudioFormat::U16LE,
+        SampleFormat::U32 => AudioFormat::U32LE,
+        SampleFormat::F32 => AudioFormat::F32LE,
+        SampleFormat::F64 => AudioFormat::F64LE,
+        _ => todo!(),
+    });
+    audio_info.set_rate(stream_config.sample_rate.0);
+    audio_info.set_channels(stream_config.channels as u32);
+
+    PodSerializer::serialize(
+        Cursor::new(Vec::new()),
+        &Value::Object(Object {
+            type_: SPA_TYPE_OBJECT_Format,
+            id: SPA_PARAM_EnumFormat,
+            properties: audio_info.into(),
+        }),
+    )
+    .unwrap()
+    .0
+    .into_inner()
+}

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -1,0 +1,25 @@
+use crate::{traits::StreamTrait, PauseStreamError, PlayStreamError};
+
+use super::Message;
+
+#[derive(Clone)]
+pub struct Stream {
+    pub(super) id: usize,
+    pub(super) tx: pipewire::channel::Sender<Message>,
+}
+
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        Ok(())
+    }
+
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        Ok(())
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        self.tx.send(Message::DestroyStream { id: self.id });
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -589,12 +589,18 @@ mod platform_impl {
         SupportedInputConfigs as JackSupportedInputConfigs,
         SupportedOutputConfigs as JackSupportedOutputConfigs,
     };
+    /*#[cfg(feature = "pipewire")]*/
+    pub use crate::host::pipewire::{
+        Device as PipeWireDevice, Devices as PipeWireDevices, Host as PipeWireHost,
+        Stream as PipeWireStream, SupportedInputConfigs as PipeWireSupportedInputConfigs,
+        SupportedOutputConfigs as PipeWireSupportedOutputConfigs,
+    };
 
-    impl_platform_host!(#[cfg(feature = "jack")] Jack jack "JACK", Alsa alsa "ALSA");
+    impl_platform_host!(/*#[cfg(feature = "pipewire")]*/ PipeWire pipewire "PipeWire", #[cfg(feature = "jack")] Jack jack "JACK", Alsa alsa "ALSA");
 
     /// The default host for the current compilation target platform.
     pub fn default_host() -> Host {
-        AlsaHost::new()
+        PipeWireHost::new()
             .expect("the default host should always be available")
             .into()
     }


### PR DESCRIPTION
This PR implements PW,

it works by having a main loop and use uni-directional channels to pass control messages to the main loop.

There are some open questions, and I use jack as foundation. For example there is not really any equivalent for devices, maybe it can be set that a device is the node the newly created node connects to.

Or its just like Jack, that there is a default device, and the user can create devices. But each individual stream should be a node.

As I can't test with ALSA, when a stream is dropped it gets released and its a permanent operation in contrary to play and pause which are temporary. Theoretically play and pause could also be mapped to connect, disconnect, but idk if this is correct.

Fixes https://github.com/RustAudio/cpal/issues/554