### PR TITLE
PipeWire implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/target
-/Cargo.lock
+target/
+Cargo.lock
 .cargo/
 .DS_Store
 recorded.wav

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ rust-version = "1.70"
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
 oboe-shared-stdcxx = ["oboe/shared-stdcxx"] # Only available on Android. See README for what it does.
+jack = ["dep:jack"]
+pipewire = ["dep:pipewire-client"]
 
 [dependencies]
 dasp_sample = "0.11"
@@ -46,6 +48,7 @@ num-traits = { version = "0.2.6", optional = true }
 alsa = "0.9"
 libc = "0.2"
 jack = { version = "0.13.0", optional = true }
+pipewire-client = { version = "0.1", path = "pipewire-client", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation-sys = "0.8.2" # For linking to CoreFoundation.framework and handling device name `CFString`s.

--- a/pipewire-client/Cargo.toml
+++ b/pipewire-client/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pipewire-client"
+version = "0.1.0"
+edition = "2021"
+authors = ["Alexis Bekhdadi <alexis@bekhdadi.com>"]
+description = "PipeWire Client"
+repository = "https://github.com/RustAudio/cpal/"
+#documentation = ""
+license = "Apache-2.0"
+keywords = ["pipewire", "client"]
+
+[dependencies]
+pipewire = { version = "0.8" }
+pipewire-spa-utils = { version = "0.1", path = "../pipewire-spa-utils"}
+serde_json = "1.0"
+
+[dev-dependencies]
+rstest = "0.24"
+serial_test = "3.2"

--- a/pipewire-client/src/client/connection_string.rs
+++ b/pipewire-client/src/client/connection_string.rs
@@ -1,0 +1,36 @@
+use std::path::PathBuf;
+use crate::constants::*;
+
+pub(super) struct PipewireClientConnectionString;
+
+impl PipewireClientConnectionString {
+    pub(super) fn from_env() -> String {
+        let pipewire_runtime_dir = std::env::var(PIPEWIRE_RUNTIME_DIR_ENVIRONMENT_KEY);
+        let xdg_runtime_dir = std::env::var(XDG_RUNTIME_DIR_ENVIRONMENT_KEY);
+
+        let socket_directory = match (xdg_runtime_dir, pipewire_runtime_dir) {
+            (Ok(value), Ok(_)) => value,
+            (Ok(value), Err(_)) => value,
+            (Err(_), Ok(value)) => value,
+            (Err(_), Err(_)) => panic!(
+                "${} or ${} should be set. See https://docs.pipewire.org/page_man_pipewire_1.html",
+                PIPEWIRE_RUNTIME_DIR_ENVIRONMENT_KEY, XDG_RUNTIME_DIR_ENVIRONMENT_KEY
+            ),
+        };
+
+        let pipewire_remote = match std::env::var(PIPEWIRE_REMOTE_ENVIRONMENT_KEY) {
+            Ok(value) => value,
+            Err(_) => panic!(
+                "${PIPEWIRE_REMOTE_ENVIRONMENT_KEY} should be set. See https://docs.pipewire.org/page_man_pipewire_1.html",
+            )
+        };
+
+        let socket_path = PathBuf::from(socket_directory).join(pipewire_remote);
+        socket_path.to_str().unwrap().to_string()
+    }
+}
+
+pub(super) struct PipewireClientInfo {
+    pub name: String,
+    pub connection_string: String,
+}

--- a/pipewire-client/src/client/handlers/event.rs
+++ b/pipewire-client/src/client/handlers/event.rs
@@ -1,0 +1,263 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::mpsc;
+use pipewire_spa_utils::audio::raw::AudioInfoRaw;
+use crate::constants::{METADATA_NAME_PROPERTY_VALUE_DEFAULT, METADATA_NAME_PROPERTY_VALUE_SETTINGS};
+use crate::error::Error;
+use crate::listeners::ListenerTriggerPolicy;
+use crate::messages::{EventMessage, MessageResponse};
+use crate::states::{DefaultAudioNodesState, GlobalId, GlobalState, SettingsState};
+
+pub(super) fn event_handler(
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+) -> impl Fn(EventMessage) + 'static
+{    
+    move |event_message: EventMessage| match event_message {
+        EventMessage::SetMetadataListeners { id } => handle_set_metadata_listeners(
+            id,
+            state.clone(),
+            main_sender.clone(),
+        ),
+        EventMessage::RemoveNode { id } => handle_remove_node(
+            id, 
+            state.clone(), 
+            main_sender.clone()
+        ),
+        EventMessage::SetNodePropertiesListener { id } => handle_set_node_properties_listener(
+            id, 
+            state.clone(), 
+            main_sender.clone(), 
+            event_sender.clone()
+        ),
+        EventMessage::SetNodeFormatListener { id } => handle_set_node_format_listener(
+            id, 
+            state.clone(), 
+            main_sender.clone(), 
+            event_sender.clone()
+        ),
+        EventMessage::SetNodeProperties { 
+            id, 
+            properties 
+        } => handle_set_node_properties(
+            id, 
+            properties, 
+            state.clone(), 
+            main_sender.clone()
+        ),
+        EventMessage::SetNodeFormat { id, format } => handle_set_node_format(
+            id, 
+            format, 
+            state.clone(), 
+            main_sender.clone()
+        ),
+    }
+}
+
+fn handle_set_metadata_listeners(
+    id: GlobalId,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let listener_state = state.clone();
+    let mut state = state.borrow_mut();
+    let metadata = match state.get_metadata_mut(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let main_sender = main_sender.clone();
+    match metadata.name.as_str() {
+        METADATA_NAME_PROPERTY_VALUE_SETTINGS => {
+            metadata.add_property_listener(
+                ListenerTriggerPolicy::Keep,
+                SettingsState::listener(
+                    listener_state,
+                    move |settings: &SettingsState| {
+                        main_sender
+                            .send(MessageResponse::SettingsState(settings.state.clone()))
+                            .unwrap();
+                    }
+                )
+            )
+        },
+        METADATA_NAME_PROPERTY_VALUE_DEFAULT => {
+            metadata.add_property_listener(
+                ListenerTriggerPolicy::Keep,
+                DefaultAudioNodesState::listener(
+                    listener_state,
+                    move |default_audio_devices: &DefaultAudioNodesState| {
+                        main_sender
+                            .send(MessageResponse::DefaultAudioNodesState(default_audio_devices.state.clone()))
+                            .unwrap();
+                    }
+                )
+            )
+        },
+        _ => {
+            main_sender
+                .send(MessageResponse::Error(Error {
+                    description: format!("Unexpected metadata with name: {}", metadata.name)
+                }))
+                .unwrap();
+        }
+    };
+}
+fn handle_remove_node(
+    id: GlobalId,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let _ = match state.get_node(&id) {
+        Ok(_) => {},
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    state.remove(&id);
+}
+fn handle_set_node_properties_listener(
+    id: GlobalId,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let node = match state.get_node_mut(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let event_sender = event_sender.clone();
+    node.add_properties_listener(
+        ListenerTriggerPolicy::Keep,
+        move |properties| {
+            // "object.register" property when set to "false", indicate we should not
+            // register this object
+            // Some bluez nodes don't have sample rate information in their
+            // EnumFormat object. We delete those nodes since parsing node audio format
+            // imply to retrieve:
+            //   - Media type
+            //   - Media subtype
+            //   - Sample format
+            //   - Sample rate
+            //   - Channels
+            //   - Channels position
+            // Lets see in the future if node with no "object.register: false" property
+            // and with incorrect EnumFormat object occur.
+            if properties.get("object.register").is_some_and(move |value| value == "false") {
+                event_sender
+                    .send(EventMessage::RemoveNode {
+                        id: id.clone(),
+                    })
+                    .unwrap();
+            }
+            else {
+                event_sender
+                    .send(EventMessage::SetNodeProperties {
+                        id: id.clone(),
+                        properties,
+                    })
+                    .unwrap();
+                event_sender
+                    .send(EventMessage::SetNodeFormatListener {
+                        id: id.clone(),
+                    })
+                    .unwrap();
+            }
+        }
+    );
+}
+fn handle_set_node_format_listener(
+    id: GlobalId,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let node = match state.get_node_mut(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let main_sender = main_sender.clone();
+    let event_sender = event_sender.clone();
+    node.add_format_listener(
+        ListenerTriggerPolicy::Keep,
+        move |format| {
+            match format {
+                Ok(value) => {
+                    event_sender
+                        .send(EventMessage::SetNodeFormat {
+                            id,
+                            format: value,
+                        })
+                        .unwrap();
+                }
+                Err(value) => {
+                    main_sender.send(MessageResponse::Error(value)).unwrap();
+                }
+            }
+        }
+    )
+}
+fn handle_set_node_properties(
+    id: GlobalId,
+    properties: HashMap<String, String>,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let node = match state.get_node_mut(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    node.set_properties(properties);
+}
+fn handle_set_node_format(
+    id: GlobalId,
+    format: AudioInfoRaw,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let node = match state.get_node_mut(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    node.set_format(format)
+}

--- a/pipewire-client/src/client/handlers/mod.rs
+++ b/pipewire-client/src/client/handlers/mod.rs
@@ -1,0 +1,5 @@
+mod event;
+mod registry;
+mod request;
+mod thread;
+pub use thread::pw_thread as thread;

--- a/pipewire-client/src/client/handlers/registry.rs
+++ b/pipewire-client/src/client/handlers/registry.rs
@@ -1,0 +1,272 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::mpsc;
+use pipewire::registry::GlobalObject;
+use pipewire::spa;
+use crate::constants::{APPLICATION_NAME_PROPERTY_KEY, APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION, APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER, MEDIA_CLASS_PROPERTY_KEY, MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK, MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE, METADATA_NAME_PROPERTY_KEY, METADATA_NAME_PROPERTY_VALUE_DEFAULT, METADATA_NAME_PROPERTY_VALUE_SETTINGS};
+use crate::messages::{EventMessage, MessageResponse};
+use crate::states::{ClientState, GlobalId, GlobalObjectState, GlobalState, MetadataState, NodeState};
+use crate::utils::debug_dict_ref;
+
+pub(super) fn registry_global_handler(
+    state: Rc<RefCell<GlobalState>>,
+    registry: Rc<pipewire::registry::Registry>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+) -> impl Fn(&GlobalObject<&spa::utils::dict::DictRef>) + 'static
+{
+    move |global: &GlobalObject<&spa::utils::dict::DictRef>| match global.type_ {
+        pipewire::types::ObjectType::Client => handle_client(
+            global, 
+            state.clone(), 
+            main_sender.clone()
+        ),
+        pipewire::types::ObjectType::Metadata => handle_metadata(
+            global, 
+            state.clone(), 
+            registry.clone(), 
+            main_sender.clone(), 
+            event_sender.clone()
+        ),
+        pipewire::types::ObjectType::Node => handle_node(
+            global,
+            state.clone(),
+            registry.clone(),
+            main_sender.clone(),
+            event_sender.clone()
+        ),
+        pipewire::types::ObjectType::Port => handle_port(
+            global,
+            state.clone(),
+            registry.clone(),
+            main_sender.clone(),
+            event_sender.clone()
+        ),
+        pipewire::types::ObjectType::Link => handle_link(
+            global,
+            state.clone(),
+            registry.clone(),
+            main_sender.clone(),
+            event_sender.clone()
+        ),
+        _ => {}
+    }
+}
+
+fn handle_client(
+    global: &GlobalObject<&spa::utils::dict::DictRef>,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    if global.props.is_none() {
+        return;
+    }
+    let properties = global.props.unwrap();
+    let client =
+        match properties.get(APPLICATION_NAME_PROPERTY_KEY) {
+            Some(APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER) => {
+                ClientState::new(
+                    APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER.to_string()
+                )
+            }
+            Some(APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION) => {
+                ClientState::new(
+                    APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION.to_string()
+                )
+            }
+            _ => return,
+        };
+    let mut state = state.borrow_mut();
+    if let Err(value) = state.insert_client(global.id.into(), client) {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+}
+
+fn handle_metadata(
+    global: &GlobalObject<&spa::utils::dict::DictRef>,
+    state: Rc<RefCell<GlobalState>>,
+    registry: Rc<pipewire::registry::Registry>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+) 
+{
+    if global.props.is_none() {
+        return;
+    }
+    let properties = global.props.unwrap();
+    let metadata =
+        match properties.get(METADATA_NAME_PROPERTY_KEY) {
+            Some(METADATA_NAME_PROPERTY_VALUE_SETTINGS)
+            | Some(METADATA_NAME_PROPERTY_VALUE_DEFAULT) => {
+                let metadata = registry.bind(global).unwrap();
+                MetadataState::new(
+                    metadata,
+                    properties.get(METADATA_NAME_PROPERTY_KEY).unwrap().to_string(),
+                )
+            }
+            _ => return,
+        };
+    let mut state = state.borrow_mut();
+    if let Err(value) = state.insert_metadata(global.id.into(), metadata) {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    let metadata = state.get_metadata(&global.id.into()).unwrap();
+    add_metadata_listeners(
+        global.id.into(),
+        &metadata,
+        &event_sender
+    );
+}
+
+fn handle_node(
+    global: &GlobalObject<&spa::utils::dict::DictRef>,
+    state: Rc<RefCell<GlobalState>>,
+    registry: Rc<pipewire::registry::Registry>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+)
+{
+    if global.props.is_none() {
+        
+    }
+    let properties = global.props.unwrap();
+    let node = match properties.get(MEDIA_CLASS_PROPERTY_KEY) {
+        Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE)
+        | Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK) => {
+            let node: pipewire::node::Node = registry.bind(global).unwrap();
+            NodeState::new(node)
+        }
+        _ => return,
+    };
+    let mut state = state.borrow_mut();
+    if let Err(value) = state.insert_node(global.id.into(), node) {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    let node = state.get_node(&global.id.into()).unwrap();
+    add_node_listeners(
+        global.id.into(),
+        &node,
+        &event_sender
+    );
+}
+
+fn handle_port(
+    global: &GlobalObject<&spa::utils::dict::DictRef>,
+    state: Rc<RefCell<GlobalState>>,
+    registry: Rc<pipewire::registry::Registry>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+)
+{
+    if global.props.is_none() {
+
+    }
+    let properties = global.props.unwrap();
+    debug_dict_ref(properties);
+
+    let port: pipewire::port::Port = registry.bind(global).unwrap();
+
+    // let node = match properties.get(MEDIA_CLASS_PROPERTY_KEY) {
+    //     Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE)
+    //     | Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK) => {
+    //         let node: pipewire::node::Node = registry.bind(global).unwrap();
+    //         NodeState::new(node)
+    //     }
+    //     _ => return,
+    // };
+    // let mut state = state.borrow_mut();
+    // if let Err(value) = state.insert_node(global.id.into(), node) {
+    //     main_sender
+    //         .send(MessageResponse::Error(value))
+    //         .unwrap();
+    //     return;
+    // };
+    // let node = state.get_node(&global.id.into()).unwrap();
+    // add_node_listeners(
+    //     global.id.into(),
+    //     &node,
+    //     &event_sender
+    // );
+}
+
+fn handle_link(
+    global: &GlobalObject<&spa::utils::dict::DictRef>,
+    state: Rc<RefCell<GlobalState>>,
+    registry: Rc<pipewire::registry::Registry>,
+    main_sender: mpsc::Sender<MessageResponse>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+)
+{
+    if global.props.is_none() {
+
+    }
+    let properties = global.props.unwrap();
+    debug_dict_ref(properties);
+    
+    let link: pipewire::link::Link = registry.bind(global).unwrap();
+    // link.
+    
+    // let node = match properties.get(MEDIA_CLASS_PROPERTY_KEY) {
+    //     Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE)
+    //     | Some(MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK) => {
+    //         let node: pipewire::node::Node = registry.bind(global).unwrap();
+    //         NodeState::new(node)
+    //     }
+    //     _ => return,
+    // };
+    // let mut state = state.borrow_mut();
+    // if let Err(value) = state.insert_node(global.id.into(), node) {
+    //     main_sender
+    //         .send(MessageResponse::Error(value))
+    //         .unwrap();
+    //     return;
+    // };
+    // let node = state.get_node(&global.id.into()).unwrap();
+    // add_node_listeners(
+    //     global.id.into(),
+    //     &node,
+    //     &event_sender
+    // );
+}
+
+fn add_metadata_listeners(
+    id: GlobalId,
+    metadata: &MetadataState,
+    event_sender: &pipewire::channel::Sender<EventMessage>
+) {
+    if *metadata.state.borrow() != GlobalObjectState::Pending {
+        return;
+    }
+    let id = id.clone();
+    event_sender
+        .send(EventMessage::SetMetadataListeners {
+            id,
+        })
+        .unwrap()
+}
+
+fn add_node_listeners(
+    id: GlobalId,
+    node: &NodeState,
+    event_sender: &pipewire::channel::Sender<EventMessage>
+) {
+    if node.state() != GlobalObjectState::Pending {
+        return;
+    }
+    let id = id.clone();
+    event_sender
+        .send(EventMessage::SetNodePropertiesListener {
+            id,
+        })
+        .unwrap()
+}

--- a/pipewire-client/src/client/handlers/request.rs
+++ b/pipewire-client/src/client/handlers/request.rs
@@ -1,0 +1,560 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::mpsc;
+use pipewire::proxy::ProxyT;
+use crate::constants::*;
+use crate::{AudioStreamInfo, Direction, NodeInfo};
+use crate::error::Error;
+use crate::listeners::ListenerTriggerPolicy;
+use crate::messages::{MessageRequest, MessageResponse, StreamCallback};
+use crate::states::{GlobalId, GlobalObjectState, GlobalState, OrphanState, StreamState};
+use crate::utils::PipewireCoreSync;
+
+pub(super) fn request_handler(
+    core: Rc<pipewire::core::Core>,
+    core_sync: Rc<PipewireCoreSync>,
+    main_loop: pipewire::main_loop::MainLoop,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) -> impl Fn(MessageRequest) + 'static
+{
+    move |message_request: MessageRequest| match message_request {
+        MessageRequest::Quit => main_loop.quit(),
+        MessageRequest::Settings => {
+            handle_settings(
+                state.clone(),
+                main_sender.clone(),
+            )
+        }
+        MessageRequest::DefaultAudioNodes => {
+            handle_default_audio_nodes(
+                state.clone(), 
+                main_sender.clone()
+            )
+        },
+        MessageRequest::CreateNode {
+            name,
+            description,
+            nickname,
+            direction,
+            channels,
+        } => {
+            handle_create_node(
+                name,
+                description,
+                nickname,
+                direction,
+                channels,
+                core.clone(),
+                core_sync.clone(),
+                state.clone(),
+                main_sender.clone(),
+            )
+        }
+        MessageRequest::EnumerateNodes(direction) => {
+            handle_enumerate_node(
+                direction,
+                state.clone(),
+                main_sender.clone(),
+            )
+        },
+        MessageRequest::CreateStream {
+            node_id,
+            direction,
+            format,
+            callback
+        } => {
+            handle_create_stream(
+                node_id,
+                direction,
+                format,
+                callback,
+                core.clone(),
+                state.clone(),
+                main_sender.clone(),
+            )
+        }
+        MessageRequest::DeleteStream { name } => {
+            handle_delete_stream(
+                name,
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+        MessageRequest::ConnectStream { name } => {
+            handle_connect_stream(
+                name,
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+        MessageRequest::DisconnectStream { name } => {
+            handle_disconnect_stream(
+                name,
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+        // Internal requests
+        MessageRequest::CheckSessionManagerRegistered => {
+            handle_check_session_manager_registered(
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+        MessageRequest::NodeState(id) => {
+            handle_node_state(
+                id,
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+        MessageRequest::NodeStates => {
+            handle_node_states(
+                state.clone(),
+                main_sender.clone()
+            )
+        }
+    }
+}
+
+fn handle_settings(
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let state = state.borrow();
+    let settings = state.get_settings();
+    main_sender.send(MessageResponse::Settings(settings)).unwrap();
+}
+fn handle_default_audio_nodes(
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let state = state.borrow();
+    let default_audio_devices = state.get_default_audio_nodes();
+    main_sender.send(MessageResponse::DefaultAudioNodes(default_audio_devices)).unwrap();
+}
+fn handle_create_node(
+    name: String,
+    description: String,
+    nickname: String,
+    direction: Direction,
+    channels: u16,
+    core: Rc<pipewire::core::Core>,
+    core_sync: Rc<PipewireCoreSync>,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let default_audio_position = format!(
+        "[ {} ]",
+        (1..=channels + 1)
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
+    let properties = &pipewire::properties::properties! {
+        *pipewire::keys::FACTORY_NAME => "support.null-audio-sink",
+        *pipewire::keys::NODE_NAME => name.clone(),
+        *pipewire::keys::NODE_DESCRIPTION => description.clone(),
+        *pipewire::keys::NODE_NICK => nickname.clone(),
+        *pipewire::keys::MEDIA_CLASS => match direction {
+            Direction::Input => MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE,
+            Direction::Output => MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK,
+        },
+        *pipewire::keys::OBJECT_LINGER => "false",
+        *pipewire::keys::AUDIO_CHANNELS => channels.to_string(),
+        MONITOR_CHANNEL_VOLUMES_PROPERTY_KEY => "true",
+        MONITOR_PASSTHROUGH_PROPERTY_KEY => "true",
+        AUDIO_POSITION_PROPERTY_KEY => match channels {
+            1 => "[ MONO ]",
+            2 => "[ FL FR ]", // 2.0
+            3 => "[ FL FR LFE ]", // 2.1
+            4 => "[ FL FR RL RR ]", // 4.0
+            5 => "[ FL FR FC RL RR ]", // 5.0
+            6 => "[ FL FR FC RL RR LFE ]", // 5.1
+            7 => "[ FL FR FC RL RR SL SR ]", // 7.0
+            8 => "[ FL FR FC RL RR SL SR LFE ]", // 7.1
+            _ => default_audio_position.as_str(),
+        }
+    };
+    let node: pipewire::node::Node = match core
+        .create_object("adapter", properties)
+        .map_err(move |error| {
+            Error {
+                description: error.to_string(),
+            }
+        }) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let core_sync = core_sync.clone();
+    let listener_main_sender = main_sender.clone();
+    let listener_state = state.clone();
+    core_sync.register(
+        false,
+        PIPEWIRE_CORE_SYNC_CREATE_DEVICE_SEQ,
+        move || {
+            let state = listener_state.borrow();
+            let nodes = match state.get_nodes() {
+                Ok(value) => value,
+                Err(value) => {
+                    listener_main_sender
+                        .send(MessageResponse::Error(value))
+                        .unwrap();
+                    return;
+                }
+            };
+            let node = nodes.iter()
+                .find(move |(_, node)| {
+                    node.state() == GlobalObjectState::Pending
+                });
+            if let None = node {
+                listener_main_sender
+                    .send(MessageResponse::Error(Error {
+                        description: "Created node not found".to_string(),
+                    }))
+                    .unwrap();
+                return;
+            };
+            let node_id = node.unwrap().0;
+            listener_main_sender
+                .send(MessageResponse::CreateNode {
+                    id: (*node_id).clone(),
+                })
+                .unwrap();
+        }
+    );
+    let mut state = state.borrow_mut();
+    // We need to store created node object as orphan since it had not been
+    // registered by server at this point (does not have an id yet).
+    //
+    // When a proxy object is dropped its send a server request to remove it on server
+    // side, then the server ask clients to remove proxy object on their side.
+    //
+    // The server will send a global object (through registry global object event
+    // listener) later, represented by a new proxy object instance that we can store
+    // as a NodeState.
+    // OrphanState object define "removed" listener from Proxy to ensure our orphan
+    // proxy object is removed when proper NodeState object is retrieved from server
+    let orphan = OrphanState::new(node.upcast());
+    state.insert_orphan(orphan);
+}
+fn handle_enumerate_node(
+    direction: Direction,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let state = state.borrow();
+    let default_audio_nodes = state.get_default_audio_nodes();
+    let default_audio_node = match direction {
+        Direction::Input => default_audio_nodes.source.clone(),
+        Direction::Output => default_audio_nodes.sink.clone()
+    };
+    let filter_value = match direction {
+        Direction::Input => MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE,
+        Direction::Output => MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK,
+    };
+    let nodes = match state.get_nodes() {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let nodes: Vec<NodeInfo> = nodes
+        .iter()
+        .filter_map(|(id, node)| {
+            let properties = node.properties();
+            let format = node.format().unwrap();
+            if properties.iter().any(|(_, v)| v == filter_value) {
+                Some((id, properties, format))
+            } else {
+                None
+            }
+        })
+        .map(|(id, properties, format)| {
+            let name = properties.get(*pipewire::keys::NODE_NAME).unwrap().clone();
+            let description = properties
+                .get(*pipewire::keys::NODE_DESCRIPTION)
+                .unwrap()
+                .clone();
+            let nickname = match properties.contains_key(*pipewire::keys::NODE_NICK) {
+                true => properties.get(*pipewire::keys::NODE_NICK).unwrap().clone(),
+                false => name.clone(),
+            };
+            let is_default = name == default_audio_node;
+            NodeInfo {
+                id: (*id).clone().into(),
+                name,
+                description,
+                nickname,
+                direction: direction.clone(),
+                is_default,
+                format: format.clone()
+            }
+        })
+        .collect();
+    main_sender.send(MessageResponse::EnumerateNodes(nodes)).unwrap();
+}
+fn handle_create_stream(
+    node_id: GlobalId,
+    direction: Direction,
+    format: AudioStreamInfo,
+    callback: StreamCallback,
+    core: Rc<pipewire::core::Core>,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let node_name = match state.get_node(&node_id) {
+        Ok(value) => value.name(),
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let stream_name = match direction {
+        Direction::Input => {
+            format!("{}.stream_input", node_name)
+        }
+        Direction::Output => {
+            format!("{}.stream_output", node_name)
+        }
+    };
+    let properties = pipewire::properties::properties! {
+                    *pipewire::keys::MEDIA_TYPE => MEDIA_TYPE_PROPERTY_VALUE_AUDIO,
+                    *pipewire::keys::MEDIA_CLASS => match direction {
+                        Direction::Input => MEDIA_CLASS_PROPERTY_VALUE_STREAM_INPUT_AUDIO,
+                        Direction::Output => MEDIA_CLASS_PROPERTY_VALUE_STREAM_OUTPUT_AUDIO,
+                    },
+                };
+    let stream = match pipewire::stream::Stream::new(
+        &core,
+        stream_name.clone().as_str(),
+        properties,
+    )
+        .map_err(move |error| {
+            Error {
+                description: error.to_string(),
+            }
+        }) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let mut stream = StreamState::new(
+        stream_name.clone(),
+        format.into(),
+        direction.into(),
+        stream
+    );
+    stream.add_process_listener(
+        ListenerTriggerPolicy::Keep,
+        callback
+    );
+    if let Err(value) = state.insert_stream(stream_name.clone(), stream) {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    main_sender
+        .send(MessageResponse::CreateStream {
+            name: stream_name.clone(),
+        })
+        .unwrap();
+}
+fn handle_delete_stream(
+    name: String,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let stream = match state.get_stream_mut(&name) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    if let Err(value) = stream.disconnect() {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    if let Err(value) = state.remove_stream(&name) {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    main_sender.send(MessageResponse::DeleteStream).unwrap();
+}
+fn handle_connect_stream(
+    name: String,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+)
+{
+    let mut state = state.borrow_mut();
+    let stream = match state.get_stream_mut(&name) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    if let Err(value) = stream.connect() {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    main_sender.send(MessageResponse::ConnectStream).unwrap();
+}
+fn handle_disconnect_stream(
+    name: String,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let mut state = state.borrow_mut();
+    let stream = match state.get_stream_mut(&name) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    if let Err(value) = stream.disconnect() {
+        main_sender
+            .send(MessageResponse::Error(value))
+            .unwrap();
+        return;
+    };
+    main_sender.send(MessageResponse::DisconnectStream).unwrap();
+}
+fn handle_check_session_manager_registered(
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    // Checking if session manager is registered because we need "default" metadata
+    // object to determine default audio nodes (sink and source).
+    fn generate_error_message(session_managers: &Vec<&str>) -> String {
+        let session_managers = session_managers.iter()
+            .map(move |session_manager| {
+                let session_manager = match *session_manager {
+                    APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER => "WirePlumber",
+                    APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION => "PipeWire Media Session",
+                    _ => panic!("Cannot determine session manager name")
+                };
+                format!("  - {}", session_manager)
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+        let message = format!(
+            "No session manager registered. Install and run one of the following:\n{}",
+            session_managers
+        );
+        message
+    }
+    let session_managers = vec![
+        APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER,
+        APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION
+    ];
+    let state = state.borrow_mut();
+    let clients = state.get_clients().map_err(|_| {
+        Error {
+            description: generate_error_message(&session_managers),
+        }
+    });
+    let clients = match clients {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let session_manager_registered = clients.iter()
+        .any(|(_, client)| {
+            session_managers.contains(&client.name.as_str())
+        });
+    if session_manager_registered {
+        return;
+    }
+    let description = generate_error_message(&session_managers);
+    main_sender
+        .send(MessageResponse::Error(Error {
+            description,
+        }))
+        .unwrap();
+}
+fn handle_node_state(
+    id: GlobalId,
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) {
+    let state = state.borrow();
+    let node = match state.get_node(&id) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let state = node.state();
+    main_sender.send(MessageResponse::NodeState(state)).unwrap();
+}
+fn handle_node_states(
+    state: Rc<RefCell<GlobalState>>,
+    main_sender: mpsc::Sender<MessageResponse>,
+) 
+{
+    let state = state.borrow_mut();
+    let nodes = match state.get_nodes() {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(value))
+                .unwrap();
+            return;
+        }
+    };
+    let states = nodes.iter()
+        .map(move |(_, node)| {
+            node.state()
+        })
+        .collect::<Vec<_>>();
+    main_sender.send(MessageResponse::NodeStates(states)).unwrap();
+}

--- a/pipewire-client/src/client/handlers/thread.rs
+++ b/pipewire-client/src/client/handlers/thread.rs
@@ -1,0 +1,134 @@
+use crate::client::connection_string::PipewireClientInfo;
+use crate::client::handlers::event::event_handler;
+use crate::client::handlers::registry::registry_global_handler;
+use crate::client::handlers::request::request_handler;
+use crate::constants::PIPEWIRE_CORE_SYNC_INITIALIZATION_SEQ;
+use crate::error::Error;
+use crate::messages::{EventMessage, MessageRequest, MessageResponse};
+use crate::states::GlobalState;
+use crate::utils::PipewireCoreSync;
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::sync::mpsc;
+
+pub fn pw_thread(
+    client_info: PipewireClientInfo,
+    main_sender: mpsc::Sender<MessageResponse>,
+    pw_receiver: pipewire::channel::Receiver<MessageRequest>,
+    event_sender: pipewire::channel::Sender<EventMessage>,
+    event_receiver: pipewire::channel::Receiver<EventMessage>,
+) {
+    let connection_properties = Some(pipewire::properties::properties! {
+        *pipewire::keys::REMOTE_NAME => client_info.connection_string,
+        *pipewire::keys::APP_NAME => client_info.name,
+    });
+
+    let main_loop = match pipewire::main_loop::MainLoop::new(None) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(Error {
+                    description: format!("Failed to create PipeWire main loop: {}", value),
+                }))
+                .unwrap();
+            return;
+        }
+    };
+
+    let context = match pipewire::context::Context::new(&main_loop) {
+        Ok(value) => Rc::new(value),
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(Error {
+                    description: format!("Failed to create PipeWire context: {}", value),
+                }))
+                .unwrap();
+            return;
+        }
+    };
+
+    let core = match context.connect(connection_properties) {
+        Ok(value) => value,
+        Err(value) => {
+            main_sender
+                .send(MessageResponse::Error(Error {
+                    description: format!("Failed to connect PipeWire server: {}", value),
+                }))
+                .unwrap();
+            return;
+        }
+    };
+
+    let listener_main_sender = main_sender.clone();
+    let _core_listener = core
+        .add_listener_local()
+        .error(move |_, _, _, message| {
+            listener_main_sender
+                .send(MessageResponse::Error(Error {
+                    description: format!("Server error: {}", message),
+                }))
+                .unwrap();
+        })
+        .register();
+
+    let registry = match core.get_registry() {
+        Ok(value) => Rc::new(value),
+        Err(value) => {
+            unsafe {
+                pipewire::deinit();
+            }
+            panic!("Failed to get Pipewire registry: {}", value);
+        }
+    };
+
+    let core_sync = Rc::new(PipewireCoreSync::new(Rc::new(RefCell::new(core.clone()))));
+    let core = Rc::new(core);
+    let state = Rc::new(RefCell::new(GlobalState::default()));
+
+    let listener_main_sender = main_sender.clone();
+    core_sync.register(
+        false,
+        PIPEWIRE_CORE_SYNC_INITIALIZATION_SEQ,
+        move || {
+            listener_main_sender
+                .send(MessageResponse::Initialized)
+                .unwrap();
+        }
+    );
+
+    let _attached_event_receiver = event_receiver.attach(
+        main_loop.loop_(),
+        event_handler(
+            state.clone(),
+            main_sender.clone(),
+            event_sender.clone()
+        )
+    );
+
+    let _attached_pw_receiver = pw_receiver.attach(
+        main_loop.loop_(),
+        request_handler(
+            core.clone(),
+            core_sync.clone(),
+            main_loop.clone(),
+            state.clone(),
+            main_sender.clone()
+        )
+    );
+
+    let _registry_listener = registry
+        .add_listener_local()
+        .global(registry_global_handler(
+            state.clone(),
+            registry.clone(),
+            main_sender.clone(),
+            event_sender.clone(),
+        ))
+        .global_remove(move |global_id| {
+            let mut state = state.borrow_mut();
+            state.remove(&global_id.into())
+        })
+        .register();
+
+    main_loop.run();
+}

--- a/pipewire-client/src/client/implementation.rs
+++ b/pipewire-client/src/client/implementation.rs
@@ -1,0 +1,430 @@
+extern crate pipewire;
+
+use crate::client::connection_string::{PipewireClientConnectionString, PipewireClientInfo};
+use crate::client::handlers::thread;
+use crate::error::Error;
+use crate::info::{AudioStreamInfo, NodeInfo};
+use crate::messages::{EventMessage, MessageRequest, MessageResponse, StreamCallback};
+use crate::states::{DefaultAudioNodesState, GlobalId, GlobalObjectState, SettingsState};
+use crate::utils::{Direction, Backoff};
+use std::fmt::{Debug, Formatter};
+use std::string::ToString;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::mpsc;
+use std::thread;
+use std::thread::JoinHandle;
+
+pub(super) static CLIENT_NAME_PREFIX: &str = "cpal-client";
+pub(super) static CLIENT_INDEX: AtomicU32 = AtomicU32::new(0);
+
+pub struct PipewireClient {
+    pub(crate) name: String,
+    connection_string: String,
+    sender: pipewire::channel::Sender<MessageRequest>,
+    receiver: mpsc::Receiver<MessageResponse>,
+    thread_handle: Option<JoinHandle<()>>,
+}
+
+impl PipewireClient {
+    pub fn new() -> Result<Self, Error> {
+        let name = format!("{}-{}", CLIENT_NAME_PREFIX, CLIENT_INDEX.load(Ordering::SeqCst));
+        CLIENT_INDEX.fetch_add(1, Ordering::SeqCst);
+
+        let connection_string = PipewireClientConnectionString::from_env();
+
+        let client_info = PipewireClientInfo {
+            name: name.clone(),
+            connection_string: connection_string.clone(),
+        };
+
+        let (main_sender, main_receiver) = mpsc::channel();
+        let (pw_sender, pw_receiver) = pipewire::channel::channel();
+        let (event_sender, event_receiver) = pipewire::channel::channel::<EventMessage>();
+
+        let pw_thread = thread::spawn(move || thread(
+            client_info,
+            main_sender,
+            pw_receiver,
+            event_sender,
+            event_receiver
+        ));
+
+        let client = Self {
+            name,
+            connection_string,
+            sender: pw_sender,
+            receiver: main_receiver,
+            thread_handle: Some(pw_thread),
+        };
+
+        match client.wait_initialization() {
+            Ok(_) => {}
+            Err(value) => return Err(value)
+        };
+        match client.wait_post_initialization() {
+            Ok(_) => {}
+            Err(value) => return Err(value),
+        };
+        Ok(client)
+    }
+
+    fn wait_initialization(&self) -> Result<(), Error> {
+        let response = self.receiver.recv();
+        let response = match response {
+            Ok(value) => value,
+            Err(value) => {
+                return Err(Error {
+                    description: format!(
+                        "Failed during pipewire initialization: {:?}",
+                        value
+                    ),
+                })
+            }
+        };
+        match response {
+            MessageResponse::Initialized => Ok(()),
+            _ => Err(Error {
+                description: format!("Received unexpected response: {:?}", response),
+            }),
+        }
+    }
+
+    fn wait_post_initialization(&self) -> Result<(), Error> {
+        let mut settings_initialized = false;
+        let mut default_audio_devices_initialized = false;
+        let mut nodes_initialized = false;
+        #[cfg(debug_assertions)]
+        let timeout_duration = std::time::Duration::from_secs(u64::MAX);
+        #[cfg(not(debug_assertions))]
+        let timeout_duration = std::time::Duration::from_millis(500);
+        self.check_session_manager_registered()?;
+        self.node_states()?;
+        let operation = move || {
+            let response = self.receiver.recv_timeout(timeout_duration);
+            match response {
+                Ok(value) => match value {
+                    MessageResponse::SettingsState(state) => {
+                        match state {
+                            GlobalObjectState::Initialized => {
+                                settings_initialized = true;
+                            }
+                            _ => return Err(Error {
+                                description: "Settings not yet initialized".to_string(),
+                            })
+                        };
+                    },
+                    MessageResponse::DefaultAudioNodesState(state) => {
+                        match state {
+                            GlobalObjectState::Initialized => {
+                                default_audio_devices_initialized = true;
+                            }
+                            _ => return Err(Error {
+                                description: "Default audio nodes not yet initialized".to_string(),
+                            })
+                        }
+                    },
+                    MessageResponse::NodeStates(states) => {
+                        let condition = states.iter()
+                            .all(|state| *state == GlobalObjectState::Initialized);
+                        match condition {
+                            true => {
+                                nodes_initialized = true;
+                            },
+                            false => {
+                                self.node_states()?;
+                                return Err(Error {
+                                    description: "All nodes should be initialized at this point".to_string(),
+                                })
+                            }
+                        };
+                    }
+                    MessageResponse::Error(value) => return Err(value),
+                    _ => return Err(Error {
+                        description: format!("Received unexpected response: {:?}", value),
+                    }),
+                }
+                Err(value) => return Err(Error {
+                    description: format!("Failed during post initialization: {:?}", value),
+                })
+            };
+            if settings_initialized == false || default_audio_devices_initialized == false || nodes_initialized == false {
+                return Err(Error {
+                    description: "Post initialization not yet finalized".to_string(),
+                })
+                
+            }
+            return Ok(());
+        };
+        let mut backoff = Backoff::new(
+            30,
+            std::time::Duration::from_millis(10),
+            std::time::Duration::from_millis(100),
+        );
+        backoff.retry(operation)
+    }
+
+    fn send_request(&self, request: &MessageRequest) -> Result<MessageResponse, Error> {
+        let response = self.sender.send(request.clone());
+        let response = match response {
+            Ok(_) => self.receiver.recv(),
+            Err(_) => return Err(Error {
+                description: format!("Failed to send request: {:?}", request),
+            }),
+        };
+        match response {
+            Ok(value) => {
+                match value {
+                    MessageResponse::Error(value) => Err(value),
+                    _ => Ok(value),
+                }
+            },
+            Err(value) => Err(Error {
+                description: format!(
+                    "Failed to execute request ({:?}): {:?}",
+                    request, value
+                ),
+            }),
+        }
+    }
+
+    fn send_request_without_response(&self, request: &MessageRequest) -> Result<(), Error> {
+        let response = self.sender.send(request.clone());
+        match response {
+            Ok(_) => Ok(()),
+            Err(value) => Err(Error {
+                description: format!(
+                    "Failed to execute request ({:?}): {:?}",
+                    request, value
+                ),
+            }),
+        }
+    }
+
+    pub fn quit(&self) {
+        let request = MessageRequest::Quit;
+        self.send_request_without_response(&request).unwrap();
+    }
+
+    pub fn settings(&self) -> Result<SettingsState, Error> {
+        let request = MessageRequest::Settings;
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::Settings(value)) => Ok(value),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn default_audio_nodes(&self) -> Result<DefaultAudioNodesState, Error> {
+        let request = MessageRequest::DefaultAudioNodes;
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::DefaultAudioNodes(value)) => Ok(value),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn create_node(
+        &self,
+        name: String,
+        description: String,
+        nickname: String,
+        direction: Direction,
+        channels: u16,
+    ) -> Result<(), Error> {
+        let request = MessageRequest::CreateNode {
+            name,
+            description,
+            nickname,
+            direction,
+            channels,
+        };
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::CreateNode {
+                   id
+               }) => {
+                #[cfg(debug_assertions)]
+                let timeout_duration = std::time::Duration::from_secs(u64::MAX);
+                #[cfg(not(debug_assertions))]
+                let timeout_duration = std::time::Duration::from_millis(500);
+                self.node_state(&id)?;
+                let operation = move || {
+                    let response = self.receiver.recv_timeout(timeout_duration);
+                    return match response {
+                        Ok(value) => match value {
+                            MessageResponse::NodeState(state) => {
+                                match state == GlobalObjectState::Initialized {
+                                    true => {
+                                        Ok(())
+                                    },
+                                    false => {
+                                        self.node_state(&id)?;
+                                        Err(Error {
+                                            description: "Created node should be initialized at this point".to_string(),
+                                        })
+                                    }
+                                }
+                            }
+                            _ => Err(Error {
+                                description: format!("Received unexpected response: {:?}", value),
+                            }),
+                        },
+                        Err(value) => Err(Error {
+                            description: format!("Failed during post initialization: {:?}", value),
+                        })
+                    };
+                };
+                let mut backoff = Backoff::new(
+                    10,
+                    std::time::Duration::from_millis(10),
+                    std::time::Duration::from_millis(100),
+                );
+                backoff.retry(operation)
+            },
+            Ok(MessageResponse::Error(value)) => Err(value),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn enumerate_nodes(
+        &self,
+        direction: Direction,
+    ) -> Result<Vec<NodeInfo>, Error> {
+        let request = MessageRequest::EnumerateNodes(direction);
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::EnumerateNodes(value)) => Ok(value),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn create_stream<F>(
+        &self,
+        node_id: u32,
+        direction: Direction,
+        format: AudioStreamInfo,
+        callback: F,
+    ) -> Result<String, Error>
+    where
+        F: FnMut(pipewire::buffer::Buffer) + Send + 'static
+    {
+        let request = MessageRequest::CreateStream {
+            node_id: GlobalId::from(node_id),
+            direction,
+            format,
+            callback: StreamCallback::from(callback),
+        };
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::CreateStream{name}) => Ok(name),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn delete_stream(
+        &self,
+        name: String
+    ) -> Result<(), Error> {
+        let request = MessageRequest::DeleteStream {
+            name,
+        };
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::DeleteStream) => Ok(()),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value)
+            }),
+        }
+    }
+
+    pub fn connect_stream(
+        &self,
+        name: String
+    ) -> Result<(), Error> {
+        let request = MessageRequest::ConnectStream {
+            name,
+        };
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::ConnectStream) => Ok(()),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    pub fn disconnect_stream(
+        &self,
+        name: String
+    ) -> Result<(), Error> {
+        let request = MessageRequest::DisconnectStream {
+            name,
+        };
+        let response = self.send_request(&request);
+        match response {
+            Ok(MessageResponse::DisconnectStream) => Ok(()),
+            Err(value) => Err(value),
+            Ok(value) => Err(Error {
+                description: format!("Received unexpected response: {:?}", value),
+            }),
+        }
+    }
+
+    // Internal requests
+    pub(super) fn check_session_manager_registered(&self) -> Result<(), Error> {
+        let request = MessageRequest::CheckSessionManagerRegistered;
+        self.send_request_without_response(&request)
+    }
+
+    pub(super) fn node_state(
+        &self,
+        id: &GlobalId,
+    ) -> Result<(), Error> {
+        let request = MessageRequest::NodeState(id.clone());
+        self.send_request_without_response(&request)
+    }
+
+    pub(super) fn node_states(
+        &self,
+    ) -> Result<(), Error> {
+        let request = MessageRequest::NodeStates;
+        self.send_request_without_response(&request)
+    }
+}
+
+impl Debug for PipewireClient {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "PipewireClient: {}", self.connection_string)
+    }
+}
+
+impl Drop for PipewireClient {
+    fn drop(&mut self) {
+        if self.sender.send(MessageRequest::Quit).is_ok() {
+            if let Some(thread_handle) = self.thread_handle.take() {
+                if let Err(err) = thread_handle.join() {
+                    panic!("Failed to join PipeWire thread: {:?}", err);
+                }
+            }
+        } else {
+            panic!("Failed to send Quit message to PipeWire thread.");
+        }
+    }
+}

--- a/pipewire-client/src/client/implementation_test.rs
+++ b/pipewire-client/src/client/implementation_test.rs
@@ -1,0 +1,162 @@
+use std::sync::atomic::Ordering;
+use rstest::rstest;
+use serial_test::serial;
+use crate::client::implementation::CLIENT_INDEX;
+use crate::{Direction, PipewireClient};
+
+#[rstest]
+#[serial]
+pub fn all() {
+    for _ in 0..100 {
+        name();
+        quit();
+        settings();
+        default_audio_nodes();
+        create_node();
+        create_node_then_enumerate_nodes();
+        create_stream();
+        enumerate_nodes();
+    }
+}
+
+#[rstest]
+#[serial]
+pub fn name() {
+    let client_1 = PipewireClient::new().unwrap();
+    assert_eq!(format!("cpal-client-{}", CLIENT_INDEX.load(Ordering::SeqCst) - 1), client_1.name);
+    let client_2 = PipewireClient::new().unwrap();
+    assert_eq!(format!("cpal-client-{}", CLIENT_INDEX.load(Ordering::SeqCst) - 1), client_2.name);
+}
+
+#[rstest]
+#[serial]
+fn quit() {
+    let client = PipewireClient::new().unwrap();
+    client.quit();
+}
+
+#[rstest]
+#[serial]
+fn settings() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.settings();
+    assert!(
+        response.is_ok(),
+        "Should send settings message without errors"
+    );
+    let settings = response.unwrap();
+    assert_eq!(true, settings.sample_rate > u32::default());
+    assert_eq!(true, settings.default_buffer_size > u32::default());
+    assert_eq!(true, settings.min_buffer_size > u32::default());
+    assert_eq!(true, settings.max_buffer_size > u32::default());
+    assert_eq!(true, settings.allowed_sample_rates[0] > u32::default());
+}
+
+#[rstest]
+#[serial]
+fn default_audio_nodes() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.default_audio_nodes();
+    assert!(
+        response.is_ok(),
+        "Should send default audio nodes message without errors"
+    );
+    let default_audio_nodes = response.unwrap();
+    assert_eq!(false, default_audio_nodes.sink.is_empty());
+    assert_eq!(false, default_audio_nodes.source.is_empty());
+}
+
+#[rstest]
+#[serial]
+fn create_node() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.create_node(
+        "test".to_string(),
+        "test".to_string(),
+        "test".to_string(),
+        Direction::Output,
+        2
+    );
+    assert!(
+        response.is_ok(),
+        "Should send create node message without errors"
+    );
+}
+
+#[rstest]
+#[serial]
+fn create_node_then_enumerate_nodes() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.create_node(
+        "test".to_string(),
+        "test".to_string(),
+        "test".to_string(),
+        Direction::Output,
+        2
+    );
+    assert!(
+        response.is_ok(),
+        "Should send create node message without errors"
+    );
+    let response = client.enumerate_nodes(Direction::Output);
+    assert!(
+        response.is_ok(),
+        "Should send enumerate devices message without errors"
+    );
+    let nodes = response.unwrap();
+    assert_eq!(false, nodes.is_empty());
+    let default_node = nodes.iter()
+        .filter(|node| node.is_default)
+        .last();
+    assert_eq!(true, default_node.is_some());
+}
+
+#[rstest]
+#[serial]
+fn create_stream() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.enumerate_nodes(Direction::Output).unwrap();
+    let default_node = response.iter()
+        .filter(|node| node.is_default)
+        .last()
+        .unwrap();
+    let response = client.create_stream(
+        default_node.id,
+        Direction::Output,
+        default_node.format.clone().into(),
+        move |mut buffer| {
+            let data = buffer.datas_mut();
+            let data = &mut data[0];
+            let data = data.data().unwrap();
+            assert_eq!(true, data.len() > 0);
+        }
+    );
+    assert!(
+        response.is_ok(),
+        "Should send create stream message without errors"
+    );
+    let stream_name = response.ok().unwrap();
+    let response = client.connect_stream(stream_name);
+    std::thread::sleep(std::time::Duration::from_millis(1 * 1000));
+    assert!(
+        response.is_ok(),
+        "Should send connect stream message without errors"
+    );
+}
+
+#[rstest]
+#[serial]
+fn enumerate_nodes() {
+    let client = PipewireClient::new().unwrap();
+    let response = client.enumerate_nodes(Direction::Output);
+    assert!(
+        response.is_ok(),
+        "Should send enumerate devices message without errors"
+    );
+    let nodes = response.unwrap();
+    assert_eq!(false, nodes.is_empty());
+    let default_node = nodes.iter()
+        .filter(|node| node.is_default)
+        .last();
+    assert_eq!(true, default_node.is_some());
+}

--- a/pipewire-client/src/client/mod.rs
+++ b/pipewire-client/src/client/mod.rs
@@ -1,0 +1,8 @@
+mod implementation;
+pub use implementation::PipewireClient;
+mod connection_string;
+mod handlers;
+
+#[cfg(test)]
+#[path = "implementation_test.rs"]
+mod implementation_test;

--- a/pipewire-client/src/constants.rs
+++ b/pipewire-client/src/constants.rs
@@ -1,0 +1,32 @@
+pub(super) const PIPEWIRE_RUNTIME_DIR_ENVIRONMENT_KEY: &str = "PIPEWIRE_RUNTIME_DIR";
+pub(super) const PIPEWIRE_REMOTE_ENVIRONMENT_KEY: &str = "PIPEWIRE_REMOTE";
+pub(super) const XDG_RUNTIME_DIR_ENVIRONMENT_KEY: &str = "XDG_RUNTIME_DIR";
+pub(super) const PIPEWIRE_REMOTE_ENVIRONMENT_DEFAULT: &str = "pipewire-0";
+
+pub(super) const PIPEWIRE_CORE_SYNC_INITIALIZATION_SEQ :u32 = 0;
+pub(super) const PIPEWIRE_CORE_SYNC_CREATE_DEVICE_SEQ :u32 = 1;
+
+pub(super) const MEDIA_TYPE_PROPERTY_VALUE_AUDIO: &str = "Audio";
+pub(super) const MEDIA_CLASS_PROPERTY_KEY: &str = "media.class";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SOURCE: &str = "Audio/Source";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_AUDIO_SINK: &str = "Audio/Sink";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_AUDIO_DUPLEX: &str = "Audio/Duplex";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_AUDIO_DEVICE: &str = "Audio/Device";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_STREAM_OUTPUT_AUDIO: &str = "Stream/Output/Audio";
+pub(super) const MEDIA_CLASS_PROPERTY_VALUE_STREAM_INPUT_AUDIO: &str = "Stream/Input/Audio";
+pub(super) const METADATA_NAME_PROPERTY_KEY: &str = "metadata.name";
+pub(super) const METADATA_NAME_PROPERTY_VALUE_SETTINGS: &str = "settings";
+pub(super) const METADATA_NAME_PROPERTY_VALUE_DEFAULT: &str = "default";
+pub(super) const CLOCK_RATE_PROPERTY_KEY: &str = "clock.rate";
+pub(super) const CLOCK_QUANTUM_PROPERTY_KEY: &str = "clock.quantum";
+pub(super) const CLOCK_QUANTUM_MIN_PROPERTY_KEY: &str = "clock.min-quantum";
+pub(super) const CLOCK_QUANTUM_MAX_PROPERTY_KEY: &str = "clock.max-quantum";
+pub(super) const CLOCK_ALLOWED_RATES_PROPERTY_KEY: &str = "clock.allowed-rates";
+pub(super) const MONITOR_CHANNEL_VOLUMES_PROPERTY_KEY: &str = "monitor.channel-volumes";
+pub(super) const MONITOR_PASSTHROUGH_PROPERTY_KEY: &str = "monitor.passthrough";
+pub(super) const DEFAULT_AUDIO_SINK_PROPERTY_KEY: &str = "default.audio.sink";
+pub(super) const DEFAULT_AUDIO_SOURCE_PROPERTY_KEY: &str = "default.audio.source";
+pub(super) const AUDIO_POSITION_PROPERTY_KEY: &str = "audio.position";
+pub(super) const APPLICATION_NAME_PROPERTY_KEY: &str = "application.name";
+pub(super) const APPLICATION_NAME_PROPERTY_VALUE_WIRE_PLUMBER: &str = "WirePlumber";
+pub(super) const APPLICATION_NAME_PROPERTY_VALUE_PIPEWIRE_MEDIA_SESSION: &str = "pipewire-media-session";

--- a/pipewire-client/src/error.rs
+++ b/pipewire-client/src/error.rs
@@ -1,0 +1,15 @@
+use std::error::Error as StdError;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Clone)]
+pub struct Error {
+    pub description: String,
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.description)
+    }
+}
+
+impl StdError for Error {}

--- a/pipewire-client/src/info.rs
+++ b/pipewire-client/src/info.rs
@@ -1,0 +1,53 @@
+use pipewire_spa_utils::audio::{AudioChannelPosition};
+use pipewire_spa_utils::audio::AudioSampleFormat;
+use pipewire_spa_utils::audio::raw::AudioInfoRaw;
+use pipewire_spa_utils::format::{MediaSubtype, MediaType};
+use crate::utils::Direction;
+
+#[derive(Debug, Clone)]
+pub struct NodeInfo {
+    pub id: u32,
+    pub name: String,
+    pub description: String,
+    pub nickname: String,
+    pub direction: Direction,
+    pub is_default: bool,
+    pub format: AudioInfoRaw
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioStreamInfo {
+    pub media_type: MediaType,
+    pub media_subtype: MediaSubtype,
+    pub sample_format: AudioSampleFormat,
+    pub sample_rate: u32,
+    pub channels: u32,
+    pub position: AudioChannelPosition
+}
+
+impl From<AudioInfoRaw> for AudioStreamInfo {
+    fn from(value: AudioInfoRaw) -> Self {
+        Self {
+            media_type: MediaType::Audio,
+            media_subtype: MediaSubtype::Raw,
+            sample_format: value.sample_format.default,
+            sample_rate: value.sample_rate.value,
+            channels: *value.channels,
+            position: AudioChannelPosition::default(),
+        }
+    }
+}
+
+impl From<AudioStreamInfo> for pipewire::spa::param::audio::AudioInfoRaw {
+    fn from(value: AudioStreamInfo) -> Self {
+        let format: pipewire::spa::sys::spa_audio_format = value.sample_format as u32;
+        let format = pipewire::spa::param::audio::AudioFormat::from_raw(format);
+        let position: [u32; 64] = value.position.to_array();
+        let mut info = pipewire::spa::param::audio::AudioInfoRaw::default();
+        info.set_format(format);
+        info.set_rate(value.sample_rate);
+        info.set_channels(value.channels);
+        info.set_position(position);
+        info
+    }
+}

--- a/pipewire-client/src/lib.rs
+++ b/pipewire-client/src/lib.rs
@@ -1,0 +1,19 @@
+mod client;
+pub use client::PipewireClient;
+
+mod constants;
+mod listeners;
+mod messages;
+mod states;
+
+mod utils;
+pub use utils::Direction;
+
+mod error;
+
+mod info;
+pub use info::NodeInfo;
+pub use info::AudioStreamInfo;
+
+pub use pipewire as pipewire;
+pub use pipewire_spa_utils as spa_utils;

--- a/pipewire-client/src/listeners.rs
+++ b/pipewire-client/src/listeners.rs
@@ -1,0 +1,49 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum ListenerTriggerPolicy {
+    Keep,
+    Remove
+}
+
+pub(super) struct Listener<T> {
+    inner: T,
+    trigger_policy: ListenerTriggerPolicy,
+}
+
+impl <T> Listener<T> {
+    pub fn new(inner: T, policy: ListenerTriggerPolicy) -> Self
+    {
+        Self {
+            inner,
+            trigger_policy: policy,
+        }
+    }
+}
+
+pub(super) struct Listeners<L> {
+    listeners: Rc<RefCell<HashMap<String, Listener<L>>>>,
+}
+
+impl<L> Listeners<L> {
+    pub fn new() -> Self {
+        Self {
+            listeners: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    pub fn add(&mut self, name: String, listener: Listener<L>) {
+        let mut listeners = self.listeners.borrow_mut();
+        listeners.insert(name, listener);
+    }
+
+    pub fn triggered(&mut self, name: &String) {
+        let mut listeners = self.listeners.borrow_mut();
+        let listener = listeners.get_mut(name).unwrap();
+        if listener.trigger_policy == ListenerTriggerPolicy::Remove {
+            listeners.remove(name);
+        }
+    }
+}

--- a/pipewire-client/src/messages.rs
+++ b/pipewire-client/src/messages.rs
@@ -1,0 +1,118 @@
+use pipewire_spa_utils::audio::raw::AudioInfoRaw;
+use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
+use std::sync::{Arc, Mutex};
+use crate::error::Error;
+use crate::info::{AudioStreamInfo, NodeInfo};
+use crate::states::{DefaultAudioNodesState, GlobalId, GlobalObjectState, SettingsState};
+use crate::utils::Direction;
+
+pub(super) struct StreamCallback {
+    callback: Arc<Mutex<Box<dyn FnMut(pipewire::buffer::Buffer) + Send + 'static>>>
+}
+
+impl <F: FnMut(pipewire::buffer::Buffer) + Send + 'static> From<F> for StreamCallback {
+    fn from(value: F) -> Self {
+        Self { callback: Arc::new(Mutex::new(Box::new(value))) }
+    }
+}
+
+impl StreamCallback {
+    pub fn call(&mut self, buffer: pipewire::buffer::Buffer) {
+        let mut callback = self.callback.lock().unwrap();
+        callback(buffer);
+    }
+}
+
+impl Debug for StreamCallback {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamCallback").finish()
+    }
+}
+
+impl Clone for StreamCallback {
+    fn clone(&self) -> Self {
+        Self { callback: self.callback.clone() }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum MessageRequest {
+    Quit,
+    Settings,
+    DefaultAudioNodes,
+    CreateNode {
+        name: String,
+        description: String,
+        nickname: String,
+        direction: Direction,
+        channels: u16,
+    },
+    EnumerateNodes(Direction),
+    CreateStream {
+        node_id: GlobalId,
+        direction: Direction,
+        format: AudioStreamInfo,
+        callback: StreamCallback,
+    },
+    DeleteStream {
+        name: String
+    },
+    ConnectStream {
+        name: String
+    },
+    DisconnectStream {
+        name: String
+    },
+    // Internal requests
+    CheckSessionManagerRegistered,
+    NodeState(GlobalId),
+    NodeStates,
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum MessageResponse {
+    Error(Error),
+    Initialized,
+    Settings(SettingsState),
+    DefaultAudioNodes(DefaultAudioNodesState),
+    CreateNode {
+        id: GlobalId
+    },
+    EnumerateNodes(Vec<NodeInfo>),
+    CreateStream {
+        name: String,
+    },
+    DeleteStream,
+    ConnectStream,
+    DisconnectStream,
+    // Internals responses
+    SettingsState(GlobalObjectState),
+    DefaultAudioNodesState(GlobalObjectState),
+    NodeState(GlobalObjectState),
+    NodeStates(Vec<GlobalObjectState>)
+}
+
+#[derive(Debug, Clone)]
+pub(super) enum EventMessage {
+    SetMetadataListeners {
+        id: GlobalId
+    },
+    RemoveNode {
+        id: GlobalId
+    },
+    SetNodePropertiesListener {
+        id: GlobalId
+    },
+    SetNodeFormatListener{
+        id: GlobalId
+    },
+    SetNodeProperties {
+        id: GlobalId,
+        properties: HashMap<String, String>,
+    },
+    SetNodeFormat {
+        id: GlobalId,
+        format: AudioInfoRaw,
+    }
+}

--- a/pipewire-client/src/states.rs
+++ b/pipewire-client/src/states.rs
@@ -1,0 +1,777 @@
+use super::constants::*;
+use std::cell::{Cell, RefCell};
+use std::collections::HashMap;
+use std::fmt::{Display, Formatter};
+use std::io::Cursor;
+use std::rc::Rc;
+use std::str::FromStr;
+use pipewire::spa::utils::dict::ParsableValue;
+use pipewire_spa_utils::audio::AudioChannel;
+use pipewire_spa_utils::audio::raw::AudioInfoRaw;
+use pipewire_spa_utils::format::{MediaSubtype, MediaType};
+use crate::Direction;
+use crate::error::Error;
+use crate::listeners::{Listener, ListenerTriggerPolicy, Listeners};
+use crate::messages::StreamCallback;
+use crate::utils::dict_ref_to_hashmap;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) struct GlobalId(u32);
+
+impl From<String> for GlobalId {
+    fn from(value: String) -> Self {
+        u32::parse_value(value.as_str()).unwrap().into()
+    }
+}
+
+impl From<u32> for GlobalId {
+    fn from(value: u32) -> Self {
+        GlobalId(value)
+    }
+}
+
+impl From<i32> for GlobalId {
+    fn from(value: i32) -> Self {
+        GlobalId(value as u32)
+    }
+}
+
+impl Into<i32> for GlobalId {
+    fn into(self) -> i32 {
+        self.0 as i32
+    }
+}
+
+impl From<GlobalId> for u32 {
+    fn from(value: GlobalId) -> Self {
+        value.0
+    }
+}
+
+impl Display for GlobalId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(super) enum GlobalObjectState {
+    Pending,
+    Initialized
+}
+
+pub(super) struct GlobalState {
+    orphans: Rc<RefCell<HashMap<usize, OrphanState>>>,
+    clients: HashMap<GlobalId, ClientState>,
+    metadata: HashMap<GlobalId, MetadataState>,
+    nodes: HashMap<GlobalId, NodeState>,
+    streams: HashMap<String, StreamState>,
+    settings: SettingsState,
+    default_audio_nodes: DefaultAudioNodesState,
+}
+
+impl GlobalState {
+    pub fn insert_orphan(&mut self, mut state: OrphanState) {
+        let index = std::ptr::addr_of!(state) as usize;
+        let listener_orphans = self.orphans.clone();
+        state.add_removed_listener(
+            ListenerTriggerPolicy::Remove,
+            move || {
+                listener_orphans.borrow_mut().remove(&index);
+            }
+        );
+        self.orphans.borrow_mut().insert(index, state);
+    }
+
+    pub fn insert_client(&mut self, id: GlobalId, state: ClientState) -> Result<(), Error> {
+        if self.clients.contains_key(&id) {
+            return Err(Error {
+                description: format!("Client with id({}) already exists", id),
+            });
+        }
+        self.clients.insert(id, state);
+        Ok(())
+    }
+
+    pub fn get_clients(&self) -> Result<HashMap<&GlobalId ,&ClientState>, Error> {
+        let clients = self.clients.iter()
+            .map(|(id, state)| (id, state))
+            .collect::<HashMap<_, _>>();
+        if clients.is_empty() {
+            return Err(Error {
+                description: "Zero client registered".to_string(),
+            })
+        }
+        Ok(clients)
+    }
+
+    pub fn insert_metadata(&mut self, id: GlobalId, state: MetadataState) -> Result<(), Error> {
+        if self.metadata.contains_key(&id) {
+            return Err(Error {
+                description: format!("Metadata with id({}) already exists", id),
+            });
+        }
+        self.metadata.insert(id, state);
+        Ok(())
+    }
+
+    pub fn get_metadata(&self, id: &GlobalId) -> Result<&MetadataState, Error> {
+        self.metadata.get(id).ok_or(Error {
+            description: format!("Metadata with id({}) not found", id),
+        })
+    }
+
+    pub fn get_metadata_mut(&mut self, id: &GlobalId) -> Result<&mut MetadataState, Error> {
+        self.metadata.get_mut(id).ok_or(Error {
+            description: format!("Metadata with id({}) not found", id),
+        })
+    }
+
+    pub fn insert_node(&mut self, id: GlobalId, state: NodeState) -> Result<(), Error> {
+        if self.nodes.contains_key(&id) {
+            return Err(Error {
+                description: format!("Node with id({}) already exists", id),
+            });
+        }
+        self.nodes.insert(id, state);
+        Ok(())
+    }
+
+    pub fn get_node(&self, id: &GlobalId) -> Result<&NodeState, Error> {
+        self.nodes.get(id).ok_or(Error {
+            description: format!("Node with id({}) not found", id),
+        })
+    }
+
+    pub fn get_node_mut(&mut self, id: &GlobalId) -> Result<&mut NodeState, Error> {
+        self.nodes.get_mut(id).ok_or(Error {
+            description: format!("Node with id({}) not found", id),
+        })
+    }
+
+    pub fn get_nodes(&self) -> Result<HashMap<&GlobalId ,&NodeState>, Error> {
+        let nodes = self.nodes.iter()
+            .map(|(id, state)| (id, state))
+            .collect::<HashMap<_, _>>();
+        if nodes.is_empty() {
+            return Err(Error {
+                description: "Zero node registered".to_string(),
+            })
+        }
+        Ok(nodes)
+    }
+
+    pub fn insert_stream(&mut self, name: String, state: StreamState) -> Result<(), Error> {
+        if self.streams.contains_key(&name) {
+            return Err(Error {
+                description: format!("Stream with name({}) already exists", name),
+            });
+        }
+        self.streams.insert(name, state);
+        Ok(())
+    }
+
+    pub fn remove_stream(&mut self, name: &String) -> Result<(), Error> {
+        if self.streams.contains_key(name) == false {
+            return Err(Error {
+                description: format!("Stream with name({}) not found", name),
+            });
+        }
+        self.streams.remove(name);
+        Ok(())
+    }
+
+    pub fn get_stream(&self, name: &String) -> Result<&StreamState, Error> {
+        self.streams.get(name).ok_or(Error {
+            description: format!("Stream with name({}) not found", name),
+        })
+    }
+
+    pub fn get_stream_mut(&mut self, name: &String) -> Result<&mut StreamState, Error> {
+        self.streams.get_mut(name).ok_or(Error {
+            description: format!("Stream with name({}) not found", name),
+        })
+    }
+
+    pub fn get_settings(&self) -> SettingsState {
+        self.settings.clone()
+    }
+
+    pub fn get_default_audio_nodes(&self) -> DefaultAudioNodesState {
+        self.default_audio_nodes.clone()
+    }
+
+    pub fn remove(&mut self, id: &GlobalId) {
+        self.metadata.remove(id);
+        self.nodes.remove(id);
+    }
+}
+
+impl Default for GlobalState {
+    fn default() -> Self {
+        GlobalState {
+            orphans: Rc::new(RefCell::new(HashMap::new())),
+            clients: HashMap::new(),
+            metadata: HashMap::new(),
+            nodes: HashMap::new(),
+            streams: HashMap::new(),
+            settings: SettingsState::default(),
+            default_audio_nodes: DefaultAudioNodesState::default(),
+        }
+    }
+}
+
+pub(super) struct OrphanState {
+    proxy: pipewire::proxy::Proxy,
+    listeners: Rc<RefCell<Listeners<pipewire::proxy::ProxyListener>>>
+}
+
+impl OrphanState {
+    pub fn new(proxy: pipewire::proxy::Proxy) -> Self {
+        Self {
+            proxy,
+            listeners: Rc::new(RefCell::new(Listeners::new())),
+        }
+    }
+
+    pub fn add_removed_listener<F>(&mut self, policy: ListenerTriggerPolicy, callback: F)
+    where
+        F: Fn() + 'static
+    {
+        const LISTENER_NAME: &str = "removed";
+        let listeners = self.listeners.clone();
+        let listener = self.proxy.add_listener_local()
+            .removed(move || {
+                callback();
+                listeners.borrow_mut().triggered(&LISTENER_NAME.to_string());
+            })
+            .register();
+        self.listeners.borrow_mut().add(
+            LISTENER_NAME.to_string(),
+            Listener::new(listener, policy)
+        );
+    }
+}
+
+pub(super) struct NodeState {
+    proxy: pipewire::node::Node,
+    state: Rc<RefCell<GlobalObjectState>>,
+    properties: Rc<RefCell<HashMap<String, String>>>,
+    format: Rc<RefCell<Option<AudioInfoRaw>>>,
+    listeners: Rc<RefCell<Listeners<pipewire::node::NodeListener>>>
+}
+
+impl NodeState {
+    pub fn new(proxy: pipewire::node::Node) -> Self {
+        Self {
+            proxy,
+            state: Rc::new(RefCell::new(GlobalObjectState::Pending)),
+            properties: Rc::new(RefCell::new(HashMap::new())),
+            format: Rc::new(RefCell::new(None)),
+            listeners: Rc::new(RefCell::new(Listeners::new())),
+        }
+    }
+    
+    pub fn state(&self) -> GlobalObjectState {
+        self.state.borrow().clone()
+    }
+
+    fn set_state(&mut self) {
+        let properties = self.properties.borrow();
+        let format = self.format.borrow();
+        
+        let new_state = if properties.is_empty() == false && format.is_some() {
+            GlobalObjectState::Initialized
+        } else {
+            GlobalObjectState::Pending
+        };
+        
+        let mut state = self.state.borrow_mut();
+        *state = new_state;
+    }
+    
+    pub fn properties(&self) -> HashMap<String, String> {
+        self.properties.borrow().clone()
+    }
+    
+    pub fn set_properties(&mut self, properties: HashMap<String, String>) {
+        self.properties.borrow_mut().extend(properties);
+        self.set_state();
+    }
+    
+    pub fn format(&self) -> Option<AudioInfoRaw> {
+        self.format.borrow().clone()
+    }
+    
+    pub fn set_format(&mut self, format: AudioInfoRaw) {
+        *self.format.borrow_mut() = Some(format);
+        self.set_state();
+    }
+    
+    pub fn name(&self) -> String {
+        self.properties.borrow().get(*pipewire::keys::NODE_NAME).unwrap().clone()
+    }
+
+    fn add_info_listener<F>(&mut self, name: String, policy: ListenerTriggerPolicy, listener: F)
+    where
+        F: Fn(&pipewire::node::NodeInfoRef) + 'static
+    {
+        let listeners = self.listeners.clone();
+        let listener_name = name.clone();
+        let listener = self.proxy.add_listener_local()
+            .info(move |info| {
+                listener(info);
+                listeners.borrow_mut().triggered(&listener_name);
+            })
+            .register();
+        self.listeners.borrow_mut().add(name, Listener::new(listener, policy));
+    }
+
+    pub fn add_properties_listener<F>(&mut self, policy: ListenerTriggerPolicy, callback: F)
+    where
+        F: Fn(HashMap<String, String>) + 'static,
+    {
+        self.add_info_listener(
+            "properties".to_string(),
+            policy,
+            move |info| {
+                if info.props().is_none() {
+                    return;
+                }
+                let properties = info.props().unwrap();
+                let properties = dict_ref_to_hashmap(properties);
+                callback(properties);
+            }
+        );
+    }
+
+    fn add_parameter_listener<F>(
+        &mut self,
+        name: String,
+        expected_kind: pipewire::spa::param::ParamType,
+        policy: ListenerTriggerPolicy,
+        listener: F
+    )
+    where
+        F: Fn(u32, u32, &pipewire::spa::pod::Pod) + 'static,
+    {
+        let listeners = self.listeners.clone();
+        let listener_name = name.clone();
+        self.proxy.subscribe_params(&[expected_kind]);
+        let listener = self.proxy.add_listener_local()
+            .param(move |_, kind, id, next_id, parameter| {
+                if kind != expected_kind {
+                    return;
+                }
+                let Some(parameter) = parameter else {
+                    return;
+                };
+                listener(id, next_id, parameter);
+                listeners.borrow_mut().triggered(&listener_name);
+            })
+            .register();
+        self.listeners.borrow_mut().add(name, Listener::new(listener, policy));
+    }
+
+    pub fn add_format_listener<F>(&mut self, policy: ListenerTriggerPolicy, callback: F)
+    where
+        F: Fn(Result<AudioInfoRaw, Error>) + 'static,
+    {
+        self.add_parameter_listener(
+            "format".to_string(),
+            pipewire::spa::param::ParamType::EnumFormat,
+            policy,
+            move |_, _, parameter| {
+                let (media_type, media_subtype): (MediaType, MediaSubtype) =
+                    match pipewire::spa::param::format_utils::parse_format(parameter) {
+                        Ok((media_type, media_subtype)) => (media_type.0.into(), media_subtype.0.into()),
+                        Err(_) => return,
+                    };
+                let pod = parameter;
+                let data = pod.as_bytes();
+                let parameter = match media_type {
+                    MediaType::Audio => match media_subtype {
+                        MediaSubtype::Raw => {
+                            let result = pipewire::spa::pod::deserialize::PodDeserializer::deserialize_from(data);
+                            let result = result
+                                .map(move |(_, parameter)| {
+                                    parameter
+                                })
+                                .map_err(move |error| {
+                                    let description = match error {
+                                        pipewire::spa::pod::deserialize::DeserializeError::Nom(_) => "Parsing error",
+                                        pipewire::spa::pod::deserialize::DeserializeError::UnsupportedType => "Unsupported type",
+                                        pipewire::spa::pod::deserialize::DeserializeError::InvalidType => "Invalid type",
+                                        pipewire::spa::pod::deserialize::DeserializeError::PropertyMissing => "Property missing",
+                                        pipewire::spa::pod::deserialize::DeserializeError::PropertyWrongKey(value) => &*format!(
+                                            "Wrong property key({})", 
+                                            value
+                                        ),
+                                        pipewire::spa::pod::deserialize::DeserializeError::InvalidChoiceType => "Invalide choice type",
+                                        pipewire::spa::pod::deserialize::DeserializeError::MissingChoiceValues => "Missing choice values",
+                                    };
+                                    Error {
+                                        description: format!(
+                                            "Failed POD deserialization for type(AudioInfoRaw): {}", 
+                                            description
+                                        ),
+                                    }
+                                });
+                            result
+                        }
+                        _ => return
+                    },
+                    _ => return
+                };
+                callback(parameter);
+            }
+        );
+    }
+}
+
+pub(super) struct ClientState {
+    pub(super) name: String
+}
+
+impl ClientState {
+    pub fn new(name: String) -> Self {
+        Self {
+            name,
+        }
+    }
+}
+
+pub(super) struct MetadataState {
+    proxy: pipewire::metadata::Metadata,
+    pub(super) state: Rc<RefCell<GlobalObjectState>>,
+    pub(super) name: String,
+    listeners: Rc<RefCell<Listeners<pipewire::metadata::MetadataListener>>>,
+}
+
+impl MetadataState {
+    pub fn new(proxy: pipewire::metadata::Metadata, name: String) -> Self {
+        Self {
+            proxy,
+            name,
+            state: Rc::new(RefCell::new(GlobalObjectState::Pending)),
+            listeners: Rc::new(RefCell::new(Listeners::new())),
+        }
+    }
+
+    pub fn add_property_listener<F>(&mut self, policy: ListenerTriggerPolicy, listener: F)
+    where
+        F: Fn(u32, Option<&str>, Option<&str>, Option<&str>) -> i32 + Sized + 'static
+    {
+        const LISTENER_NAME: &str = "property";
+        let listeners = self.listeners.clone();
+        let listener = self.proxy.add_listener_local()
+            .property(move |subject , key, kind, value| {
+                let result = listener(subject, key, kind, value);
+                listeners.borrow_mut().triggered(&LISTENER_NAME.to_string());
+                result
+            })
+            .register();
+        self.listeners.borrow_mut().add(
+            LISTENER_NAME.to_string(),
+            Listener::new(listener, policy)
+        );
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct StreamUserData {}
+
+pub(super) struct StreamState {
+    proxy: pipewire::stream::Stream,
+    pub(super) name: String,
+    is_connected: bool,
+    format: pipewire::spa::param::audio::AudioInfoRaw,
+    direction: pipewire::spa::utils::Direction,
+    listeners: Rc<RefCell<Listeners<pipewire::stream::StreamListener<StreamUserData>>>>,
+}
+
+impl StreamState {
+    pub fn new(
+        name: String,
+        format: pipewire::spa::param::audio::AudioInfoRaw,
+        direction: pipewire::spa::utils::Direction,
+        proxy: pipewire::stream::Stream
+    ) -> Self {
+        Self {
+            name,
+            proxy,
+            is_connected: false,
+            format,
+            direction,
+            listeners: Rc::new(RefCell::new(Listeners::new())),
+        }
+    }
+
+    pub fn connect(&mut self) -> Result<(), Error> {
+        if self.is_connected {
+            return Err(Error {
+                description: format!("Stream {} is already connected", self.name)
+            });
+        }
+        
+        let object = pipewire::spa::pod::Value::Object(pipewire::spa::pod::Object {
+            type_: pipewire::spa::sys::SPA_TYPE_OBJECT_Format,
+            id: pipewire::spa::sys::SPA_PARAM_EnumFormat,
+            properties: self.format.into(),
+        });
+
+        let values: Vec<u8> = pipewire::spa::pod::serialize::PodSerializer::serialize(
+            Cursor::new(Vec::new()),
+            &object,
+        )
+        .unwrap()
+        .0
+        .into_inner();
+
+        let mut params = [pipewire::spa::pod::Pod::from_bytes(&values).unwrap()];
+        let flags = pipewire::stream::StreamFlags::AUTOCONNECT | pipewire::stream::StreamFlags::MAP_BUFFERS;
+
+        self.proxy
+            .connect(
+                self.direction,
+                None,
+                flags,
+                &mut params,
+            )
+            .map_err(move |error| Error { description: error.to_string() })?;
+
+        self.is_connected = true;
+
+        Ok(())
+    }
+    
+    pub fn disconnect(&mut self) -> Result<(), Error> {
+        if self.is_connected == false {
+            return Err(Error {
+                description: format!("Stream {} is not connected", self.name)
+            });
+        }
+        self.proxy
+            .disconnect()
+            .map_err(move |error| Error { description: error.to_string() })?;
+
+        self.is_connected = false;
+
+        Ok(())
+    }
+
+    pub fn add_process_listener(
+        &mut self,
+        policy: ListenerTriggerPolicy,
+        mut callback: StreamCallback
+    )
+    {
+        const LISTENER_NAME: &str = "process";
+        let listeners = self.listeners.clone();
+        let listener = self.proxy.add_local_listener()
+            .process(move |stream, _| {
+                let buffer = stream.dequeue_buffer().unwrap();
+                callback.call(buffer);
+                listeners.borrow_mut().triggered(&LISTENER_NAME.to_string());
+            })
+            .register()
+            .unwrap();
+        self.listeners.borrow_mut().add(LISTENER_NAME.to_string(), Listener::new(listener, policy));
+    }
+}
+
+pub(super) struct PortStateProperties {
+    path: String,
+    channel: AudioChannel,
+    id: GlobalId,
+    name: String,
+    direction: Direction,
+    alias: String,
+    group: String,
+}
+
+impl From<&pipewire::spa::utils::dict::DictRef> for PortStateProperties {
+    fn from(value: &pipewire::spa::utils::dict::DictRef) -> Self {
+        let properties = dict_ref_to_hashmap(value);
+        let path = properties.get("object.path").unwrap().to_string();
+        let channel = properties.get("audio.channel").unwrap().to_string();
+        let id = properties.get("port.id").unwrap().to_string();
+        let name = properties.get("port.name").unwrap().to_string();
+        let direction = properties.get("port.direction").unwrap().to_string();
+        let alias = properties.get("port.alias").unwrap().to_string();
+        let group = properties.get("port.group").unwrap().to_string();
+        Self {
+            path,
+            channel: AudioChannel::UNKNOWN,
+            id: id.into(),
+            name,
+            direction: match direction.as_str() {
+                "in" => Direction::Input,
+                "out" => Direction::Output,
+                &_ => panic!("Cannot determine direction: {}", direction.as_str()),
+            },
+            alias,
+            group,
+        }
+    }
+}
+
+pub(super) struct PortState {
+    proxy: pipewire::link::Link,
+    properties: Rc<RefCell<Option<PortStateProperties>>>,
+    pub(super) state: Rc<RefCell<GlobalObjectState>>,
+    listeners: Rc<RefCell<Listeners<pipewire::stream::StreamListener<StreamUserData>>>>,
+}
+
+// impl PortState {
+//     pub fn new(proxy: pipewire::port::Port) {
+//         proxy.add_listener_local().info(move |x| {
+//             x.
+//         })
+//             .param(move |subject , key, kind, value| {
+// 
+//             })
+//     }
+// }
+
+pub(super) struct LinkState {
+    proxy: pipewire::link::Link,
+    input_node_id: GlobalId,
+    input_port_id: GlobalId,
+    output_node_id: GlobalId,
+    output_port_id: GlobalId,
+    pub(super) state: Rc<RefCell<GlobalObjectState>>,
+    listeners: Rc<RefCell<Listeners<pipewire::stream::StreamListener<StreamUserData>>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SettingsState {
+    pub(super) state: GlobalObjectState,
+    pub allowed_sample_rates: Vec<u32>,
+    pub sample_rate: u32,
+    pub min_buffer_size: u32,
+    pub max_buffer_size: u32,
+    pub default_buffer_size: u32,
+}
+
+impl Default for SettingsState {
+    fn default() -> Self {
+        Self {
+            state: GlobalObjectState::Pending,
+            allowed_sample_rates: vec![],
+            sample_rate: 0,
+            min_buffer_size: 0,
+            max_buffer_size: 0,
+            default_buffer_size: 0,
+        }
+    }
+}
+
+impl SettingsState {
+    pub(super) fn listener<F>(state: Rc<RefCell<GlobalState>>, callback: F) -> impl Fn(u32, Option<&str>, Option<&str>, Option<&str>) -> i32 + 'static
+    where
+        F: Fn(&SettingsState) + 'static
+    {
+        const EXPECTED_PROPERTY: u32 = 5;
+        let property_count: Rc<Cell<u32>> = Rc::new(Cell::new(0));
+        move |_: u32, key: Option<&str>, _: Option<&str>, value: Option<&str>| {
+            let settings = &mut state.borrow_mut().settings;
+            let key = key.unwrap();
+            let value = value.unwrap();
+            match key {
+                CLOCK_RATE_PROPERTY_KEY => {
+                    settings.sample_rate = u32::from_str(value).unwrap();
+                    property_count.set(property_count.get() + 1);
+                },
+                CLOCK_QUANTUM_PROPERTY_KEY => {
+                    settings.default_buffer_size = u32::from_str(value).unwrap();
+                    property_count.set(property_count.get() + 1);
+                }
+                CLOCK_QUANTUM_MIN_PROPERTY_KEY => {
+                    settings.min_buffer_size = u32::from_str(value).unwrap();
+                    property_count.set(property_count.get() + 1);
+                }
+                CLOCK_QUANTUM_MAX_PROPERTY_KEY => {
+                    settings.max_buffer_size = u32::from_str(value).unwrap();
+                    property_count.set(property_count.get() + 1);
+                }
+                CLOCK_ALLOWED_RATES_PROPERTY_KEY => {
+                    let rates: Result<Vec<u32>, _> = value[2..value.len() - 2]
+                        .split_whitespace()
+                        .map(|x| x.parse::<u32>())
+                        .collect();
+                    settings.allowed_sample_rates = rates.unwrap();
+                    property_count.set(property_count.get() + 1);
+                }
+                &_ => {}
+            };
+            if let (GlobalObjectState::Pending, EXPECTED_PROPERTY) = (settings.state.clone(), property_count.get()) {
+                settings.state = GlobalObjectState::Initialized;
+                callback(settings)
+            }
+            0
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DefaultAudioNodesState {
+    pub(super) state: GlobalObjectState,
+    pub source: String,
+    pub sink: String,
+}
+
+impl Default for DefaultAudioNodesState {
+    fn default() -> Self {
+        Self {
+            state: GlobalObjectState::Pending,
+            source: "".to_string(),
+            sink: "".to_string(),
+        }
+    }
+}
+
+impl DefaultAudioNodesState {
+    pub(super) fn listener<F>(state: Rc<RefCell<GlobalState>>, callback: F) -> impl Fn(u32, Option<&str>, Option<&str>, Option<&str>) -> i32 + 'static
+    where
+        F: Fn(&DefaultAudioNodesState) + 'static
+    {
+        const EXPECTED_PROPERTY: u32 = 2;
+        let property_count: Rc<Cell<u32>> = Rc::new(Cell::new(0));
+        move |_: u32, key: Option<&str>, _: Option<&str>, value: Option<&str>| {
+            let default_audio_devices = &mut state.borrow_mut().default_audio_nodes;
+            let key = key.unwrap();
+            let value = value.unwrap();
+            match key {
+                DEFAULT_AUDIO_SINK_PROPERTY_KEY => {
+                    let value: serde_json::Value = serde_json::from_str(value).unwrap();
+                    default_audio_devices.sink = value.as_object()
+                        .unwrap()
+                        .get("name")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    property_count.set(property_count.get() + 1);
+                },
+                DEFAULT_AUDIO_SOURCE_PROPERTY_KEY => {
+                    let value: serde_json::Value = serde_json::from_str(value).unwrap();
+                    default_audio_devices.source = value.as_object()
+                        .unwrap()
+                        .get("name")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                        .to_string();
+                    property_count.set(property_count.get() + 1);
+                },
+                &_ => {}
+            };
+            if let (GlobalObjectState::Pending, EXPECTED_PROPERTY) = (default_audio_devices.state.clone(), property_count.get()) {
+                default_audio_devices.state = GlobalObjectState::Initialized;
+                callback(default_audio_devices)
+            }
+            0
+        }
+    }
+}

--- a/pipewire-client/src/utils.rs
+++ b/pipewire-client/src/utils.rs
@@ -1,0 +1,139 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use crate::listeners::{Listener, ListenerTriggerPolicy, Listeners};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Direction {
+    Input,
+    Output,
+}
+
+impl From<Direction> for pipewire::spa::utils::Direction {
+    fn from(value: Direction) -> Self {
+        match value {
+            Direction::Input => pipewire::spa::utils::Direction::Input,
+            Direction::Output => pipewire::spa::utils::Direction::Output,
+        }
+    }
+}
+
+pub(super) fn dict_ref_to_hashmap(dict: &pipewire::spa::utils::dict::DictRef) -> HashMap<String, String> {
+    dict
+        .iter()
+        .map(move |(k, v)| {
+            let k = String::from(k).clone();
+            let v = String::from(v).clone();
+            (k, v)
+        })
+        .collect::<HashMap<_, _>>()
+}
+
+pub(super) fn debug_dict_ref(dict: &pipewire::spa::utils::dict::DictRef) {
+    for (key, value) in dict.iter() {
+        println!("{} => {}", key ,value);
+    }
+    println!("\n");
+}
+
+pub(super) struct PipewireCoreSync {
+    core: Rc<RefCell<pipewire::core::Core>>,
+    listeners: Rc<RefCell<Listeners<pipewire::core::Listener>>>,
+}
+
+impl PipewireCoreSync {
+    pub fn new(core: Rc<RefCell<pipewire::core::Core>>) -> Self {
+        Self {
+            core,
+            listeners: Rc::new(RefCell::new(Listeners::new())),
+        }
+    }
+
+    pub fn register<F>(&self, keep: bool, seq: u32, callback: F)
+    where
+        F: Fn() + 'static,
+    {
+        let sync_id = self.core.borrow_mut().sync(seq as i32).unwrap();
+        let name = format!("sync-{}", sync_id.raw());
+        let policy = match keep {
+            true => ListenerTriggerPolicy::Keep,
+            false => ListenerTriggerPolicy::Remove,
+        };
+        let listeners = self.listeners.clone();
+        let listener_name = name.clone();
+        let listener = self
+            .core
+            .borrow_mut()
+            .add_listener_local()
+            .done(move |_, seq| {
+                if seq != sync_id {
+                    return;
+                }
+                callback();
+                listeners.borrow_mut().triggered(&listener_name);
+            })
+            .register();
+        self.listeners
+            .borrow_mut()
+            .add(name, Listener::new(listener, policy));
+    }
+}
+
+impl Clone for PipewireCoreSync {
+    fn clone(&self) -> Self {
+        Self {
+            core: self.core.clone(),
+            listeners: self.listeners.clone(),
+        }
+    }
+}
+
+pub(super) struct Backoff {
+    attempts: u32,
+    maximum_attempts: u32,
+    wait_duration: std::time::Duration,
+    initial_wait_duration: std::time::Duration,
+    maximum_wait_duration: std::time::Duration,
+}
+
+impl Backoff {
+    pub fn new(
+        maximum_attempts: u32,
+        initial_wait_duration: std::time::Duration,
+        maximum_wait_duration: std::time::Duration
+    ) -> Self {
+        Self {
+            attempts: 0,
+            maximum_attempts,
+            wait_duration: initial_wait_duration,
+            initial_wait_duration,
+            maximum_wait_duration,
+        }
+    }
+    
+    pub fn reset(&mut self) {
+        self.attempts = 0;
+        self.wait_duration = self.initial_wait_duration;
+    }
+
+    pub fn retry<F, O, E>(&mut self, mut operation: F) -> Result<O, E>
+    where
+        F: FnMut() -> Result<O, E>,
+        E: std::error::Error
+    {
+        self.reset();
+        loop {
+            let error = match operation() {
+                Ok(value) => return Ok(value),
+                Err(value) => value
+            };
+            std::thread::sleep(self.wait_duration);
+            self.wait_duration = self.maximum_wait_duration.min(self.wait_duration * 2);
+            self.attempts += 1;
+            if self.attempts < self.maximum_attempts {
+                continue;
+            }
+            return Err(error)
+        }
+    }
+}

--- a/pipewire-spa-utils/Cargo.toml
+++ b/pipewire-spa-utils/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "pipewire-spa-utils"
+version = "0.1.0"
+authors = ["Alexis Bekhdadi <alexis@bekhdadi.com>"]
+description = "PipeWire SPA Utils"
+repository = "https://github.com/RustAudio/cpal/"
+documentation = ""
+license = "Apache-2.0"
+keywords = ["pipewire", "spa", "utils"]
+build = "build.rs"
+
+[build-dependencies]
+cargo = "0.84"
+cargo_metadata = "0.19"
+libspa = "0.8"
+syn = "2.0"
+quote = "1.0"
+prettyplease = "0.2"
+itertools = "0.14"
+indexmap = "2.7"
+
+[dependencies]
+libspa = { version = "0.8" }
+
+[features]
+v0_3_33 = []
+v0_3_40 = ["v0_3_33", "libspa/v0_3_33"]
+v0_3_65 = ["v0_3_40", "libspa/v0_3_65"]
+v0_3_75 = ["v0_3_65", "libspa/v0_3_75"]
+
+

--- a/pipewire-spa-utils/build.rs
+++ b/pipewire-spa-utils/build.rs
@@ -1,0 +1,18 @@
+extern crate cargo;
+extern crate syn;
+extern crate itertools;
+extern crate indexmap;
+extern crate cargo_metadata;
+extern crate quote;
+
+mod build_modules;
+
+use build_modules::format;
+use build_modules::utils::map_package_info;
+
+
+fn main() {
+    let package = map_package_info();
+    format::generate_enums(&package.src_path, &package.build_path, &package.features);
+}
+

--- a/pipewire-spa-utils/build_modules/format/mod.rs
+++ b/pipewire-spa-utils/build_modules/format/mod.rs
@@ -1,0 +1,445 @@
+use build_modules::syntax::generators::enumerator::{EnumInfo, EnumVariantInfo};
+use build_modules::syntax::parsers::{StructImplVisitor, StructVisitor};
+use build_modules::syntax::utils::AttributeExt;
+use build_modules::utils::read_source_file;
+use indexmap::IndexMap;
+use itertools::Itertools;
+use std::cmp::Ordering;
+use std::path::PathBuf;
+use syn::__private::quote::__private::ext::RepToTokensExt;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::token::PathSep;
+use syn::{Attribute, Expr, Fields, Ident, ImplItemConst, Item, ItemConst, PathSegment, Type};
+use debug;
+
+#[derive(Debug, Clone)]
+struct StructInfo {
+    ident: Ident,
+    unnamed_field_ident: Ident,
+}
+
+#[derive(Debug, Clone)]
+struct StructImplInfo {
+    attributes: Vec<Attribute>,
+    constants: Vec<ImplItemConst>
+}
+
+pub fn generate_enums(src_path: &PathBuf, build_path: &PathBuf, features: &Vec<String>) {
+    let file_path = PathBuf::from(&"param/format.rs");
+    let src = read_source_file(&src_path, &file_path);
+
+    let media_type_enum_info = map_media_type_enum_info(&src.items);
+    let media_subtype_enum_info = map_media_subtype_enum_info(
+        &src.items,
+        move |constant | {
+            if features.is_empty() {
+                constant.attrs.contains(&"feature".to_string()) == false
+            }
+            else {
+                features.iter().any(|feature| {
+                    constant.attrs.contains(feature)
+                }) == false
+            }
+        }
+    );
+
+    let enum_infos = vec![
+        media_type_enum_info,
+        media_subtype_enum_info
+    ];
+
+    generate_enums_code(enum_infos, "format.rs");
+
+    let file_path = PathBuf::from(&"bindings.rs");
+    let src = read_source_file(&build_path, &file_path);
+
+    let audio_sample_format_enum_info = map_audio_sample_format_enum_info(&src.items);
+    let audio_channel_enum_info = map_audio_channel_enum_info(&src.items);
+
+    let enum_infos = vec![
+        audio_sample_format_enum_info,
+        audio_channel_enum_info
+    ];
+
+    generate_enums_code(enum_infos, "audio.rs");
+}
+
+fn map_media_type_enum_info(items: &Vec<Item>) -> EnumInfo {
+    const IDENT: &str = "MediaType";
+
+    let filter = move |ident: String| ident == IDENT;
+    let struct_info = map_struct_info(&items, filter);
+    let struct_impl_info = map_struct_impl_info(&items, filter);
+    
+    EnumInfo {
+        ident: struct_info.ident.clone(),
+        attributes: struct_impl_info.attributes,
+        spa_type: struct_info.unnamed_field_ident.clone(),
+        representation_type: "u32".to_string(),
+        variants: struct_impl_info.constants.iter()
+                .map(move |constant| {
+                    let index = constant.ident.to_string();
+                    let variant = EnumVariantInfo {
+                        attributes: constant.attrs.clone(),
+                        fields: Fields::Unit,
+                        ident: constant.ident.clone(),
+                        discriminant: match constant.expr.clone() {
+                            Expr::Call(value) => {
+                                let mut arg = value.args[0].clone();
+                                match arg {
+                                    Expr::Path(ref mut value) => {
+                                        let mut segments = Punctuated::<PathSegment, PathSep>::new();
+                                        for index in 1..value.path.segments.len() {
+                                            segments.push(value.path.segments[index].clone());
+                                        }
+                                        value.path.segments = segments;
+                                    },
+                                    _ => panic!("Expected a path expression"),
+                                };
+                                arg
+                            },
+                            _ => panic!("Expected a call expression"),
+                        },
+                    };
+                    (index, variant)
+                })
+                .collect::<IndexMap<_, _>>(),
+    }
+}
+
+fn map_media_subtype_enum_info<F>(items: &Vec<Item>, filter: F) -> EnumInfo
+where
+    F: FnMut(&&ImplItemConst) -> bool
+{
+    const IDENT: &str = "MediaSubtype";
+
+    let ident_filter = move |ident: String| ident == IDENT;
+    let struct_info = map_struct_info(&items, ident_filter);
+    let mut struct_impl_info = map_struct_impl_info(&items, ident_filter);
+    
+    struct_impl_info.attributes.push_one("allow", "unexpected_cfgs"); // TODO remove this when V0_3_68 will be added to libspa manifest
+    struct_impl_info.attributes.push_one("allow", "unused_doc_comments");
+
+    EnumInfo {
+        ident: struct_info.ident.clone(),
+        attributes: struct_impl_info.attributes,
+        spa_type: struct_info.unnamed_field_ident.clone(),
+        representation_type: "u32".to_string(),
+        variants: struct_impl_info.constants.iter()
+            .filter(filter)
+            .filter(move |constant| {
+                match &constant.expr {
+                    Expr::Call(_) => true,
+                    _ => false,
+                }
+            })
+            .map(move |constant| {
+                let index = constant.ident.to_string();
+                let variant = EnumVariantInfo {
+                    attributes: constant.attrs.clone(),
+                    fields: Fields::Unit,
+                    ident: constant.ident.clone(),
+                    discriminant: match constant.expr.clone() {
+                        Expr::Call(value) => {
+                            let mut arg = value.args[0].clone();
+                            match arg {
+                                Expr::Path(ref mut value) => {
+                                    let mut segments = Punctuated::<PathSegment, PathSep>::new();
+                                    for index in 1..value.path.segments.len() {
+                                        segments.push(value.path.segments[index].clone());
+                                    }
+                                    value.path.segments = segments;
+                                },
+                                _ => panic!("Expected a path expression"),
+                            };
+                            arg
+                        },
+                        _ => panic!("Expected a call expression: {:?}", constant.expr),
+                    },
+                };
+                (index, variant)
+            })
+            .collect::<IndexMap<_, _>>(),
+    }
+}
+
+fn spa_audio_format_idents() -> Vec<String> {
+    let audio_formats: Vec<String> = vec![
+        "S8".to_string(),
+        "U8".to_string(),
+        "S16".to_string(),
+        "U16".to_string(),
+        "S24".to_string(),
+        "U24".to_string(),
+        "S24_32".to_string(),
+        "U24_32".to_string(),
+        "S32".to_string(),
+        "U32".to_string(),
+        "F32".to_string(),
+        "F64".to_string(),
+    ];
+
+    let ends = vec![
+        "LE".to_string(),
+        "BE".to_string(),
+        "P".to_string(),
+    ];
+
+    audio_formats.iter()
+        .flat_map(move |format| {
+            ends.iter()
+                .map(move |end| {
+                    if format.contains("8") && end != "P" {
+                        format!("SPA_AUDIO_FORMAT_{}", format)
+                    }
+                    else if format.contains("8") && end == "P" {
+                        format!("SPA_AUDIO_FORMAT_{}{}", format, end)
+                    }
+                    else if format.contains("8") == false && end == "P" {
+                        format!("SPA_AUDIO_FORMAT_{}{}", format, end)
+                    }
+                    else {
+                        format!("SPA_AUDIO_FORMAT_{}_{}", format, end)
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn map_audio_sample_format_enum_info(items: &Vec<Item>) -> EnumInfo {
+    let spa_audio_format_idents = spa_audio_format_idents();
+    let constants = map_constant_info(
+        &items,
+        move |constant| spa_audio_format_idents.contains(constant),
+        move |a, b| {
+            a.cmp(&b)
+        }
+    );
+
+    let ident = "AudioSampleFormat";
+    let spa_type = "spa_audio_format";
+    
+    let mut attributes: Vec<Attribute> = vec![];
+    attributes.push_one("allow", "non_camel_case_types");
+
+    EnumInfo {
+        ident: Ident::new(ident, ident.span()),
+        attributes,
+        spa_type: Ident::new(spa_type, spa_type.span()),
+        representation_type: "u32".to_string(),
+        variants: constants.iter()
+            .map(move |constant| {
+                let index = constant.ident.to_string();
+                let ident = constant.ident.to_string().replace("SPA_AUDIO_FORMAT_", "");
+                let ident = Ident::new(&ident, ident.span());
+                let discriminant = *constant.expr.clone();
+                let variant = EnumVariantInfo {
+                    attributes: constant.attrs.clone(),
+                    fields: Fields::Unit,
+                    ident,
+                    discriminant,
+                };
+                (index, variant)
+            })
+            .collect::<IndexMap<_, _>>(),
+    }
+}
+
+fn map_audio_channel_enum_info(items: &Vec<Item>) -> EnumInfo {
+    let constants = map_constant_info(
+        &items,
+        move |constant| {
+            if constant.starts_with("SPA_AUDIO_CHANNEL") == false {
+                return false;
+            }
+            
+            let constant = constant.replace("SPA_AUDIO_CHANNEL_", "");
+            
+            if constant.starts_with("START") || constant.starts_with("LAST") || constant.starts_with("AUX") {
+                return false;
+            }
+            
+            return true;
+        },
+        move |a, b| {
+            a.cmp(&b)
+        }
+    );
+
+    let ident = "AudioChannel";
+    let spa_type = "spa_audio_channel";
+
+    let mut attributes: Vec<Attribute> = vec![];
+    attributes.push_one("allow", "unused_doc_comments");
+
+    EnumInfo {
+        ident: Ident::new(ident, ident.span()),
+        attributes,
+        spa_type: Ident::new(spa_type, spa_type.span()),
+        representation_type: "u32".to_string(),
+        variants: constants.iter()
+            .map(move |constant| {
+                let index = constant.ident.to_string();
+                let ident = constant.ident.to_string().replace("SPA_AUDIO_CHANNEL_", "");
+                let ident = Ident::new(&ident, ident.span());
+                let discriminant = *constant.expr.clone();
+                let variant = EnumVariantInfo {
+                    attributes: constant.attrs.clone(),
+                    fields: Fields::Unit,
+                    ident,
+                    discriminant,
+                };
+                (index, variant)
+            })
+            .collect::<IndexMap<_, _>>(),
+    }
+}
+
+fn map_constant_info<F, S>(items: &Vec<Item>, filter: F, sorter: S) -> Vec<&ItemConst>
+where
+    F: Fn(&String) -> bool,
+    S: Fn(&String, &String) -> Ordering
+{
+    items.iter()
+        .filter_map(move |item| {
+            match item {
+                Item::Const(value) => {
+                    Some(value)
+                }
+                &_ => None
+            }
+        })
+        .filter(move |constant| filter(&constant.ident.to_string()))
+        .sorted_by(move |a, b| sorter(&a.ident.to_string(), &b.ident.to_string()))
+        .collect::<Vec<_>>()
+}
+
+fn map_struct_info<F>(items: &Vec<Item>, filter: F) -> StructInfo
+where
+    F: Fn(String) -> bool
+{
+    items.iter()
+        .filter_map(move |item| {
+            let item = item.next().unwrap();
+            let item = item.next().unwrap();
+            match item {
+                Item::Struct(value) => {
+                    let ident = value.ident.clone();
+                    if filter(ident.to_string()) == false {
+                        return None;
+                    }
+                    let visitor = StructVisitor::new(value);
+                    Some((visitor, ident))
+                }
+                &_ => None
+            }
+        })
+        .filter_map(move |(visitor, ident)| {
+            let fields = visitor.fields();
+            if fields.is_empty() == false {
+                Some(StructInfo {
+                    ident,
+                    unnamed_field_ident: {
+                        let field = fields
+                            .iter()
+                            .map(|field| field.clone())
+                            .collect::<Vec<_>>()
+                            .first()
+                            .cloned()
+                            .unwrap();
+                        let ident = match field.ty {
+                            Type::Path(value) => {
+                                value.path.segments.iter()
+                                    .map(|segment| segment.ident.to_string())
+                                    .join("::")
+                            }
+                            _ => panic!("Unsupported type: {:?}", field.ty),
+                        };
+                        let ident = ident
+                            .replace("spa_sys::", "");
+                        Ident::new(&ident, ident.span())
+                    },
+                })
+            }
+            else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .first()
+        .cloned()
+        .unwrap()
+}
+
+fn map_struct_impl_info<F>(items: &Vec<Item>, filter: F) -> StructImplInfo
+where
+    F: Fn(String) -> bool
+{
+    items.iter()
+        .filter_map(move |item| {
+            let item = item.next().unwrap();
+            let item = item.next().unwrap();
+            match item {
+                Item::Impl(value) => {
+                    let visitor = StructImplVisitor::new(value);
+                    let self_ident = visitor.self_type()
+                        .segments
+                        .iter()
+                        .map(|segment| segment.ident.to_string())
+                        .collect::<Vec<_>>()
+                        .join("::");
+                    if filter(self_ident) == false {
+                        return None;
+                    }
+                    let attributes = visitor.attributes();
+                    Some((visitor, attributes))
+                }
+                &_ => None
+            }
+        })
+        .filter_map(move |(visitor, attributes)| {
+            if attributes.is_empty() {
+                return None;
+            }
+            let constants = visitor.constants()
+                .iter()
+                .filter_map(move |constant| {
+                    match constant.ty {
+                        Type::Path(_) => {
+                            Some(constant.clone())
+                        }
+                        _ => None
+                    }
+                })
+                .collect::<Vec<_>>();
+            if constants.is_empty() == false {
+                Some(StructImplInfo {
+                    attributes,
+                    constants: constants.clone(),
+                })
+            }
+            else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .first()
+        .cloned()
+        .unwrap()
+}
+
+fn generate_enums_code(enums: Vec<EnumInfo>, filename: &str) {
+    let code = enums.iter()
+        .map(move |enum_info| enum_info.generate())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let out_dir = std::env::var("OUT_DIR")
+        .expect("OUT_DIR not set");
+
+    let path = std::path::Path::new(&out_dir).join(filename);
+    std::fs::write(path, code)
+        .expect("Unable to write generated file");
+}

--- a/pipewire-spa-utils/build_modules/mod.rs
+++ b/pipewire-spa-utils/build_modules/mod.rs
@@ -1,0 +1,3 @@
+pub mod syntax;
+pub mod format;
+pub mod utils;

--- a/pipewire-spa-utils/build_modules/syntax/generators/enumerator.rs
+++ b/pipewire-spa-utils/build_modules/syntax/generators/enumerator.rs
@@ -1,0 +1,145 @@
+use build_modules::syntax::utils::AttributeExt;
+use indexmap::IndexMap;
+use quote::ToTokens;
+use quote::__private::TokenStream;
+use syn::__private::quote::quote;
+use syn::__private::TokenStream2;
+use syn::punctuated::Punctuated;
+use syn::token::{Brace, Enum, Eq, Pub};
+use syn::{Attribute, Expr, Fields, Generics, Ident, ItemEnum, Variant, Visibility};
+use debug;
+
+#[derive(Debug)]
+pub struct EnumInfo {
+    pub ident: Ident,
+    pub attributes: Vec<Attribute>,
+    pub spa_type: Ident,
+    pub representation_type: String,
+    pub variants: IndexMap<String, EnumVariantInfo>
+}
+
+#[derive(Debug)]
+pub struct EnumVariantInfo {
+    pub attributes: Vec<Attribute>,
+    pub fields: Fields,
+    pub ident: Ident,
+    pub discriminant: Expr
+}
+
+impl From<&EnumVariantInfo> for Variant {
+    fn from(value: &EnumVariantInfo) -> Self {
+        Variant {
+            attrs: value.attributes.clone(),
+            ident: value.ident.clone(),
+            fields: value.fields.clone(),
+            discriminant: Some((Eq::default(), value.discriminant.clone())),
+        }
+    }
+}
+
+impl EnumInfo {
+    pub fn generate(&self) -> String {
+        let mut variants = Punctuated::new();
+        self.variants.iter()
+            .for_each(|(_, variant)| {
+                variants.push(variant.into())
+            });
+        let mut attributes = self.attributes.clone();
+        attributes.push_one("repr", self.representation_type.as_str());
+        attributes.push_one("derive", "Debug");
+        attributes.push_one("derive", "Clone");
+        attributes.push_one("derive", "Copy");
+        attributes.push_one("derive", "Ord");
+        attributes.push_one("derive", "PartialOrd");
+        attributes.push_one("derive", "Eq");
+        attributes.push_one("derive", "PartialEq");
+        let item = ItemEnum {
+            attrs: attributes.clone(),
+            vis: Visibility::Public(Pub::default()),
+            enum_token: Enum::default(),
+            ident: self.ident.clone(),
+            generics: Generics::default(),
+            brace_token: Brace::default(),
+            variants,
+        };
+        let import_quote = quote! {
+            use libspa::sys::*;
+        };
+        let attributes_quote = self.attributes.to_token_stream();
+        let item_quote = quote!(#item);
+        let item_ident_quote = item.ident.to_token_stream();
+        let representation_type_quote = self.representation_type.parse::<TokenStream2>().unwrap();
+        let spa_type_quote = self.spa_type.to_token_stream();
+        let from_representation_to_variant_quote = self.variants.iter()
+            .map(|(_, variant)| {
+                let ident = variant.ident.to_token_stream();
+                let discriminant = variant.discriminant.to_token_stream();
+                let attributes = variant.attributes.to_token_stream();
+                quote! {
+                    #attributes
+                    #discriminant => Self::#ident,
+                }
+            })
+            .collect::<TokenStream>();
+        let from_representation_type_quote = quote! {
+            #attributes_quote
+            impl From<#representation_type_quote> for #item_ident_quote {
+                fn from(value: #representation_type_quote) -> Self {
+                    let value: #spa_type_quote = value;
+                    match value {
+                        #from_representation_to_variant_quote
+                        _ => panic!("Unknown variant")
+                    }
+                }
+            }
+        };
+        let to_representation_type_quote = quote! {
+            #attributes_quote
+            impl From<&#item_ident_quote> for #representation_type_quote {
+                fn from(value: &#item_ident_quote) -> Self {
+                    let value: #spa_type_quote = value.into();
+                    value
+                }
+            }
+        
+            #attributes_quote
+            impl From<#item_ident_quote> for #representation_type_quote {
+                fn from(value: #item_ident_quote) -> Self {
+                    let value: #spa_type_quote = value.into();
+                    value
+                }
+            }
+        };
+        let from_variant_to_string_quote = self.variants.iter()
+            .map(|(_, variant)| {
+                let ident = variant.ident.to_token_stream();
+                let ident_string = variant.ident.to_string();
+                let attributes = variant.attributes.to_token_stream();
+                quote! {
+                    #attributes
+                    Self::#ident => #ident_string.to_string(),
+                }
+            })
+            .collect::<TokenStream>();
+        let to_string_quote = quote! {
+            #attributes_quote
+            impl #item_ident_quote {
+                fn to_string(&self) -> String {
+                    match self {
+                        #from_variant_to_string_quote
+                    }
+                }
+            }
+        };
+        let items = vec![
+            import_quote.to_string(),
+            item_quote.to_string(),
+            from_representation_type_quote.to_string(),
+            to_representation_type_quote.to_string(),
+            to_string_quote.to_string(),
+        ];
+        let items = items.join("\n");
+        let file = syn::parse_file(items.as_str()).unwrap();
+        prettyplease::unparse(&file)
+    }
+}

--- a/pipewire-spa-utils/build_modules/syntax/generators/mod.rs
+++ b/pipewire-spa-utils/build_modules/syntax/generators/mod.rs
@@ -1,0 +1,1 @@
+pub mod enumerator;

--- a/pipewire-spa-utils/build_modules/syntax/mod.rs
+++ b/pipewire-spa-utils/build_modules/syntax/mod.rs
@@ -1,0 +1,3 @@
+pub mod generators;
+pub mod parsers;
+pub mod utils;

--- a/pipewire-spa-utils/build_modules/syntax/parsers/mod.rs
+++ b/pipewire-spa-utils/build_modules/syntax/parsers/mod.rs
@@ -1,0 +1,59 @@
+use syn::{Attribute, Fields, ImplItem, ImplItemConst, ItemImpl, ItemStruct, Path, Type};
+
+pub struct StructVisitor<'a> {
+    item: &'a ItemStruct,
+}
+
+impl<'a> StructVisitor<'a> {
+    pub fn new(item: &'a ItemStruct) -> Self {
+        Self {
+            item,
+        }
+    }
+
+    pub fn fields(&self) -> Fields {
+        self.item.fields.clone()
+    }
+}
+
+pub struct StructImplVisitor<'a> {
+    item: &'a ItemImpl
+}
+
+impl<'a> StructImplVisitor<'a> {
+    pub fn new(item: &'a ItemImpl) -> Self {
+        Self {
+            item,
+        }
+    }
+    pub fn self_type(&self) -> Path {
+        match *self.item.self_ty.clone() {
+            Type::Path(value) => {
+                value.path.clone()
+            }
+            _ => panic!("Path expected")
+        }
+    }
+
+    pub fn attributes(&self) -> Vec<Attribute> {
+        self.item.attrs.iter()
+            .map(move |attribute| {
+                attribute.clone()
+            })
+            .collect::<Vec<_>>()
+    }
+
+    pub fn constants(&self) -> Vec<ImplItemConst> {
+        self.item.items.iter()
+            .filter_map(move |item| {
+                match item {
+                    ImplItem::Const(value) => {
+                        Some(value.clone())
+                    }
+                    &_ => return None
+                }
+            })
+            .collect::<Vec<_>>()
+    }
+}
+

--- a/pipewire-spa-utils/build_modules/syntax/utils.rs
+++ b/pipewire-spa-utils/build_modules/syntax/utils.rs
@@ -1,0 +1,67 @@
+use quote::ToTokens;
+use quote::__private::TokenStream;
+use std::str::FromStr;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::token::{Bracket, Paren, Pound};
+use syn::{AttrStyle, Attribute, Ident, MacroDelimiter, Meta, MetaList, PathArguments, PathSegment};
+
+fn add_attribute(attrs: &mut Vec<Attribute>, ident: &str, value: &str) {
+    attrs.push(
+        Attribute {
+            pound_token: Pound::default(),
+            style: AttrStyle::Outer,
+            bracket_token: Bracket::default(),
+            meta: Meta::List(MetaList {
+                path: syn::Path {
+                    leading_colon: None,
+                    segments: {
+                        let mut segments = Punctuated::default();
+                        let ident = ident;
+                        segments.push(PathSegment {
+                            ident: Ident::new(ident, ident.span()),
+                            arguments: PathArguments::None,
+                        });
+                        segments
+                    },
+                },
+                delimiter: MacroDelimiter::Paren(Paren::default()),
+                tokens: TokenStream::from_str(value).unwrap(),
+            }),
+        }
+    );
+}
+
+pub trait AttributeExt {
+    fn push_one(&mut self, ident: &str, value: &str);
+    fn to_token_stream(&self) -> TokenStream;
+    fn contains(&self, ident: &String) -> bool;
+}
+
+impl AttributeExt for Vec<Attribute> {
+    fn push_one(&mut self, ident: &str, value: &str) {
+        add_attribute(self, ident, value);
+    }
+
+    fn to_token_stream(&self) -> TokenStream {
+        self.iter()
+            .map(|attr| attr.to_token_stream())
+            .collect()
+    }
+
+    fn contains(&self, ident: &String) -> bool {
+        self.iter().any(move |attribute| {
+            match &attribute.meta {
+                Meta::Path(value) => {
+                    value.segments.iter().any(|segment| segment.ident == ident)
+                }
+                Meta::List(value) => {
+                    value.path.segments.iter().any(|segment| segment.ident == ident)
+                }
+                Meta::NameValue(value) => {
+                    value.path.segments.iter().any(|segment| segment.ident == ident)
+                }
+            }
+        })
+    }
+}

--- a/pipewire-spa-utils/build_modules/utils/mod.rs
+++ b/pipewire-spa-utils/build_modules/utils/mod.rs
@@ -1,0 +1,104 @@
+use cargo_metadata::camino::Utf8PathBuf;
+use cargo_metadata::{Message, Node, Package};
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+#[macro_export]
+macro_rules! debug {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning={}", format!($($tokens)*))
+    }
+}
+
+pub struct PackageInfo {
+    pub src_path: PathBuf,
+    pub build_path: PathBuf,
+    pub features: Vec<String>,
+}
+
+pub fn map_package_info() -> PackageInfo {
+    let (package, resolve) = find_dependency(
+        "./Cargo.toml", 
+        move |package| package.name == "libspa"
+    );
+    let src_path = package.manifest_path.parent().unwrap().as_str();
+    let src_path = PathBuf::from(src_path).join("src");
+    let build_path = dependency_build_path(&package.manifest_path, &resolve).unwrap();
+    PackageInfo {
+        src_path,
+        build_path,
+        features: resolve.features.clone(),
+    }
+}
+
+fn find_dependency<F>(manifest_path: &str, filter: F) -> (Package, Node)
+where
+    F: Fn(&Package) -> bool
+{
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+    let metadata = cmd
+        .manifest_path(manifest_path)
+        .exec().unwrap();
+    let package = metadata.packages
+        .iter()
+        .find(move |package| filter(package))
+        .unwrap()
+        .clone();
+    let package_id = package.id.clone();
+    let resolve = metadata.resolve.as_ref().unwrap().nodes
+        .iter()
+        .find(move |node| {
+            node.id == package_id
+        })
+        .unwrap()
+        .clone();
+    (package, resolve)
+}
+
+fn dependency_build_path(manifest_path: &Utf8PathBuf, node: &Node) -> Option<PathBuf> {
+    let dependency = node.deps.iter()
+        .find(move |dependency| dependency.name == "spa_sys")
+        .and_then(move |dependency| Some(dependency.pkg.clone()))
+        .unwrap();
+    let (package, _) = find_dependency(
+        manifest_path.as_ref(),
+        move |package| package.id == dependency
+    );
+    let mut command = Command::new("cargo")
+        .current_dir(package.manifest_path.parent().unwrap())
+        .args(&["check", "--message-format=json", "--quiet"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    command.wait().unwrap();
+    let reader = BufReader::new(command.stdout.take().unwrap());
+    for message in Message::parse_stream(reader) {
+        match message.ok().unwrap() {
+            Message::BuildScriptExecuted(script) => {
+                if script.package_id.repr.starts_with("path+file://"){
+                    return Some(script.out_dir.clone().as_std_path().to_path_buf())
+                }
+            },
+            _ => ()
+        }
+    }
+    
+    None
+}
+
+pub fn read_source_file(src_path: &PathBuf, file_path: &PathBuf) -> syn::File {
+    let path = src_path.join(file_path);
+    let mut file = File::open(path)
+        .expect("Unable to open file");
+
+    let mut src = String::new();
+    file.read_to_string(&mut src)
+        .expect("Unable to read file");
+
+    let syntax = syn::parse_file(&src)
+        .expect("Unable to parse file");
+    syntax
+}

--- a/pipewire-spa-utils/src/audio/mod.rs
+++ b/pipewire-spa-utils/src/audio/mod.rs
@@ -1,0 +1,57 @@
+use libspa::pod::deserialize::DeserializeError;
+use libspa::pod::deserialize::DeserializeSuccess;
+use libspa::pod::deserialize::PodDeserialize;
+use libspa::pod::deserialize::PodDeserializer;
+use libspa::pod::deserialize::VecVisitor;
+use libspa::utils::Id;
+use std::convert::TryInto;
+use std::ops::Deref;
+use impl_array_id_deserializer;
+use utils::IdOrEnumId;
+
+pub mod raw;
+
+include!(concat!(env!("OUT_DIR"), "/audio.rs"));
+
+#[derive(Debug, Clone)]
+pub struct AudioSampleFormatEnum(IdOrEnumId<AudioSampleFormat>);
+
+impl Deref for AudioSampleFormatEnum {
+    type Target = IdOrEnumId<AudioSampleFormat>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AudioChannelPosition(Vec<AudioChannel>);
+
+impl Default for AudioChannelPosition {
+    fn default() -> Self {
+        AudioChannelPosition(vec![])
+    }
+}
+
+impl AudioChannelPosition {
+    pub fn to_array<const N: usize>(&self) -> [u32; N] {
+        let mut channels = self.0
+            .iter()
+            .map(move |channel| *channel as u32)
+            .collect::<Vec<u32>>();
+        if channels.len() < N {
+            channels.resize(N, AudioChannel::UNKNOWN as u32);
+        }
+        channels.try_into().unwrap()
+    }
+}
+
+impl Deref for AudioChannelPosition {
+    type Target = Vec<AudioChannel>;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl_array_id_deserializer!(AudioChannelPosition, AudioChannel);

--- a/pipewire-spa-utils/src/audio/raw.rs
+++ b/pipewire-spa-utils/src/audio/raw.rs
@@ -1,0 +1,63 @@
+use audio::{AudioChannelPosition, AudioSampleFormat};
+use format::{MediaSubtype, MediaType};
+use libspa::pod::deserialize::{DeserializeError, DeserializeSuccess, ObjectPodDeserializer, PodDeserialize, PodDeserializer, Visitor};
+use utils::{IdOrEnumId, IntOrChoiceInt, IntOrRangeInt32};
+
+#[derive(Debug, Clone)]
+pub struct AudioInfoRaw {
+    pub media_type: MediaType,
+    pub media_subtype: MediaSubtype,
+    pub sample_format: IdOrEnumId<AudioSampleFormat>,
+    pub sample_rate: IntOrRangeInt32,
+    pub channels: IntOrChoiceInt,
+    pub position: AudioChannelPosition
+}
+
+impl<'de> PodDeserialize<'de> for AudioInfoRaw {
+    fn deserialize(
+        deserializer: PodDeserializer<'de>,
+    ) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+    where
+        Self: Sized,
+    {
+        struct EnumFormatVisitor;
+        
+        impl<'de> Visitor<'de> for EnumFormatVisitor {
+            type Value = AudioInfoRaw;
+            type ArrayElem = std::convert::Infallible;
+        
+            fn visit_object(
+                &self,
+                object_deserializer: &mut ObjectPodDeserializer<'de>,
+            ) -> Result<Self::Value, DeserializeError<&'de [u8]>> {                
+                let media_type = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_mediaType)?
+                    .0;
+                let media_subtype = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_mediaSubtype)?
+                    .0;
+                let sample_format = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_AUDIO_format)?
+                    .0;
+                let sample_rate = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_AUDIO_rate)?
+                    .0;
+                let channels = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_AUDIO_channels)?
+                    .0;
+                let position = object_deserializer
+                    .deserialize_property_key(libspa::sys::SPA_FORMAT_AUDIO_position)?
+                    .0;
+                Ok(AudioInfoRaw {
+                    media_type,
+                    media_subtype,
+                    sample_format,
+                    sample_rate,
+                    channels,
+                    position,
+                })
+            }
+        }
+        deserializer.deserialize_object(EnumFormatVisitor)
+    }
+}

--- a/pipewire-spa-utils/src/format/mod.rs
+++ b/pipewire-spa-utils/src/format/mod.rs
@@ -1,0 +1,12 @@
+use libspa::utils::Id;
+use libspa::pod::deserialize::DeserializeError;
+use libspa::pod::deserialize::DeserializeSuccess;
+use libspa::pod::deserialize::PodDeserialize;
+use libspa::pod::deserialize::PodDeserializer;
+use libspa::pod::deserialize::IdVisitor;
+use ::{impl_id_deserializer};
+
+include!(concat!(env!("OUT_DIR"), "/format.rs"));
+
+impl_id_deserializer!(MediaType);
+impl_id_deserializer!(MediaSubtype);

--- a/pipewire-spa-utils/src/lib.rs
+++ b/pipewire-spa-utils/src/lib.rs
@@ -1,0 +1,5 @@
+extern crate libspa;
+mod macros;
+pub mod format;
+pub mod audio;
+pub mod utils;

--- a/pipewire-spa-utils/src/macros/mod.rs
+++ b/pipewire-spa-utils/src/macros/mod.rs
@@ -1,0 +1,115 @@
+#[macro_export]
+macro_rules! impl_id_deserializer {
+    (
+        $name:ident
+    ) => {        
+        impl From<Id> for $name {
+            fn from(value: Id) -> Self {
+                value.0.into()
+            }
+        }
+
+        impl<'de> PodDeserialize<'de> for $name {
+            fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+            where
+                Self: Sized
+            {
+                let res = deserializer.deserialize_id(IdVisitor)?;
+                Ok((res.0.into(), res.1))
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_choice_id_deserializer {
+    (
+        $name:ident
+    ) => {
+        impl From<Choice<Id>> for $name {
+            fn from(value: Choice<Id>) -> Self {
+                value.1.into()
+            }
+        }
+
+        impl<'de> PodDeserialize<'de> for $name {
+            fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+            where
+                Self: Sized
+            {
+                let res = deserializer.deserialize_choice(ChoiceIdVisitor)?;
+                Ok((res.0.into(), res.1))
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_choice_int_deserializer {
+    (
+        $name:ident
+    ) => {
+        impl From<Choice<i32>> for $name {
+            fn from(value: Choice<i32>) -> Self {
+                value.1.into()
+            }
+        }
+
+        impl<'de> PodDeserialize<'de> for $name {
+            fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+            where
+                Self: Sized
+            {
+                let res = deserializer.deserialize_choice(ChoiceIntVisitor)?;
+                Ok((res.0.into(), res.1))
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_array_id_deserializer {
+    (
+        $array_name:ident,
+        $item_name:ident
+    ) => {
+        impl From<&Id> for $item_name {
+            fn from(value: &Id) -> Self {
+                value.0.into()
+            }
+        }
+
+        impl From<Vec<Id>> for $array_name {
+            fn from(value: Vec<Id>) -> Self {
+                $array_name(value.iter().map(|id| id.into()).collect())
+            }
+        }
+
+        impl<'de> PodDeserialize<'de> for $array_name {
+            fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+            where
+                Self: Sized
+            {
+                let res = deserializer.deserialize_array(VecVisitor::default())?;
+                Ok((res.0.into(), res.1))
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_any_deserializer {
+    (
+        $name:ident
+    ) => {
+        impl<'de> PodDeserialize<'de> for $name {
+            fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+            where
+                Self: Sized
+            {
+                let res = deserializer.deserialize_any()?;
+                Ok((res.0.into(), res.1))
+            }
+        }
+    }
+}

--- a/pipewire-spa-utils/src/utils/mod.rs
+++ b/pipewire-spa-utils/src/utils/mod.rs
@@ -1,0 +1,255 @@
+use libspa::pod::deserialize::DeserializeError;
+use libspa::pod::deserialize::DeserializeSuccess;
+use libspa::pod::deserialize::PodDeserialize;
+use libspa::pod::deserialize::PodDeserializer;
+use libspa::pod::deserialize::{ChoiceIdVisitor, ChoiceIntVisitor};
+use libspa::pod::{ChoiceValue, Value};
+use libspa::utils::{Choice, ChoiceEnum, Id};
+use std::ops::Deref;
+use ::impl_any_deserializer;
+use impl_choice_int_deserializer;
+
+#[derive(Debug, Clone)]
+pub struct IntOrChoiceInt(u32);
+
+impl From<u32> for IntOrChoiceInt {
+    fn from(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl From<ChoiceValue> for IntOrChoiceInt {
+    fn from(value: ChoiceValue) -> Self {
+        match value {
+            ChoiceValue::Int(value) => value.into(),
+            _ => panic!("Expected Int or ChoiceValue::Int"),
+        }
+    }
+}
+
+impl From<Choice<i32>> for IntOrChoiceInt {
+    fn from(value: Choice<i32>) -> Self {
+        match value.1 {
+            ChoiceEnum::None(value) => IntOrChoiceInt(value as u32),
+            _ => panic!("Expected ChoiceEnum::None"),
+        }
+    }
+}
+
+impl From<Value> for IntOrChoiceInt {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(value) => Self(value as u32),
+            Value::Choice(value) => value.into(),
+            _ => panic!("Expected Int or Choice")
+        }
+    }
+}
+
+impl Deref for IntOrChoiceInt {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl_any_deserializer!(IntOrChoiceInt);
+
+#[derive(Debug, Clone)]
+pub struct RangeInt32 {
+    pub value: u32,
+    pub minimum: u32,
+    pub maximum: u32,
+}
+
+impl RangeInt32 {
+    fn new(value: u32, minimum: u32, maximum: u32) -> Self {
+        Self {
+            value,
+            minimum,
+            maximum,
+        }
+    }
+}
+
+impl From<ChoiceEnum<i32>> for RangeInt32 {
+    fn from(value: ChoiceEnum<i32>) -> Self {
+        match value {
+            ChoiceEnum::Range {
+                default, min, max
+            } => RangeInt32::new(
+                default as u32, min as u32, max as u32,
+            ),
+            _ => panic!("Expected ChoiceEnum<i32>::Range")
+        }
+    }
+}
+
+impl_choice_int_deserializer!(RangeInt32);
+
+#[derive(Debug, Clone)]
+pub struct IntOrRangeInt32(RangeInt32);
+
+impl From<u32> for IntOrRangeInt32 {
+    fn from(value: u32) -> Self {
+        Self(RangeInt32::new(value, value, value))
+    }
+}
+
+impl From<i32> for IntOrRangeInt32 {
+    fn from(value: i32) -> Self {
+        Self(RangeInt32::new(value as u32, value as u32, value as u32))
+    }
+}
+
+impl From<ChoiceValue> for IntOrRangeInt32 {
+    fn from(value: ChoiceValue) -> Self {
+        match value {
+            ChoiceValue::Int(value) => value.into(),
+            _ => panic!("Expected ChoiceValue::Int")
+        }
+    }
+}
+
+impl From<Choice<i32>> for IntOrRangeInt32 {
+
+    fn from(value: Choice<i32>) -> Self {
+        match value.1 {
+            ChoiceEnum::None(value) => {
+                Self(RangeInt32::new(value as u32, value as u32, value as u32))
+            }
+            ChoiceEnum::Range { default, min, max } => {
+                Self(RangeInt32::new(default as u32, min as u32, max as u32))
+            }
+            _ => panic!("Expected Choice<i32>::None or Choice<i32>::Range")
+        }
+    }
+}
+
+impl From<Value> for IntOrRangeInt32 {
+
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Int(value) => Self::from(value),
+            Value::Choice(value) => value.into(),
+            _ => panic!("Expected Int or Choice")
+        }
+    }
+}
+
+impl Deref for IntOrRangeInt32 {
+    type Target = RangeInt32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl_any_deserializer!(IntOrRangeInt32);
+
+#[derive(Debug, Clone)]
+pub struct EnumId<T> {
+    pub default: T,
+    pub alternatives: Vec<T>,
+}
+
+impl <T: Ord> EnumId<T> {
+    fn new(default: T, mut alternatives: Vec<T>) -> Self {
+        alternatives.sort_by(move |a, b| {
+            a.cmp(b)
+        });
+        Self {
+            default,
+            alternatives,
+        }
+    }
+}
+
+impl <T: From<u32> + Ord> From<ChoiceEnum<Id>> for EnumId<T> {
+    fn from(value: ChoiceEnum<Id>) -> Self {
+        match value {
+            ChoiceEnum::Enum {
+                default, alternatives
+            } => EnumId::new(
+                default.0.into(),
+                alternatives.into_iter()
+                    .map(move |id| id.0.into())
+                    .collect(),
+            ),
+            _ => panic!("Expected ChoiceEnum<Id>::Enum")
+        }
+    }
+}
+
+impl <T: From<u32> + Ord> From<Choice<Id>> for EnumId<T> {
+    fn from(value: Choice<Id>) -> Self {
+        value.1.into()
+    }
+}
+
+impl <'de, T: From<u32> + Ord> PodDeserialize<'de> for EnumId<T> {
+    fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+    where
+        Self: Sized
+    {
+        let res = deserializer.deserialize_choice(ChoiceIdVisitor)?;
+        Ok((res.0.into(), res.1))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IdOrEnumId<T>(EnumId<T>);
+
+impl <T: From<u32> + Ord> From<ChoiceValue> for IdOrEnumId<T> {
+    fn from(value: ChoiceValue) -> Self {
+        match value {
+            ChoiceValue::Id(value) => value.into(),
+            _ => panic!("Expected ChoiceValue::Id")
+        }
+    }
+}
+
+impl <T: From<u32> + Ord> From<Choice<Id>> for IdOrEnumId<T> {
+    fn from(value: Choice<Id>) -> Self {
+        match value.1 {
+            ChoiceEnum::Enum { default, alternatives } => {
+                Self(EnumId::new(
+                    default.0.into(),
+                    alternatives.into_iter()
+                        .map(move |id| id.0.into())
+                        .collect::<Vec<T>>()
+                ))
+            }
+            _ => panic!("Expected Choice<Id>::Enum")
+        }
+    }
+}
+
+impl <T: From<u32> + Ord> From<Value> for IdOrEnumId<T> {
+    fn from(value: Value) -> Self {
+        match value {
+            Value::Id(value) => Self(EnumId::new(value.0.into(), vec![value.0.into()])),
+            Value::Choice(value) => value.into(),
+            _ => panic!("Expected Id or Choice")
+        }
+    }
+}
+
+impl <T> Deref for IdOrEnumId<T> {
+    type Target = EnumId<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl <'de, T: From<u32> + Ord> PodDeserialize<'de> for IdOrEnumId<T> {
+    fn deserialize(deserializer: PodDeserializer<'de>) -> Result<(Self, DeserializeSuccess<'de>), DeserializeError<&'de [u8]>>
+    where
+        Self: Sized
+    {
+        let res = deserializer.deserialize_any()?;
+        Ok((res.0.into(), res.1))
+    }
+}

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -21,6 +21,16 @@ pub(crate) mod emscripten;
     feature = "jack"
 ))]
 pub(crate) mod jack;
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd"
+    ),
+    feature = "pipewire"
+))]
+pub(crate)mod pipewire;
 pub(crate) mod null;
 #[cfg(target_os = "android")]
 pub(crate) mod oboe;

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -1,0 +1,208 @@
+use crate::host::pipewire::utils::{AudioBuffer, FromStreamConfigWithSampleFormat};
+use crate::host::pipewire::Stream;
+use crate::traits::DeviceTrait;
+use crate::{BackendSpecificError, BuildStreamError, Data, DefaultStreamConfigError, DeviceNameError, InputCallbackInfo, InputStreamTimestamp, OutputCallbackInfo, OutputStreamTimestamp, SampleFormat, SampleRate, StreamConfig, StreamError, StreamInstant, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange, SupportedStreamConfigsError};
+use std::rc::Rc;
+use std::time::Duration;
+use pipewire_client::{AudioStreamInfo, Direction, PipewireClient, NodeInfo};
+use pipewire_client::spa_utils::audio::raw::AudioInfoRaw;
+
+pub type SupportedInputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+
+#[derive(Debug, Clone)]
+pub struct Device {
+    pub(super) id: u32,
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) nickname: String,
+    pub(crate) direction: Direction,
+    pub(super) is_default: bool,
+    pub(crate) format: AudioInfoRaw,
+    pub(super) client: Rc<PipewireClient>,
+}
+
+impl Device {
+    pub(super) fn from(
+        info: &NodeInfo,
+        client: Rc<PipewireClient>,
+    ) -> Result<Self, String> {
+        Ok(Self {
+            id: info.id.clone(),
+            name: info.name.clone(),
+            description: info.description.clone(),
+            nickname: info.nickname.clone(),
+            direction: info.direction.clone(),
+            is_default: info.is_default.clone(),
+            format: info.format.clone(),
+            client,
+        })
+    }
+
+    pub fn default_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        let settings = match self.client.settings() {
+            Ok(value) => value,
+            Err(value) => return Err(DefaultStreamConfigError::BackendSpecific {
+                err: BackendSpecificError {
+                    description: value.description,
+                }
+            }),
+        };
+        Ok(SupportedStreamConfig {
+            channels: *self.format.channels as u16,
+            sample_rate: SampleRate(self.format.sample_rate.value),
+            buffer_size: SupportedBufferSize::Range {
+                min: settings.min_buffer_size,
+                max: settings.max_buffer_size,
+            },
+            sample_format: self.format.sample_format.default.try_into()?,
+        })
+    }
+
+    pub fn supported_configs(&self) -> Vec<SupportedStreamConfigRange> {
+        let f = match self.default_config() {
+            Err(_) => return vec![],
+            Ok(f) => f,
+        };
+        let mut supported_configs = vec![];
+        for &sample_format in self.format.sample_format.alternatives.iter() {
+            supported_configs.push(SupportedStreamConfigRange {
+                channels: f.channels,
+                min_sample_rate: SampleRate(self.format.sample_rate.minimum),
+                max_sample_rate: SampleRate(self.format.sample_rate.maximum),
+                buffer_size: f.buffer_size.clone(),
+                sample_format: sample_format.try_into().unwrap(),
+            });
+        }
+        supported_configs
+    }
+    
+    fn build_stream_raw<D, E> (
+        &self,
+        direction: Direction,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        mut data_callback: D,
+        error_callback: E,
+        timeout: Option<Duration>,
+    ) -> Result<Stream, BuildStreamError> where
+        D: FnMut(&mut Data) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        let format: AudioStreamInfo = FromStreamConfigWithSampleFormat::from((config, sample_format));
+        let channels = config.channels;
+        let stream_name = self.client.create_stream(
+            self.id,
+            direction,
+            format,
+            move |buffer| {
+                let mut buffer = AudioBuffer::from(
+                    buffer, 
+                    sample_format,
+                    channels
+                );
+                let data = buffer.data();
+                if data.is_none() {
+                    return;
+                }
+                let mut data = data.unwrap();
+                data_callback(&mut data)
+            }
+        ).unwrap();
+        Ok(Stream::new(stream_name, self.client.clone()))
+    }
+}
+
+impl DeviceTrait for Device {
+    type SupportedInputConfigs = SupportedInputConfigs;
+    type SupportedOutputConfigs = SupportedOutputConfigs;
+    type Stream = Stream;
+
+    fn name(&self) -> Result<String, DeviceNameError> {
+        Ok(self.nickname.clone())
+    }
+
+    fn supported_input_configs(
+        &self,
+    ) -> Result<Self::SupportedInputConfigs, SupportedStreamConfigsError> {
+        Ok(self.supported_configs().into_iter())
+    }
+
+    fn supported_output_configs(
+        &self,
+    ) -> Result<Self::SupportedOutputConfigs, SupportedStreamConfigsError> {
+        Ok(self.supported_configs().into_iter())
+    }
+
+    fn default_input_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.default_config()
+    }
+
+    fn default_output_config(&self) -> Result<SupportedStreamConfig, DefaultStreamConfigError> {
+        self.default_config()
+    }
+
+    fn build_input_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        mut data_callback: D,
+        error_callback: E,
+        timeout: Option<Duration>,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&Data, &InputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        self.build_stream_raw(
+            Direction::Input,
+            config,
+            sample_format,
+            move |data| {
+                data_callback(
+                    data,
+                    &InputCallbackInfo {
+                        timestamp: InputStreamTimestamp {
+                            callback: StreamInstant::from_nanos(0),
+                            capture: StreamInstant::from_nanos(0),
+                        },
+                    }
+                )
+            },
+            error_callback,
+            timeout
+        )
+    }
+
+    fn build_output_stream_raw<D, E>(
+        &self,
+        config: &StreamConfig,
+        sample_format: SampleFormat,
+        mut data_callback: D,
+        error_callback: E,
+        timeout: Option<Duration>,
+    ) -> Result<Self::Stream, BuildStreamError>
+    where
+        D: FnMut(&mut Data, &OutputCallbackInfo) + Send + 'static,
+        E: FnMut(StreamError) + Send + 'static,
+    {
+        self.build_stream_raw(
+            Direction::Output,
+            config,
+            sample_format,
+            move |data| {
+                data_callback(
+                    data,
+                    &OutputCallbackInfo {
+                        timestamp: OutputStreamTimestamp {
+                            callback: StreamInstant::from_nanos(0),
+                            playback: StreamInstant::from_nanos(0),
+                        },
+                    }
+                )
+            },
+            error_callback,
+            timeout
+        )
+    }
+}

--- a/src/host/pipewire/host.rs
+++ b/src/host/pipewire/host.rs
@@ -1,0 +1,79 @@
+use crate::traits::HostTrait;
+use crate::{BackendSpecificError, DevicesError, HostUnavailable, SupportedStreamConfigRange};
+use std::rc::Rc;
+use pipewire_client::{Direction, PipewireClient};
+use crate::host::pipewire::Device;
+
+pub type SupportedInputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type SupportedOutputConfigs = std::vec::IntoIter<SupportedStreamConfigRange>;
+pub type Devices = std::vec::IntoIter<Device>;
+
+#[derive(Debug)]
+pub struct Host {
+    client: Rc<PipewireClient>,
+}
+
+impl Host {
+    pub fn new() -> Result<Self, HostUnavailable> {
+        let client = PipewireClient::new()
+            .map_err(move |error| {
+                eprintln!("{}", error.description);
+                HostUnavailable
+            })?;
+        let client = Rc::new(client);
+        let host = Host { client };
+        Ok(host)
+    }
+
+    fn default_device(&self, direction: Direction) -> Option<Device> {
+        self.devices()
+            .unwrap()
+            .filter(move |device| device.direction == direction && device.is_default)
+            .collect::<Vec<_>>()
+            .first()
+            .cloned()
+    }
+}
+
+impl HostTrait for Host {
+    type Devices = Devices;
+    type Device = Device;
+
+    fn is_available() -> bool {
+        true
+    }
+
+    fn devices(&self) -> Result<Self::Devices, DevicesError> {
+        let input_devices = match self.client.enumerate_nodes(Direction::Input) {
+            Ok(values) => values.into_iter(),
+            Err(value) => return Err(DevicesError::BackendSpecific {
+                err: BackendSpecificError {
+                    description: value.description,
+                },
+            }),
+        };
+        let output_devices = match self.client.enumerate_nodes(Direction::Output) {
+            Ok(values) => values.into_iter(),
+            Err(value) => return Err(DevicesError::BackendSpecific {
+                err: BackendSpecificError {
+                    description: value.description,
+                },
+            }),
+        };
+        let devices = input_devices.chain(output_devices)
+            .map(move |device| {
+                Device::from(&device, self.client.clone()).unwrap()
+            })
+            .collect::<Vec<_>>()
+            .into_iter();
+        Ok(devices)
+    }
+
+    fn default_input_device(&self) -> Option<Self::Device> {
+        self.default_device(Direction::Input)
+    }
+
+    fn default_output_device(&self) -> Option<Self::Device> {
+        self.default_device(Direction::Output)
+    }
+}

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,0 +1,11 @@
+mod host;
+pub use self::host::Host;
+pub use self::host::Devices;
+pub use self::host::SupportedInputConfigs;
+pub use self::host::SupportedOutputConfigs;
+mod device;
+
+pub use self::device::Device;
+mod stream;
+pub use self::stream::Stream;
+mod utils;

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -1,0 +1,36 @@
+use std::rc::Rc;
+use pipewire_client::PipewireClient;
+use crate::{PauseStreamError, PlayStreamError};
+use crate::traits::StreamTrait;
+
+pub struct Stream {
+    name: String,
+    client: Rc<PipewireClient>,
+}
+
+impl Stream {
+    pub(super) fn new(name: String, client: Rc<PipewireClient>) -> Self {
+        Self {
+            name,
+            client,
+        }
+    }
+}
+
+impl StreamTrait for Stream {
+    fn play(&self) -> Result<(), PlayStreamError> {
+        self.client.connect_stream(self.name.clone()).unwrap();
+        Ok(())
+    }
+
+    fn pause(&self) -> Result<(), PauseStreamError> {
+        self.client.disconnect_stream(self.name.clone()).unwrap();
+        Ok(())
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        self.client.delete_stream(self.name.clone()).unwrap()
+    }
+}

--- a/src/host/pipewire/utils.rs
+++ b/src/host/pipewire/utils.rs
@@ -1,0 +1,126 @@
+use pipewire_client::spa_utils::audio::{AudioChannelPosition, AudioSampleFormat, AudioSampleFormatEnum};
+use pipewire_client::spa_utils::format::{MediaType, MediaSubtype};
+use pipewire_client::{pipewire, AudioStreamInfo};
+use crate::{BackendSpecificError, ChannelCount, Data, SampleFormat, StreamConfig};
+
+impl TryFrom<SampleFormat> for AudioSampleFormat {
+    type Error = BackendSpecificError;
+
+    fn try_from(value: SampleFormat) -> Result<Self, Self::Error> {
+        let value = match value {
+            SampleFormat::I8 => AudioSampleFormat::S8,
+            SampleFormat::U8 => AudioSampleFormat::U8,
+            SampleFormat::I16 => AudioSampleFormat::S16_LE,
+            SampleFormat::U16 => AudioSampleFormat::U16_LE,
+            SampleFormat::I32 => AudioSampleFormat::S32_LE,
+            SampleFormat::U32 => AudioSampleFormat::U32_LE,
+            SampleFormat::F32 => AudioSampleFormat::F32_LE,
+            SampleFormat::F64 => AudioSampleFormat::F64_LE,
+            _ => return Err(BackendSpecificError {
+                description: "Unsupported sample format".to_string(),
+            })};
+        Ok(value)
+    }
+}
+
+impl TryFrom<AudioSampleFormat> for SampleFormat {
+    type Error = BackendSpecificError;
+
+    fn try_from(value: AudioSampleFormat) -> Result<Self, Self::Error> {
+        let value = match value {
+            AudioSampleFormat::S8 => SampleFormat::I8,
+            AudioSampleFormat::U8 => SampleFormat::U8,
+            AudioSampleFormat::S16_LE => SampleFormat::I16,
+            AudioSampleFormat::U16_LE => SampleFormat::U16,
+            AudioSampleFormat::S32_LE => SampleFormat::I32,
+            AudioSampleFormat::U32_LE => SampleFormat::U32,
+            AudioSampleFormat::F32_LE => SampleFormat::F32,
+            AudioSampleFormat::F64_LE => SampleFormat::F64,
+            _ => return Err(BackendSpecificError {
+                description: "Unsupported sample format".to_string(),
+            })};
+            Ok(value)
+    }
+}
+
+impl TryFrom<AudioSampleFormatEnum> for SampleFormat {
+    type Error = BackendSpecificError;
+
+    fn try_from(value: AudioSampleFormatEnum) -> Result<Self, Self::Error> {
+        let sample_format = SampleFormat::try_from(value.default);
+        if sample_format.is_ok() {
+            return sample_format;
+        }
+        let sample_format = value.alternatives.iter()
+            .map(move |sample_format| {
+                SampleFormat::try_from(sample_format.clone())
+            })
+            .filter(move |result| result.is_ok())
+            .last();
+        sample_format.unwrap()
+    }
+}
+
+pub trait FromStreamConfigWithSampleFormat {
+    fn from(value: (&StreamConfig, SampleFormat)) -> Self;
+}
+
+impl FromStreamConfigWithSampleFormat for AudioStreamInfo {
+    fn from(value: (&StreamConfig, SampleFormat)) -> Self {
+        Self {
+            media_type: MediaType::Audio,
+            media_subtype: MediaSubtype::Raw,
+            sample_format: value.1.try_into().unwrap(),
+            sample_rate: value.0.sample_rate.0,
+            channels: value.0.channels as u32,
+            position: AudioChannelPosition::default(),
+        }
+    }
+}
+
+pub(super) struct AudioBuffer<'a> {
+    buffer: pipewire::buffer::Buffer<'a>,
+    sample_format: SampleFormat,
+    channels: ChannelCount,
+}
+
+impl <'a> AudioBuffer<'a> {
+    pub fn from(
+        buffer: pipewire::buffer::Buffer<'a>,
+        sample_format: SampleFormat,
+        channels: ChannelCount,
+    ) -> Self {
+        Self {
+            buffer,
+            sample_format,
+            channels
+        }
+    }
+    
+    pub fn data(&mut self) -> Option<Data> {
+        let datas = self.buffer.datas_mut();
+        let data = &mut datas[0];
+
+        let stride = self.sample_format.sample_size() * self.channels as usize;
+
+        let data_info = if let Some(data) = data.data() {
+            let len = data.len();
+            let data = unsafe {
+                Some(Data::from_parts(
+                    data.as_mut_ptr() as *mut (),
+                    data.len() / self.sample_format.sample_size(),
+                    self.sample_format,
+                ))
+            };
+            (data, len)
+        }
+        else {
+            return None
+        };
+        let chunk = data.chunk_mut();
+        *chunk.offset_mut() = 0;
+        *chunk.stride_mut() = stride as i32;
+        *chunk.size_mut() = data_info.1 as u32;
+        data_info.0
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -607,8 +607,18 @@ mod platform_impl {
         SupportedInputConfigs as JackSupportedInputConfigs,
         SupportedOutputConfigs as JackSupportedOutputConfigs,
     };
+    #[cfg(feature = "pipewire")]
+    pub use crate::host::pipewire::{
+        Device as PipeWireDevice, Devices as PipeWireDevices, Host as PipeWireHost,
+        Stream as PipeWireStream, SupportedInputConfigs as PipeWireSupportedInputConfigs,
+        SupportedOutputConfigs as PipeWireSupportedOutputConfigs,
+    };
 
-    impl_platform_host!(#[cfg(feature = "jack")] Jack jack "JACK", Alsa alsa "ALSA");
+    impl_platform_host!(
+        #[cfg(feature = "pipewire")] PipeWire pipewire "PipeWire", 
+        #[cfg(feature = "jack")] Jack jack "JACK", 
+        Alsa alsa "ALSA"
+    );
 
     /// The default host for the current compilation target platform.
     pub fn default_host() -> Host {


### PR DESCRIPTION
PipeWire implementation based on pipewire/pipewire-rs/doc and others draft PRs in this repository (thanks to them).

There is two additional crates, one for the PW client and one for SPA utils (used for some POD deserialization).

Client capabilities:
- Retrieve all Audio/(Sink/Source) nodes
- Retrieve metadata for global settings and default audio nodes (provided by session manager, AKA WirePlumber)
- Create and manage stream
- Create virtual node 

I updated some CPAL examples (enumerate and beep).

TODO (just some ideas):
- Duplex audio node:
    - Can be useful as a "loopback" device. In CPAL that mean input stream can be retrieved, updated and injected in output stream. Need a POC, I'm just supposing.
- Updating Port/Link of an audio node: Use case, a virtual node is a DSP (EQ, Reverb, ...), clients nodes (Spotify, browser, ...), audio node (sound card playback). DSP node will be inserted between clients nodes and audio node, with all ports/links remapped correctly.
- Subscribe to node/stream events: stream format or parameters changed, same for node. 

I'm posting this PR as draft for now, if you have any suggestion/feedback or particular use cases, I'm glad to discuss it.



