### PR TITLE
[macOS] Fixed `SupportedStreamConfigRange` returns same `min_samplerate` and `max_samplerate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - ALSA(process_output): pass `silent=true` to `PCM.try_recover`, so it doesn't write to stderr
 - WASAPI: Expose IMMDevice from WASAPI host Device.
-- `Device::supported_configs` on CoreAudio now returns a single element which contains available samplerate range if the all element of list have same value for `mMinimum` and `mMaximum` (which is the most case).
+- CoreAudio: `Device::supported_configs` now returns a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values (which is the most common case).
 
 # Version 0.16.0 (2025-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - ALSA(process_output): pass `silent=true` to `PCM.try_recover`, so it doesn't write to stderr
 - WASAPI: Expose IMMDevice from WASAPI host Device.
+- `Device::supported_configs` on CoreAudio now returns a single element which contains available samplerate range if the all element of list have same value for `mMinimum` and `mMaximum` (which is the most case).
 
 # Version 0.16.0 (2025-06-07)
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -301,8 +301,20 @@ impl Device {
             } else {
                 let fmt = SupportedStreamConfigRange {
                     channels: n_channels as ChannelCount,
-                    min_sample_rate: SampleRate(ranges.into_iter().map(|v| v.mMinimum as u32).min().expect("the list must not be empty")),
-                    max_sample_rate: SampleRate(ranges.into_iter().map(|v| v.mMaximum as u32).max().expect("the list must not be empty")),
+                    min_sample_rate: SampleRate(
+                        ranges
+                            .into_iter()
+                            .map(|v| v.mMinimum as u32)
+                            .min()
+                            .expect("the list must not be empty"),
+                    ),
+                    max_sample_rate: SampleRate(
+                        ranges
+                            .into_iter()
+                            .map(|v| v.mMaximum as u32)
+                            .max()
+                            .expect("the list must not be empty"),
+                    ),
                     buffer_size,
                     sample_format,
                 };

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -290,7 +290,7 @@ impl Device {
             if ranges.is_empty() {
                 Ok(vec![].into_iter())
             } else if contains_different_sample_rates {
-                let res = ranges.into_iter().map(|range| SupportedStreamConfigRange {
+                let res = ranges.iter().map(|range| SupportedStreamConfigRange {
                     channels: n_channels as ChannelCount,
                     min_sample_rate: SampleRate(range.mMinimum as u32),
                     max_sample_rate: SampleRate(range.mMaximum as u32),
@@ -303,14 +303,14 @@ impl Device {
                     channels: n_channels as ChannelCount,
                     min_sample_rate: SampleRate(
                         ranges
-                            .into_iter()
+                            .iter()
                             .map(|v| v.mMinimum as u32)
                             .min()
                             .expect("the list must not be empty"),
                     ),
                     max_sample_rate: SampleRate(
                         ranges
-                            .into_iter()
+                            .iter()
                             .map(|v| v.mMaximum as u32)
                             .max()
                             .expect("the list must not be empty"),

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -278,19 +278,19 @@ impl Device {
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             // Collect the supported formats for the device.
-            let mut fmts = vec![];
-            for range in ranges {
-                let fmt = SupportedStreamConfigRange {
-                    channels: n_channels as ChannelCount,
-                    min_sample_rate: SampleRate(range.mMinimum as _),
-                    max_sample_rate: SampleRate(range.mMaximum as _),
-                    buffer_size,
-                    sample_format,
-                };
-                fmts.push(fmt);
-            }
+            let fmt = SupportedStreamConfigRange {
+                channels: n_channels as ChannelCount,
+                min_sample_rate: SampleRate(
+                    ranges.iter().map(|v| v.mMinimum as u32).min().unwrap(),
+                ),
+                max_sample_rate: SampleRate(
+                    ranges.iter().map(|v| v.mMaximum as u32).max().unwrap(),
+                ),
+                buffer_size,
+                sample_format,
+            };
 
-            Ok(fmts.into_iter())
+            Ok(vec![fmt].into_iter())
         }
     }
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -299,13 +299,10 @@ impl Device {
                 });
                 Ok(res.collect::<Vec<_>>().into_iter())
             } else {
-                let values = ranges.into_iter().map(|v| v.mMinimum as u32); //assume that all mMinimum and mMaximum values are the same
-                let min = values.clone().min().expect("the list must not be empty");
-                let max = values.max().expect("the list must not be empty");
                 let fmt = SupportedStreamConfigRange {
                     channels: n_channels as ChannelCount,
-                    min_sample_rate: SampleRate(min),
-                    max_sample_rate: SampleRate(max),
+                    min_sample_rate: SampleRate(ranges.into_iter().map(|v| v.mMinimum as u32).min().expect("the list must not be empty")),
+                    max_sample_rate: SampleRate(ranges.into_iter().map(|v| v.mMaximum as u32).max().expect("the list must not be empty")),
                     buffer_size,
                     sample_format,
                 };


### PR DESCRIPTION
On MacOS, `Device::supported_output/input_configs` returns multiple configs and they are the same values except for `min_samplerate` and `max_samplerate`. However, the pair of samplerates are always the same value like `min_samplerate:44100, max_samplerate:44100` and `min_samplerate:48000, max_samplerate:48000`. 

With this PR, `Device::supported_output/input_configs` now returns a combined `SupportedStreamConfig`. I found this problem when I tried to reorder the available streamconfigs depending on the parameter in my application.
 
On MacOS, `Device::default_input/output_config` does not use `cmp_default_heuristics` (I guess wasapi&asio are the same), but I hope this could be used in every platform ideally (though this PR does not address the implementation of the default config-related method).

Tested on: M1 Macbook Air(2020), macOS 15.0.1