### PR TITLE
Fix handling of integer input formats on macOS

### DIFF
--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -1,8 +1,8 @@
 extern crate coreaudio;
 
 use self::coreaudio::sys::{
-    kAudioFormatFlagIsFloat, kAudioFormatFlagIsPacked, kAudioFormatLinearPCM,
-    AudioStreamBasicDescription, OSStatus,
+    kAudioFormatFlagIsFloat, kAudioFormatFlagIsPacked, kAudioFormatFlagIsSignedInteger,
+    kAudioFormatLinearPCM, AudioStreamBasicDescription, OSStatus,
 };
 
 use crate::DefaultStreamConfigError;
@@ -52,7 +52,10 @@ fn asbd_from_config(
     let frames_per_packet = 1;
     let bytes_per_packet = frames_per_packet * bytes_per_frame;
     let format_flags = match sample_format {
-        SampleFormat::F32 => kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+        SampleFormat::F32 | SampleFormat::F64 => kAudioFormatFlagIsFloat | kAudioFormatFlagIsPacked,
+        SampleFormat::I16 | SampleFormat::I32 | SampleFormat::I64 => {
+            kAudioFormatFlagIsSignedInteger | kAudioFormatFlagIsPacked
+        }
         _ => kAudioFormatFlagIsPacked,
     };
     AudioStreamBasicDescription {


### PR DESCRIPTION
Previously attempting to capture integer-valued audio samples would fail on macOS because that `kAudioFormatFlagIsSignedInteger` flag was not set on the `AudioStreamBasicDescription`.