### PR TITLE
Added supports_input/output methods to DeviceTrait

### DIFF
--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -58,6 +58,14 @@ impl DeviceTrait for Device {
         Device::name(self)
     }
 
+    fn supports_input(&self) -> bool {
+        self.data_flow() == Audio::eCapture
+    }
+
+    fn supports_output(&self) -> bool {
+        self.data_flow() == Audio::eRender
+    }
+
     fn supported_input_configs(
         &self,
     ) -> Result<Self::SupportedInputConfigs, SupportedStreamConfigsError> {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -315,6 +315,24 @@ macro_rules! impl_platform_host {
                 }
             }
 
+            fn supports_input(&self) -> bool {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(ref d) => d.supports_input(),
+                    )*
+                }
+            }
+
+            fn supports_output(&self) -> bool {
+                match self.0 {
+                    $(
+                        $(#[cfg($feat)])?
+                        DeviceInner::$HostVariant(ref d) => d.supports_output(),
+                    )*
+                }
+            }
+
             fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, crate::SupportedStreamConfigsError> {
                 match self.0 {
                     $(

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -59,13 +59,7 @@ pub trait HostTrait {
     ///
     /// Can be empty if the system does not support audio input.
     fn input_devices(&self) -> Result<InputDevices<Self::Devices>, DevicesError> {
-        fn supports_input<D: DeviceTrait>(device: &D) -> bool {
-            device
-                .supported_input_configs()
-                .map(|mut iter| iter.next().is_some())
-                .unwrap_or(false)
-        }
-        Ok(self.devices()?.filter(supports_input::<Self::Device>))
+        Ok(self.devices()?.filter(DeviceTrait::supports_input))
     }
 
     /// An iterator yielding all `Device`s currently available to the system that support one or more
@@ -73,13 +67,7 @@ pub trait HostTrait {
     ///
     /// Can be empty if the system does not support audio output.
     fn output_devices(&self) -> Result<OutputDevices<Self::Devices>, DevicesError> {
-        fn supports_output<D: DeviceTrait>(device: &D) -> bool {
-            device
-                .supported_output_configs()
-                .map(|mut iter| iter.next().is_some())
-                .unwrap_or(false)
-        }
-        Ok(self.devices()?.filter(supports_output::<Self::Device>))
+        Ok(self.devices()?.filter(DeviceTrait::supports_output))
     }
 }
 
@@ -100,6 +88,20 @@ pub trait DeviceTrait {
 
     /// The human-readable name of the device.
     fn name(&self) -> Result<String, DeviceNameError>;
+
+    /// True if the device supports audio input, otherwise false
+    fn supports_input(&self) -> bool {
+        self.supported_input_configs()
+            .map(|mut iter| iter.next().is_some())
+            .unwrap_or(false)
+    }
+
+    /// True if the device supports audio output, otherwise false
+    fn supports_output(&self) -> bool {
+        self.supported_output_configs()
+            .map(|mut iter| iter.next().is_some())
+            .unwrap_or(false)
+    }
 
     /// An iterator yielding formats that are supported by the backend.
     ///


### PR DESCRIPTION
Only WASAPI overrides the default method implementations, other hosts work the same as before (iterating over configs) but they can potentially be optimized later.

Time to get list of WASAPI devices on my machine (5 devices in total) before change: 
Input devices: 12 ms, output devices: 187 ms

After change:
Input devices: 1 ms, output devices: 1 ms

This fixes issue #867 