### PR TITLE
Oboe: use Unprocessed preset for input streams

### DIFF
--- a/src/host/oboe/mod.rs
+++ b/src/host/oboe/mod.rs
@@ -259,6 +259,7 @@ where
 {
     let builder = configure_for_device(builder, device, config);
     let stream = builder
+        .set_input_preset(oboe::InputPreset::Unprocessed)
         .set_callback(CpalOutputCallback::<T, C>::new(
             data_callback,
             error_callback,


### PR DESCRIPTION
Hi, I'm currently using cpal in an Android application and everything seems to work well.

However, I've noticed that this crate lacks support for Oboe's [InputPresets](https://docs.rs/oboe/latest/oboe/enum.InputPreset.html), which is quite an important thing for certain projects. At the moment the default preset is `VoiceRecognition`.

It would be great if one could choose the best preset when [building the stream](https://github.com/RustAudio/cpal/blob/master/src/host/oboe/mod.rs#L237), but that would require either to change the signature of the function (making not adhere anymore to the [relative trait](https://github.com/RustAudio/cpal/blob/master/src/traits.rs#L125)), or to set this preset within a static config variable, or something similar.

In the meantime I think it would make sense to use `Unprocessed` preset, which does not apply any effect, making the user able to obtain full control over the stream.