### PR TITLE
Fix clippy lints.

### DIFF
--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -21,7 +21,7 @@ impl Devices {
 unsafe impl Send for Devices {}
 unsafe impl Sync for Devices {}
 
-const BUILTINS: [&'static str; 5] = ["default", "pipewire", "pulse", "jack", "oss"];
+const BUILTINS: [&str; 5] = ["default", "pipewire", "pulse", "jack", "oss"];
 
 impl Iterator for Devices {
     type Item = Device;
@@ -32,7 +32,7 @@ impl Iterator for Devices {
             self.builtin_pos += 1;
             let name = BUILTINS[pos];
 
-            if let Ok(handles) = DeviceHandles::open(&name) {
+            if let Ok(handles) = DeviceHandles::open(name) {
                 return Some(Device {
                     name: name.to_string(),
                     pcm_id: name.to_string(),
@@ -42,9 +42,7 @@ impl Iterator for Devices {
         }
 
         loop {
-            let Some(res) = self.card_iter.next() else {
-                return None;
-            };
+            let res = self.card_iter.next()?;
             let Ok(card) = res else { continue };
 
             let ctl_id = format!("hw:{}", card.get_index());

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -429,9 +429,9 @@ impl Device {
                 for &(min_rate, max_rate) in sample_rates.iter() {
                     output.push(SupportedStreamConfigRange {
                         channels,
-                        min_sample_rate: SampleRate(min_rate as u32),
-                        max_sample_rate: SampleRate(max_rate as u32),
-                        buffer_size: buffer_size_range.clone(),
+                        min_sample_rate: SampleRate(min_rate),
+                        max_sample_rate: SampleRate(max_rate),
+                        buffer_size: buffer_size_range,
                         sample_format,
                     });
                 }
@@ -478,7 +478,7 @@ impl Device {
 
         formats.sort_by(|a, b| a.cmp_default_heuristics(b));
 
-        match formats.into_iter().last() {
+        match formats.into_iter().next_back() {
             Some(f) => {
                 let min_r = f.min_sample_rate;
                 let max_r = f.max_sample_rate;
@@ -909,7 +909,7 @@ fn stream_timestamp(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
+    ts.tv_sec * 1_000_000_000 + ts.tv_nsec
 }
 
 // Adapted from `timediff` here:

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -909,7 +909,7 @@ fn stream_timestamp(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    ts.tv_sec * 1_000_000_000 + ts.tv_nsec
+    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
 }
 
 // Adapted from `timediff` here:

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -46,8 +46,14 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
+    // `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
+    // U24,
+
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
+
+    // `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
+    // U48,
 
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.
     U64,

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -46,13 +46,13 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
-    // `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
+    /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
 
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
 
-    // `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
+    /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
 
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -46,14 +46,8 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
-    /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
-    // U24,
-
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
-
-    /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
-    // U48,
 
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.
     U64,


### PR DESCRIPTION
Only fixes for alsa and shared components.

The only controversial one here might be removing the commented-out 24- and 48-bit ints. If anyone has context on that, please let me know.