### PR TITLE
Make Platform Impl SupportedConfigs `Clone`

### DIFF
--- a/src/host/null/mod.rs
+++ b/src/host/null/mod.rs
@@ -19,7 +19,9 @@ pub struct Host;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Stream;
 
+#[derive(Clone)]
 pub struct SupportedInputConfigs;
+#[derive(Clone)]
 pub struct SupportedOutputConfigs;
 
 impl Host {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -74,10 +74,12 @@ macro_rules! impl_platform_host {
 
         /// The `SupportedInputConfigs` iterator associated with the platform's dynamically
         /// dispatched [`Host`] type.
+        #[derive(Clone)]
         pub struct SupportedInputConfigs(SupportedInputConfigsInner);
 
         /// The `SupportedOutputConfigs` iterator associated with the platform's dynamically
         /// dispatched [`Host`] type.
+        #[derive(Clone)]
         pub struct SupportedOutputConfigs(SupportedOutputConfigsInner);
 
         /// Unique identifier for available hosts on the platform.
@@ -122,6 +124,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
+        #[derive(Clone)]
         enum SupportedInputConfigsInner {
             $(
                 $(#[cfg($feat)])?
@@ -129,6 +132,7 @@ macro_rules! impl_platform_host {
             )*
         }
 
+        #[derive(Clone)]
         enum SupportedOutputConfigsInner {
             $(
                 $(#[cfg($feat)])?


### PR DESCRIPTION
Works on my machine :p

Did a quick check over the different hosts, and it looks like literally all of them are identical except for the Null host, so it should be fine on all other platforms.