### PR TITLE
JACK: bump to 0.13.0 and fix compliation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ num-traits = { version = "0.2.6", optional = true }
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))'.dependencies]
 alsa = "0.9"
 libc = "0.2"
-jack = { version = "0.12", optional = true }
+jack = { version = "0.13.0", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.

--- a/src/host/jack/stream.rs
+++ b/src/host/jack/stream.rs
@@ -37,7 +37,7 @@ impl Stream {
         let mut port_names: Vec<String> = vec![];
         // Create ports
         for i in 0..channels {
-            let port_try = client.register_port(&format!("in_{}", i), jack::AudioIn);
+            let port_try = client.register_port(&format!("in_{}", i), jack::AudioIn::default());
             match port_try {
                 Ok(port) => {
                     // Get the port name in order to later connect it automatically
@@ -102,7 +102,7 @@ impl Stream {
         let mut port_names: Vec<String> = vec![];
         // Create ports
         for i in 0..channels {
-            let port_try = client.register_port(&format!("out_{}", i), jack::AudioOut);
+            let port_try = client.register_port(&format!("out_{}", i), jack::AudioOut::default());
             match port_try {
                 Ok(port) => {
                     // Get the port name in order to later connect it automatically
@@ -437,7 +437,7 @@ impl JackNotificationHandler {
 }
 
 impl jack::NotificationHandler for JackNotificationHandler {
-    fn shutdown(&mut self, _status: jack::ClientStatus, reason: &str) {
+    unsafe fn shutdown(&mut self, _status: jack::ClientStatus, reason: &str) {
         self.send_error(format!("JACK was shut down for reason: {}", reason));
     }
 


### PR DESCRIPTION
Fixes compilation on master when using Jack.

Replaces #914