### PR TITLE
Keep deprecated feature flag `oboe-shared-stdcxx` to avoid breaking change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ rust-version = "1.70"
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
 
+# Deprecated, the `oboe` backend has been removed
+oboe-shared-stdcxx = []
+
 [dependencies]
 dasp_sample = "0.11"
 


### PR DESCRIPTION
https://github.com/RustAudio/cpal/pull/961 removed the feature flag, which is a shame, because that means the next `cpal` release will be a breaking change. I'd like to get https://github.com/RustAudio/cpal/pull/943 out sooner rather than later (to fix [the issues Bevy and others are experiencing with `bindgen` and the iOS simulator](https://github.com/rust-lang/rust-bindgen/issues/3199)), .

So this PR re-adds the feature flag, but with a comment that it is deprecated.

One could argue that changing the backend itself is a breaking change because of the minimum supported version bump. I will argue that it is not, as there is precedent for such bumps in `rustc` as well, see e.g. [this](https://blog.rust-lang.org/2023/09/25/Increasing-Apple-Version-Requirements/) and [this](https://blog.rust-lang.org/2024/02/26/Windows-7/), and disallowing such things in non-breaking versions makes it effectively impossible for `cpal` to ever reach a stable `v1.0`.