### PR TITLE
Implement `Default` for `Host`

### DIFF
--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -580,6 +580,12 @@ macro_rules! impl_platform_host {
                 )*
             }
         }
+
+        impl Default for Host {
+            fn default() -> Host {
+                default_host()
+            }
+        }
     };
 }
 


### PR DESCRIPTION
fix #973

I don't know where you want the `impl` to be placed; I just put it at the bottom of the macro.