### PR TITLE
use set_buffer_size_near to calculate fixed alsa buffer size

### DIFF
--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1107,7 +1107,7 @@ fn set_hw_params_from_format(
     match config.buffer_size {
         BufferSize::Fixed(v) => {
             hw_params.set_period_size_near((v / 4) as alsa::pcm::Frames, alsa::ValueOr::Nearest)?;
-            hw_params.set_buffer_size(v as alsa::pcm::Frames)?;
+            hw_params.set_buffer_size_near(v as alsa::pcm::Frames)?;
         }
         BufferSize::Default => {
             // These values together represent a moderate latency and wakeup interval.


### PR DESCRIPTION
Fixes #743

Hardware parameters cannot be set to some arbitrary values within the supported range.

Two alternate fixes are:
- Expose the "near" ALSA function to the user
- Return the actual buffer size used

I am not familiar enough with CPAL usage to know if the alternate fixes are needed, but for my use cases they are not.