### PR TITLE
Actually fix release date for v0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# Version 0.16.0 (2024-06-07)
+# Version 0.16.0 (2025-06-07)
 
 - Migrate from `oboe` to `ndk::audio`. **NOTE:** This raises the minimum Android API version to 26 (Android 8/Oreo).
 - `SampleFormat` now impls `PartialOrd`, `Ord` and `Hash`.


### PR DESCRIPTION
Follow-up to https://github.com/RustAudio/cpal/pull/979.