### PR TITLE
fix: enumerate ALSA devices like aplay -L

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose IMMDevice from WASAPI host Device.
+- CoreAudio: `Device::supported_configs` now returns a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values (which is the most common case).
 
 # Version 0.16.0 (2025-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose IMMDevice from WASAPI host Device.
-- CoreAudio: `Device::supported_configs` now returns a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values (which is the most common case).
 
 # Version 0.16.0 (2025-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Unreleased
 
 - ALSA(process_output): Pass `silent=true` to `PCM.try_recover`, so it doesn't write to stderr.
-- ALSA: Fix buffer and period size selection by rounding to supported values. Actual buffer size may be different from the requested size or may be a device-specified default size. Additionally sets ALSA "periods" to 2 (previously 4). (error 22)
-- CoreAudio: `Device::supported_configs` now returns a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values (which is the most common case).
-- CoreAudio: Detect default audio device lazily when building a stream, instead of during device enumeration.
+- ALSA: Fix buffer and period size by selecting the closest supported values.
+- ALSA: Change ALSA periods from 4 to 2.
+- ALSA: Change card enumeration to work like `aplay -L` does.
+- CoreAudio: Change `Device::supported_configs` to return a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values.
+- CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose IMMDevice from WASAPI host Device.
 

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -31,7 +31,7 @@ unsafe impl Sync for Devices {}
 
 fn open_device(pcm_id: &str, desc: Option<String>) -> Device {
     // Try to open handles during enumeration
-    let handles = DeviceHandles::open(&pcm_id).unwrap_or_else(|_| {
+    let handles = DeviceHandles::open(pcm_id).unwrap_or_else(|_| {
         // If opening fails during enumeration, create default handles
         // The actual opening will be attempted when the device is used
         DeviceHandles::default()

--- a/src/host/alsa/enumerate.rs
+++ b/src/host/alsa/enumerate.rs
@@ -1,30 +1,37 @@
-use super::alsa;
-use super::{Device, DeviceHandles};
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use super::{
+    alsa, {Device, DeviceHandles},
+};
 use crate::{BackendSpecificError, DevicesError};
-use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
 
 /// ALSA's implementation for `Devices`.
 pub struct Devices {
-    hint_iter: Option<alsa::device_name::HintIter>,
+    hint_iter: alsa::device_name::HintIter,
     enumerated_pcm_ids: HashSet<String>,
 }
 
 impl Devices {
     pub fn new() -> Result<Self, DevicesError> {
-        Ok(Devices {
-            hint_iter: None,
-            enumerated_pcm_ids: HashSet::new(),
-        })
+        // Enumerate ALL devices from ALSA hints (same as aplay -L)
+        alsa::device_name::HintIter::new_str(None, "pcm")
+            .map(|hint_iter| Self {
+                hint_iter,
+                enumerated_pcm_ids: HashSet::new(),
+            })
+            .map_err(DevicesError::from)
     }
 }
 
 unsafe impl Send for Devices {}
 unsafe impl Sync for Devices {}
 
-fn try_open_device(pcm_id: &str, name: String) -> Option<Device> {
+fn open_device(pcm_id: &str, desc: Option<String>) -> Device {
     // Try to open handles during enumeration
-    let handles = DeviceHandles::open(pcm_id).unwrap_or_else(|_| {
+    let handles = DeviceHandles::open(&pcm_id).unwrap_or_else(|_| {
         // If opening fails during enumeration, create default handles
         // The actual opening will be attempted when the device is used
         DeviceHandles::default()
@@ -32,70 +39,48 @@ fn try_open_device(pcm_id: &str, name: String) -> Option<Device> {
 
     // Include all devices from ALSA hints (matches `aplay -L` behavior)
     // Even devices that can't be opened during enumeration are valid for selection
-    Some(Device {
-        name,
-        pcm_id: pcm_id.to_string(),
+    Device {
+        pcm_id: pcm_id.to_owned(),
+        desc,
         handles: Arc::new(Mutex::new(handles)),
-    })
+    }
 }
 
 impl Iterator for Devices {
     type Item = Device;
 
     fn next(&mut self) -> Option<Device> {
-        // Enumerate ALL devices from ALSA hints (same as aplay -L)
-        if self.hint_iter.is_none() {
-            match alsa::device_name::HintIter::new_str(None, "pcm") {
-                Ok(iter) => self.hint_iter = Some(iter),
-                Err(_) => return None, // If hints fail, we're done
-            }
+        loop {
+            let hint = self.hint_iter.next()?;
+            let (pcm_id, desc) = match (hint.name, hint.desc) {
+                (Some(name), desc) => (name, desc),
+                _ => continue, // Skip hints without a valid PCM ID
+            };
+
+            let device = open_device(&pcm_id, desc);
+            self.enumerated_pcm_ids.insert(pcm_id);
+            return Some(device);
         }
-
-        if let Some(ref mut hint_iter) = self.hint_iter {
-            loop {
-                match hint_iter.next() {
-                    Some(hint) => {
-                        let name = match hint.name {
-                            None => continue,
-                            Some(name) => name,
-                        };
-
-                        // Skip if we've already enumerated this device by PCM ID
-                        if self.enumerated_pcm_ids.contains(&name) {
-                            continue;
-                        }
-
-                        // Include all devices from hints (same as aplay -L)
-                        if let Some(device) = try_open_device(&name, name.clone()) {
-                            self.enumerated_pcm_ids.insert(name.clone());
-                            return Some(device);
-                        }
-                    }
-                    None => return None, // All devices enumerated
-                }
-            }
-        }
-
-        None
     }
 }
 
 #[inline]
 pub fn default_input_device() -> Option<Device> {
-    Some(Device {
-        name: "default".to_owned(),
-        pcm_id: "default".to_owned(),
-        handles: Arc::new(Mutex::new(Default::default())),
-    })
+    Some(default_device())
 }
 
 #[inline]
 pub fn default_output_device() -> Option<Device> {
-    Some(Device {
-        name: "default".to_owned(),
-        pcm_id: "default".to_owned(),
+    Some(default_device())
+}
+
+#[inline]
+pub fn default_device() -> Device {
+    Device {
+        pcm_id: "default".to_string(),
+        desc: Some("Default Audio Device".to_string()),
         handles: Arc::new(Mutex::new(Default::default())),
-    })
+    }
 }
 
 impl From<alsa::Error> for DevicesError {

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -1,25 +1,26 @@
 extern crate alsa;
 extern crate libc;
 
+use std::{
+    cell::Cell,
+    cmp, fmt,
+    sync::{Arc, Mutex},
+    thread::{self, JoinHandle},
+    time::Duration,
+    vec::IntoIter as VecIntoIter,
+};
+
 use self::alsa::poll::Descriptors;
-use crate::traits::{DeviceTrait, HostTrait, StreamTrait};
+pub use self::enumerate::{default_input_device, default_output_device, Devices};
+
 use crate::{
+    traits::{DeviceTrait, HostTrait, StreamTrait},
     BackendSpecificError, BufferSize, BuildStreamError, ChannelCount, Data,
     DefaultStreamConfigError, DeviceNameError, DevicesError, FrameCount, InputCallbackInfo,
     OutputCallbackInfo, PauseStreamError, PlayStreamError, SampleFormat, SampleRate, StreamConfig,
     StreamError, SupportedBufferSize, SupportedStreamConfig, SupportedStreamConfigRange,
     SupportedStreamConfigsError,
 };
-use std::cell::Cell;
-use std::cmp;
-use std::convert::TryInto;
-use std::ops::RangeInclusive;
-use std::sync::{Arc, Mutex};
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
-use std::vec::IntoIter as VecIntoIter;
-
-pub use self::enumerate::{default_input_device, default_output_device, Devices};
 
 pub type SupportedInputConfigs = VecIntoIter<SupportedStreamConfigRange>;
 pub type SupportedOutputConfigs = VecIntoIter<SupportedStreamConfigRange>;
@@ -241,8 +242,8 @@ impl DeviceHandles {
 
 #[derive(Clone)]
 pub struct Device {
-    name: String,
     pcm_id: String,
+    desc: Option<String>,
     handles: Arc<Mutex<DeviceHandles>>,
 }
 
@@ -306,7 +307,7 @@ impl Device {
 
     #[inline]
     fn name(&self) -> Result<String, DeviceNameError> {
-        Ok(self.name.clone())
+        Ok(self.to_string())
     }
 
     fn supported_configs(
@@ -1326,5 +1327,15 @@ impl From<alsa::Error> for StreamError {
     fn from(err: alsa::Error) -> Self {
         let err: BackendSpecificError = err.into();
         err.into()
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(desc) = &self.desc {
+            write!(f, "{} ({})", self.pcm_id, desc.replace('\n', ", "))
+        } else {
+            write!(f, "{}", self.pcm_id)
+        }
     }
 }

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -4,6 +4,7 @@ extern crate libc;
 use std::{
     cell::Cell,
     cmp, fmt,
+    ops::RangeInclusive,
     sync::{Arc, Mutex},
     thread::{self, JoinHandle},
     time::Duration,
@@ -940,7 +941,11 @@ fn stream_timestamp(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    (ts.tv_sec * 1_000_000_000 + ts.tv_nsec).into()
+    let nanos = ts.tv_sec * 1_000_000_000 + ts.tv_nsec;
+    #[cfg(target_pointer_width = "64")]
+    return nanos;
+    #[cfg(not(target_pointer_width = "64"))]
+    return nanos.into();
 }
 
 // Adapted from `timediff` here:

--- a/src/host/alsa/mod.rs
+++ b/src/host/alsa/mod.rs
@@ -889,9 +889,8 @@ fn process_output(
             }
             Ok(result) if result != available_frames => {
                 let description = format!(
-                    "unexpected number of frames written: expected {}, \
-                     result {} (this should never happen)",
-                    available_frames, result,
+                    "unexpected number of frames written: expected {available_frames}, \
+                     result {result} (this should never happen)"
                 );
                 error_callback(BackendSpecificError { description }.into());
                 continue;
@@ -941,7 +940,7 @@ fn stream_timestamp(
 // Adapted from `timestamp2ns` here:
 // https://fossies.org/linux/alsa-lib/test/audio_time.c
 fn timespec_to_nanos(ts: libc::timespec) -> i64 {
-    ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec as i64
+    (ts.tv_sec * 1_000_000_000 + ts.tv_nsec).into()
 }
 
 // Adapted from `timediff` here:
@@ -1099,8 +1098,7 @@ fn set_hw_params_from_format(
             sample_format => {
                 return Err(BackendSpecificError {
                     description: format!(
-                        "Sample format '{}' is not supported by this backend",
-                        sample_format
+                        "Sample format '{sample_format}' is not supported by this backend"
                     ),
                 })
             }
@@ -1124,8 +1122,7 @@ fn set_hw_params_from_format(
             sample_format => {
                 return Err(BackendSpecificError {
                     description: format!(
-                        "Sample format '{}' is not supported by this backend",
-                        sample_format
+                        "Sample format '{sample_format}' is not supported by this backend"
                     ),
                 })
             }


### PR DESCRIPTION
On one of my systems, cpal v0.16 enumerates these and only these devices:

```
  1. "default"
  2. "Yggdrasil+"
```

As reported in #991 this is problematic because it:
- misses a lot of virtual devices
- is unclear whether it's `hw`, `plughw`, something else
- only provides access to `DEV=0` when there could be more
- differs from ALSA idioms

## New behavior

This PR changes this behavior to enumerate all devices like `aplay -L` puts out:

```
  1. "null"
  2. "default"
  3. "sysdefault"
  4. "_audioout"
  5. "_audioout__"
  6. "alsaequal"
  7. "plug_alsaequal"
  8. "btstream"
  9. "camilladsp"
  10. "crossfeed"
  11. "plug_bs2b"
  12. "eqfa12p"
  13. "plug_eqfa12p"
  14. "invpolarity"
  15. "trx_send"
  16. "hw:CARD=Yggdrasil,DEV=0"
  17. "plughw:CARD=Yggdrasil,DEV=0"
  18. "default:CARD=Yggdrasil"
  19. "sysdefault:CARD=Yggdrasil"
  20. "front:CARD=Yggdrasil,DEV=0"
  21. "surround21:CARD=Yggdrasil,DEV=0"
  22. "surround40:CARD=Yggdrasil,DEV=0"
  23. "surround41:CARD=Yggdrasil,DEV=0"
  24. "surround50:CARD=Yggdrasil,DEV=0"
  25. "surround51:CARD=Yggdrasil,DEV=0"
  26. "surround71:CARD=Yggdrasil,DEV=0"
  27. "iec958:CARD=Yggdrasil,DEV=0"
  28. "dmix:CARD=Yggdrasil,DEV=0"
  29. "hw:CARD=vc4hdmi0,DEV=0"
  30. "plughw:CARD=vc4hdmi0,DEV=0"
  31. "default:CARD=vc4hdmi0"
  32. "sysdefault:CARD=vc4hdmi0"
  33. "hdmi:CARD=vc4hdmi0,DEV=0"
  34. "dmix:CARD=vc4hdmi0,DEV=0"
  35. "hw:CARD=vc4hdmi1,DEV=0"
  36. "plughw:CARD=vc4hdmi1,DEV=0"
  37. "default:CARD=vc4hdmi1"
  38. "sysdefault:CARD=vc4hdmi1"
  39. "hdmi:CARD=vc4hdmi1,DEV=0"
  40. "dmix:CARD=vc4hdmi1,DEV=0"
```

This solves all problems mentioned.

## System configuration

For reference the configuration as `aplay` reports:

```
$ aplay -l
**** List of PLAYBACK Hardware Devices ****
card 0: Yggdrasil [Yggdrasil+], device 0: USB Audio [USB Audio]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 1: vc4hdmi0 [vc4-hdmi-0], device 0: MAI PCM i2s-hifi-0 [MAI PCM i2s-hifi-0]
  Subdevices: 1/1
  Subdevice #0: subdevice #0
card 2: vc4hdmi1 [vc4-hdmi-1], device 0: MAI PCM i2s-hifi-0 [MAI PCM i2s-hifi-0]
  Subdevices: 1/1
  Subdevice #0: subdevice #0

$ aplay -L
null
    Discard all samples (playback) or generate zero samples (capture)
default
    Default Audio Device
sysdefault
    Default Audio Device
_audioout
_audioout__
alsaequal
plug_alsaequal
btstream
camilladsp
crossfeed
plug_bs2b
eqfa12p
plug_eqfa12p
invpolarity
trx_send
hw:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    Direct hardware device without any conversions
plughw:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    Hardware device with all software conversions
default:CARD=Yggdrasil
    Yggdrasil+, USB Audio
    Default Audio Device
sysdefault:CARD=Yggdrasil
    Yggdrasil+, USB Audio
    Default Audio Device
front:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    Front output / input
surround21:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    2.1 Surround output to Front and Subwoofer speakers
surround40:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    4.0 Surround output to Front and Rear speakers
surround41:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    4.1 Surround output to Front, Rear and Subwoofer speakers
surround50:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    5.0 Surround output to Front, Center and Rear speakers
surround51:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    5.1 Surround output to Front, Center, Rear and Subwoofer speakers
surround71:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    7.1 Surround output to Front, Center, Side, Rear and Woofer speakers
iec958:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    IEC958 (S/PDIF) Digital Audio Output
dmix:CARD=Yggdrasil,DEV=0
    Yggdrasil+, USB Audio
    Direct sample mixing device
hw:CARD=vc4hdmi0,DEV=0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    Direct hardware device without any conversions
plughw:CARD=vc4hdmi0,DEV=0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    Hardware device with all software conversions
default:CARD=vc4hdmi0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    Default Audio Device
sysdefault:CARD=vc4hdmi0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    Default Audio Device
hdmi:CARD=vc4hdmi0,DEV=0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    HDMI Audio Output
dmix:CARD=vc4hdmi0,DEV=0
    vc4-hdmi-0, MAI PCM i2s-hifi-0
    Direct sample mixing device
hw:CARD=vc4hdmi1,DEV=0
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    Direct hardware device without any conversions
plughw:CARD=vc4hdmi1,DEV=0
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    Hardware device with all software conversions
default:CARD=vc4hdmi1
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    Default Audio Device
sysdefault:CARD=vc4hdmi1
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    Default Audio Device
hdmi:CARD=vc4hdmi1,DEV=0
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    HDMI Audio Output
dmix:CARD=vc4hdmi1,DEV=0
    vc4-hdmi-1, MAI PCM i2s-hifi-0
    Direct sample mixing device
```

## References

Fixes RustAudio/cpal#991