### PR TITLE
feat(android): add `input_preset` to `StreamConfig`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.70"
 
 [features]
 asio = ["asio-sys", "num-traits"] # Only available on Windows. See README for setup instructions.
+android-input-preset = ["ndk/api-level-28"]
 
 # Deprecated, the `oboe` backend has been removed
 oboe-shared-stdcxx = []
@@ -83,7 +84,7 @@ js-sys = { version = "0.3.35" }
 web-sys = { version = "0.3.35", features = [ "AudioContext", "AudioContextOptions", "AudioBuffer", "AudioBufferSourceNode", "AudioNode",  "AudioDestinationNode", "Window", "AudioContextState"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = { version = "0.9", default-features = false, features = ["audio", "api-level-26"]}
+ndk = { version = "0.9", default-features = false, features = ["audio", "api-level-26"] }
 ndk-context = "0.1"
 jni = "0.21"
 num-derive = "0.4"

--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -403,10 +403,12 @@ impl DeviceTrait for Device {
         };
 
         let builder = ndk::audio::AudioStreamBuilder::new()?
-            .input_preset(config.input_preset)
             .direction(ndk::audio::AudioDirection::Input)
             .channel_count(channel_count)
             .format(format);
+
+        #[cfg(feature = "android-input-preset")]
+        let builder = builder.input_preset(config.input_preset);
 
         build_input_stream(
             self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub struct StreamConfig {
     pub channels: ChannelCount,
     pub sample_rate: SampleRate,
     pub buffer_size: BufferSize,
-    #[cfg(feature = "android-input-preset")]
+    #[cfg(all(target_os = "android", feature = "android-input-preset"))]
     pub input_preset: ndk::audio::AudioInputPreset,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@ impl SupportedStreamConfig {
             channels: self.channels,
             sample_rate: self.sample_rate,
             buffer_size: BufferSize::Default,
-            #[cfg(feature = "android-input-preset")]
+            #[cfg(all(target_os = "android", feature = "android-input-preset"))]
             input_preset: ndk::audio::AudioInputPreset::VoiceRecognition,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ pub struct StreamConfig {
     pub sample_rate: SampleRate,
     pub buffer_size: BufferSize,
     #[cfg(all(target_os = "android", feature = "android-input-preset"))]
-    pub input_preset: ndk::audio::AudioInputPreset,
+    pub input_preset: platform::AudioInputPreset,
 }
 
 /// Describes the minimum and maximum supported buffer size for the device
@@ -413,7 +413,7 @@ impl SupportedStreamConfig {
             sample_rate: self.sample_rate,
             buffer_size: BufferSize::Default,
             #[cfg(all(target_os = "android", feature = "android-input-preset"))]
-            input_preset: ndk::audio::AudioInputPreset::VoiceRecognition,
+            input_preset: platform::AudioInputPreset::VoiceRecognition,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,8 @@ pub struct StreamConfig {
     pub channels: ChannelCount,
     pub sample_rate: SampleRate,
     pub buffer_size: BufferSize,
+    #[cfg(feature = "android-input-preset")]
+    pub input_preset: ndk::audio::AudioInputPreset,
 }
 
 /// Describes the minimum and maximum supported buffer size for the device
@@ -410,6 +412,8 @@ impl SupportedStreamConfig {
             channels: self.channels,
             sample_rate: self.sample_rate,
             buffer_size: BufferSize::Default,
+            #[cfg(feature = "android-input-preset")]
+            input_preset: ndk::audio::AudioInputPreset::VoiceRecognition,
         }
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -708,6 +708,7 @@ mod platform_impl {
         Stream as AAudioStream, SupportedInputConfigs as AAudioSupportedInputConfigs,
         SupportedOutputConfigs as AAudioSupportedOutputConfigs,
     };
+    pub use ndk::audio::AudioInputPreset;
 
     impl_platform_host!(AAudio aaudio "AAudio");
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -708,6 +708,7 @@ mod platform_impl {
         Stream as AAudioStream, SupportedInputConfigs as AAudioSupportedInputConfigs,
         SupportedOutputConfigs as AAudioSupportedOutputConfigs,
     };
+    #[cfg(feature = "android-input-preset")]
     pub use ndk::audio::AudioInputPreset;
 
     impl_platform_host!(AAudio aaudio "AAudio");


### PR DESCRIPTION
Users can enable AEC (Acoustic Echo Canceler) via setting `VOICE_COMMUNICATION` for recording audio on Android (refer to [here](https://source.android.com/docs/core/audio/implement-pre-processing)), which is a powerful and important feature for developing Android applications. However, I find no ways to enable this feature in **cpal** at present. So I add it here.