### PR TITLE
Fix macos non-default audio output

### DIFF
--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -296,7 +296,18 @@ impl Device {
             let ranges: *mut AudioValueRange = ranges.as_mut_ptr() as *mut _;
             let ranges: &'static [AudioValueRange] = slice::from_raw_parts(ranges, n_ranges);
 
-            let audio_unit = audio_unit_from_device(self, true)?;
+            #[allow(non_upper_case_globals)]
+            let input = match scope {
+                kAudioObjectPropertyScopeInput => Ok(true),
+                kAudioObjectPropertyScopeOutput => Ok(false),
+                _ => Err(BackendSpecificError {
+                    description: format!(
+                        "unexpected scope (neither input nor output): {:?}",
+                        scope
+                    ),
+                }),
+            }?;
+            let audio_unit = audio_unit_from_device(self, input)?;
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             // Collect the supported formats for the device.
@@ -398,7 +409,18 @@ impl Device {
                 }
             };
 
-            let audio_unit = audio_unit_from_device(self, true)?;
+            #[allow(non_upper_case_globals)]
+            let input = match scope {
+                kAudioObjectPropertyScopeInput => Ok(true),
+                kAudioObjectPropertyScopeOutput => Ok(false),
+                _ => Err(BackendSpecificError {
+                    description: format!(
+                        "unexpected scope (neither input nor output): {:?}",
+                        scope
+                    ),
+                }),
+            }?;
+            let audio_unit = audio_unit_from_device(self, input)?;
             let buffer_size = get_io_buffer_frame_size_range(&audio_unit)?;
 
             let config = SupportedStreamConfig {


### PR DESCRIPTION
This patch fixes playing to an an output device other than the default. Such as playing to built-in speakers when headphones are plugged in and the default.

Here is a snippet from the `enumerate` example from before. The error coming from within `audio_unit_from_device` when its `input` parameter was mistakenly `true`.
```
  8. "MacBook Pro Speakers"
    Error getting supported output configs: BackendSpecific { err: BackendSpecificError { description: "Invalid property value" } }
```

Here is the output of the `feedback` example from before the fix:
```
$ RUST_BACKTRACE=1 cargo run --example feedback -- -i "USB Audio CODEC " -o "MacBook Pro Speakers"
﻿    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/examples/feedback -i 'USB Audio CODEC ' -o 'MacBook Pro Speakers'`
thread 'main' panicked at examples/feedback.rs:98:6:
failed to find output device
stack backtrace:
   0: rust_begin_unwind
             at /rustc/e71f9a9a98b0faf423844bf0ba7438f29dc27d58/library/std/src/panicking.rs:665:5
   1: core::panicking::panic_fmt
             at /rustc/e71f9a9a98b0faf423844bf0ba7438f29dc27d58/library/core/src/panicking.rs:76:14
   2: core::panicking::panic_display
             at /rustc/e71f9a9a98b0faf423844bf0ba7438f29dc27d58/library/core/src/panicking.rs:269:5
   3: core::option::expect_failed
             at /rustc/e71f9a9a98b0faf423844bf0ba7438f29dc27d58/library/core/src/option.rs:2018:5
   4: core::option::Option<T>::expect
             at /Users/miles/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:933:21
   5: feedback::main
             at ./examples/feedback.rs:92:25
   6: core::ops::function::FnOnce::call_once
             at /Users/miles/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```