### PR TITLE
properly detect `is_default` in `Device::new()` for MacOS

### DIFF
--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -105,7 +105,7 @@ pub fn default_input_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError as i32 {
+    if status != kAudioHardwareNoError {
         return None;
     }
 
@@ -135,7 +135,7 @@ pub fn default_output_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError as i32 {
+    if status != kAudioHardwareNoError {
         return None;
     }
 

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -105,7 +105,7 @@ pub fn default_input_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError {
+    if status != kAudioHardwareNoError as i32 {
         return None;
     }
 
@@ -135,7 +135,7 @@ pub fn default_output_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError {
+    if status != kAudioHardwareNoError as i32 {
         return None;
     }
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -20,12 +20,12 @@ use objc2_core_audio::{
     kAudioDevicePropertyAvailableNominalSampleRates, kAudioDevicePropertyBufferFrameSize,
     kAudioDevicePropertyBufferFrameSizeRange, kAudioDevicePropertyDeviceIsAlive,
     kAudioDevicePropertyNominalSampleRate, kAudioDevicePropertyStreamConfiguration,
-    kAudioDevicePropertyStreamFormat, kAudioObjectPropertyElementMaster,
+    kAudioDevicePropertyStreamFormat, kAudioHardwarePropertyDefaultInputDevice,
+    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyElementMaster,
     kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
-    kAudioObjectPropertyScopeOutput, AudioDeviceID, AudioObjectGetPropertyData,
-    AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-    AudioObjectPropertyScope, AudioObjectSetPropertyData, kAudioHardwarePropertyDefaultInputDevice,
-    kAudioObjectSystemObject, kAudioHardwarePropertyDefaultOutputDevice
+    kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject, AudioDeviceID,
+    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
+    AudioObjectPropertyAddress, AudioObjectPropertyScope, AudioObjectSetPropertyData,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -165,7 +165,6 @@ impl Device {
     /// Construct a new device given its ID.
     /// Useful for constructing hidden devices.
     pub fn new(audio_device_id: AudioDeviceID) -> Self {
-
         // Get default input device ID.
         let mut property_address = AudioObjectPropertyAddress {
             mSelector: kAudioHardwarePropertyDefaultInputDevice,
@@ -200,13 +199,10 @@ impl Device {
                 NonNull::from(&mut default_output_device_id).cast(),
             )
         };
-
-
         Device {
             audio_device_id,
-            is_default: 
-                (default_input_device_id == audio_device_id && input_status == 0) || 
-                (default_output_device_id == audio_device_id && output_status == 0)
+            is_default: (default_input_device_id == audio_device_id && input_status == 0)
+                || (default_output_device_id == audio_device_id && output_status == 0),
         }
     }
 

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -26,7 +26,6 @@ pub use self::macos::{
 };
 
 /// Common helper methods used by both macOS and iOS
-
 fn check_os_status(os_status: OSStatus) -> Result<(), BackendSpecificError> {
     match coreaudio::Error::from_os_status(os_status) {
         Ok(()) => Ok(()),

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -37,7 +37,6 @@ pub enum SampleFormat {
 
     // /// `I48` with a valid range of '-(1 << 47)..(1 << 47)' with `0` being the origin
     // I48,
-    
     /// `i64` with a valid range of `i64::MIN..=i64::MAX` with `0` being the origin.
     I64,
 
@@ -49,13 +48,11 @@ pub enum SampleFormat {
 
     // /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
-
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
 
     // /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
-
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.
     U64,
 

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -46,12 +46,12 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
-    // /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
+    /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
 
-    // /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
+    /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.
     U64,

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -37,6 +37,7 @@ pub enum SampleFormat {
 
     // /// `I48` with a valid range of '-(1 << 47)..(1 << 47)' with `0` being the origin
     // I48,
+    
     /// `i64` with a valid range of `i64::MIN..=i64::MAX` with `0` being the origin.
     I64,
 
@@ -46,13 +47,13 @@ pub enum SampleFormat {
     /// `u16` with a valid range of `u16::MIN..=u16::MAX` with `1 << 15 == 32768` being the origin.
     U16,
 
-    /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
+    // /// `U24` with a valid range of '0..16777216' with `1 << 23 == 8388608` being the origin
     // U24,
 
     /// `u32` with a valid range of `u32::MIN..=u32::MAX` with `1 << 31` being the origin.
     U32,
 
-    /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
+    // /// `U48` with a valid range of '0..(1 << 48)' with `1 << 47` being the origin
     // U48,
 
     /// `u64` with a valid range of `u64::MIN..=u64::MAX` with `1 << 63` being the origin.


### PR DESCRIPTION
I've introduced proper detection if a `Device::new()` is actually default to the system.

Previously, I hardcoded `is_default` to be false, regardless of the device ID. Now, the function will gather both the default input and output device IDs, and compare them to this device. If this device matches at least one device's ID, and no platform specific error occurred behind the scenes, we return true, otherwise we return false.

If we'd prefer to now return `Result<Self, BackendSpecificError>` I can implement this, though I didn't as I didn't have time. Just let me know if you'd prefer that, now that these errors *can* occur.