### PR TITLE
Adopt windows version range >=0.54, <=0.57

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clap = { version = "4.0", features = ["derive"] }
 ndk-glue = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.54.0", features = [
+windows = { version = ">=0.54, <=0.57.0", features = [
     "Win32_Media_Audio",
     "Win32_Foundation",
     "Win32_Devices_Properties",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ clap = { version = "4.0", features = ["derive"] }
 ndk-glue = "0.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]
+# Support a range of versions in order to avoid duplication of this crate. Make sure to test all
+# versions when bumping to a new release, and only increase the minimum when absolutely necessary.
 windows = { version = ">=0.54, <=0.57.0", features = [
     "Win32_Media_Audio",
     "Win32_Foundation",


### PR DESCRIPTION
`windows` is a "heavy" crate. Duplicate `windows` versions in a tree can add precious seconds to compile times (or even _minutes_ by some Bevy user reports). On the Bevy side, we are trying to ensure that `windows` is only compiled once. We also believe it is in the ecosystem's best interest (and in the interest of crate owners that consume `windows`) to align their versioning with the rest of ecosystem. Therefore, I would like to encourage crate owners to adopt the following approach to `windows` crate usage:

1. Adopt "range versioning" for windows instead of locking to a specific version.
2. Before adding a new version to the range, test that each previous version in the range still compiles.
3. Only remove old versions from the range when _absolutely necessary_. Try your hardest to ensure that your version support aligns with other ecosystem crates.

We've picked 0.54 as a baseline because breaking API changes were made to use Rust Results instead of HRESULT.

I have personally tested that cpal compiles with 0.54, 0.56 (0.55 does not exist), and 0.57.