### PR TITLE
Fix warning in MacOS CoreAudio — `audio_device_id < 0`

### DIFF
--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -166,7 +166,11 @@ impl Device {
     pub fn new(audio_device_id: AudioDeviceID) -> Self {
         Device {
             audio_device_id,
-            is_default: audio_device_id < 0,
+            // is_default: audio_device_id < 0;
+            // This doesn't makse sense, as audio_device_id is of type u32,
+            // and will never be less than 0. We'll just say false as a simpler correction.
+            // TODO: This could be made to detect the default device properly.
+            is_default: false,
         }
     }
 


### PR DESCRIPTION
After running `cargo build` and `cargo clippy` I observed a warning for code testing if a u32 variable was less than 0. 

```
pub fn new(audio_device_id: AudioDeviceID) -> Self {
        Device {
            audio_device_id,
            is_default: audio_device_id < 0;
        }
    }
```

This doesn't make sense, however, as a u32 cannot be below 0. For readability-sake, and because I didn't have anything else to do, I've changed this from `audio_device_id < 0` to `false`.