### PR TITLE
Add/make public constructors for InputCallbackInfo, OutputCallbackInfo and StreamInstant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,7 @@ impl StreamInstant {
         Self::new(s, ns)
     }
 
-    fn new(secs: i64, nanos: u32) -> Self {
+    pub fn new(secs: i64, nanos: u32) -> Self {
         StreamInstant { secs, nanos }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,6 +332,7 @@ pub struct Data {
 /// | wasapi | `QueryPerformanceCounter` |
 /// | asio | `timeGetTime` |
 /// | emscripten | `AudioContext.getOutputTimestamp` |
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct StreamInstant {
     secs: i64,
@@ -339,6 +340,7 @@ pub struct StreamInstant {
 }
 
 /// A timestamp associated with a call to an input stream's data callback.
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct InputStreamTimestamp {
     /// The instant the stream's data callback was invoked.
@@ -350,6 +352,7 @@ pub struct InputStreamTimestamp {
 }
 
 /// A timestamp associated with a call to an output stream's data callback.
+#[cfg_attr(target_os = "emscripten", wasm_bindgen)]
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct OutputStreamTimestamp {
     /// The instant the stream's data callback was invoked.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,10 @@ impl StreamInstant {
 }
 
 impl InputCallbackInfo {
+    pub fn new(timestamp: InputStreamTimestamp) -> Self {
+        Self { timestamp }
+    }
+
     /// The timestamp associated with the call to an input stream's data callback.
     pub fn timestamp(&self) -> InputStreamTimestamp {
         self.timestamp
@@ -492,6 +496,10 @@ impl InputCallbackInfo {
 }
 
 impl OutputCallbackInfo {
+    pub fn new(timestamp: OutputStreamTimestamp) -> Self {
+        Self { timestamp }
+    }
+
     /// The timestamp associated with the call to an output stream's data callback.
     pub fn timestamp(&self) -> OutputStreamTimestamp {
         self.timestamp


### PR DESCRIPTION
Bumping #899 but follows the same convention as #679, using constructors rather than public fields.