### PR TITLE
Fix wasi CI not running due to target rename in rust 1.84

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -137,7 +137,7 @@ jobs:
 
     strategy:
       matrix:
-        target: [wasm32-wasi]
+        target: [wasm32-wasip1]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
See changelog: https://releases.rs/docs/1.84.0/
relevant excerpt:
> Support for the target named wasm32-wasi has been removed as the target is now named wasm32-wasip1. This completes the transition plan for this target following the introduction of wasm32-wasip1 in Rust 1.78. Compiler warnings on use of wasm32-wasi introduced in Rust 1.81 are now gone as well as the target is removed.