### PR TITLE
refactor: fix clippy warnings, replace Arc<Mutex> with Rc<RefCell> in CoreAudio

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@ use std::env;
 const CPAL_ASIO_DIR: &str = "CPAL_ASIO_DIR";
 
 fn main() {
-    println!("cargo:rerun-if-env-changed={}", CPAL_ASIO_DIR);
+    println!("cargo:rerun-if-env-changed={CPAL_ASIO_DIR}");
 
     // If ASIO directory isn't set silently return early
     // otherwise set the asio config flag

--- a/examples/beep.rs
+++ b/examples/beep.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
     println!("Output device: {}", device.name()?);
 
     let config = device.default_output_config().unwrap();
-    println!("Default output config: {:?}", config);
+    println!("Default output config: {config:?}");
 
     match config.sample_format() {
         cpal::SampleFormat::I8 => run::<i8>(&device, &config.into()),
@@ -108,7 +108,7 @@ where
         (sample_clock * 440.0 * 2.0 * std::f32::consts::PI / sample_rate).sin()
     };
 
-    let err_fn = |err| eprintln!("an error occurred on stream: {}", err);
+    let err_fn = |err| eprintln!("an error occurred on stream: {err}");
 
     let stream = device.build_output_stream(
         config,

--- a/examples/enumerate.rs
+++ b/examples/enumerate.rs
@@ -6,7 +6,7 @@ use cpal::traits::{DeviceTrait, HostTrait};
 fn main() -> Result<(), anyhow::Error> {
     println!("Supported hosts:\n  {:?}", cpal::ALL_HOSTS);
     let available_hosts = cpal::available_hosts();
-    println!("Available hosts:\n  {:?}", available_hosts);
+    println!("Available hosts:\n  {available_hosts:?}");
 
     for host_id in available_hosts {
         println!("{}", host_id.name());
@@ -14,8 +14,8 @@ fn main() -> Result<(), anyhow::Error> {
 
         let default_in = host.default_input_device().map(|e| e.name().unwrap());
         let default_out = host.default_output_device().map(|e| e.name().unwrap());
-        println!("  Default Input Device:\n    {:?}", default_in);
-        println!("  Default Output Device:\n    {:?}", default_out);
+        println!("  Default Input Device:\n    {default_in:?}");
+        println!("  Default Output Device:\n    {default_out:?}");
 
         let devices = host.devices()?;
         println!("  Devices: ");
@@ -24,12 +24,12 @@ fn main() -> Result<(), anyhow::Error> {
 
             // Input configs
             if let Ok(conf) = device.default_input_config() {
-                println!("    Default input stream config:\n      {:?}", conf);
+                println!("    Default input stream config:\n      {conf:?}");
             }
             let input_configs = match device.supported_input_configs() {
                 Ok(f) => f.collect(),
                 Err(e) => {
-                    println!("    Error getting supported input configs: {:?}", e);
+                    println!("    Error getting supported input configs: {e:?}");
                     Vec::new()
                 }
             };
@@ -47,12 +47,12 @@ fn main() -> Result<(), anyhow::Error> {
 
             // Output configs
             if let Ok(conf) = device.default_output_config() {
-                println!("    Default output stream config:\n      {:?}", conf);
+                println!("    Default output stream config:\n      {conf:?}");
             }
             let output_configs = match device.supported_output_configs() {
                 Ok(f) => f.collect(),
                 Err(e) => {
-                    println!("    Error getting supported output configs: {:?}", e);
+                    println!("    Error getting supported output configs: {e:?}");
                     Vec::new()
                 }
             };

--- a/examples/feedback.rs
+++ b/examples/feedback.rs
@@ -148,8 +148,7 @@ fn main() -> anyhow::Result<()> {
 
     // Build streams.
     println!(
-        "Attempting to build both streams with f32 samples and `{:?}`.",
-        config
+        "Attempting to build both streams with f32 samples and `{config:?}`."
     );
     let input_stream = input_device.build_input_stream(&config, input_data_fn, err_fn, None)?;
     let output_stream = output_device.build_output_stream(&config, output_data_fn, err_fn, None)?;
@@ -173,5 +172,5 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn err_fn(err: cpal::StreamError) {
-    eprintln!("an error occurred on stream: {}", err);
+    eprintln!("an error occurred on stream: {err}");
 }

--- a/examples/record_wav.rs
+++ b/examples/record_wav.rs
@@ -82,7 +82,7 @@ fn main() -> Result<(), anyhow::Error> {
     let config = device
         .default_input_config()
         .expect("Failed to get default input config");
-    println!("Default input config: {:?}", config);
+    println!("Default input config: {config:?}");
 
     // The WAV file we're recording to.
     const PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/recorded.wav");
@@ -97,7 +97,7 @@ fn main() -> Result<(), anyhow::Error> {
     let writer_2 = writer.clone();
 
     let err_fn = move |err| {
-        eprintln!("an error occurred on stream: {}", err);
+        eprintln!("an error occurred on stream: {err}");
     };
 
     let stream = match config.sample_format() {
@@ -138,7 +138,7 @@ fn main() -> Result<(), anyhow::Error> {
     std::thread::sleep(std::time::Duration::from_secs(3));
     drop(stream);
     writer.lock().unwrap().take().unwrap().finalize()?;
-    println!("Recording {} complete!", PATH);
+    println!("Recording {PATH} complete!");
     Ok(())
 }
 

--- a/examples/synth_tones.rs
+++ b/examples/synth_tones.rs
@@ -123,7 +123,7 @@ pub fn host_device_setup(
     println!("Output device : {}", device.name()?);
 
     let config = device.default_output_config()?;
-    println!("Default output config : {:?}", config);
+    println!("Default output config : {config:?}");
 
     Ok((host, device, config))
 }
@@ -142,10 +142,10 @@ where
         current_sample_index: 0.0,
         frequency_hz: 440.0,
     };
-    let err_fn = |err| eprintln!("Error building output sound stream: {}", err);
+    let err_fn = |err| eprintln!("Error building output sound stream: {err}");
 
     let time_at_start = std::time::Instant::now();
-    println!("Time at start: {:?}", time_at_start);
+    println!("Time at start: {time_at_start:?}");
 
     let stream = device.build_output_stream(
         config,

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -63,7 +63,7 @@ impl Devices {
             match audio_devices() {
                 Ok(devices) => devices,
                 Err(os_status) => {
-                    let description = format!("{}", os_status);
+                    let description = format!("{os_status}");
                     let err = BackendSpecificError { description };
                     return Err(err.into());
                 }
@@ -105,7 +105,7 @@ pub fn default_input_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError as i32 {
+    if status != kAudioHardwareNoError {
         return None;
     }
 
@@ -135,7 +135,7 @@ pub fn default_output_device() -> Option<Device> {
             NonNull::from(&mut audio_device_id).cast(),
         )
     };
-    if status != kAudioHardwareNoError as i32 {
+    if status != kAudioHardwareNoError {
         return None;
     }
 

--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -29,9 +29,11 @@ use objc2_core_audio::{
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
 };
+use std::cell::RefCell;
 use std::fmt;
 use std::mem;
 use std::ptr::{null, NonNull};
+use std::rc::Rc;
 use std::slice;
 use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
@@ -276,8 +278,7 @@ impl Device {
                 kAudioObjectPropertyScopeOutput => Ok(false),
                 _ => Err(BackendSpecificError {
                     description: format!(
-                        "unexpected scope (neither input nor output): {:?}",
-                        scope
+                        "unexpected scope (neither input nor output): {scope:?}"
                     ),
                 }),
             }?;
@@ -359,7 +360,7 @@ impl Device {
                     Err(DefaultStreamConfigError::DeviceNotAvailable)
                 }
                 err => {
-                    let description = format!("{}", err);
+                    let description = format!("{err}");
                     let err = BackendSpecificError { description };
                     Err(err.into())
                 }
@@ -412,8 +413,7 @@ impl Device {
                 kAudioObjectPropertyScopeOutput => Ok(false),
                 _ => Err(BackendSpecificError {
                     description: format!(
-                        "unexpected scope (neither input nor output): {:?}",
-                        scope
+                        "unexpected scope (neither input nor output): {scope:?}"
                     ),
                 }),
             }?;
@@ -465,7 +465,7 @@ impl StreamInner {
     fn play(&mut self) -> Result<(), PlayStreamError> {
         if !self.playing {
             if let Err(e) = self.audio_unit.start() {
-                let description = format!("{}", e);
+                let description = format!("{e}");
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }
@@ -477,7 +477,7 @@ impl StreamInner {
     fn pause(&mut self) -> Result<(), PauseStreamError> {
         if self.playing {
             if let Err(e) = self.audio_unit.stop() {
-                let description = format!("{}", e);
+                let description = format!("{e}");
                 let err = BackendSpecificError { description };
                 return Err(err.into());
             }
@@ -497,8 +497,8 @@ fn add_disconnect_listener<E>(
 where
     E: FnMut(StreamError) + Send + 'static,
 {
-    let stream_inner_weak = Arc::downgrade(&stream.inner);
-    let mut stream_inner = stream.inner.lock().unwrap();
+    let stream_inner_weak = Rc::downgrade(&stream.inner);
+    let mut stream_inner = stream.inner.borrow_mut();
     stream_inner._disconnect_listener = Some(AudioObjectPropertyListener::new(
         stream_inner.device_id,
         AudioObjectPropertyAddress {
@@ -508,7 +508,7 @@ where
         },
         move || {
             if let Some(stream_inner_strong) = stream_inner_weak.upgrade() {
-                let mut stream_inner = stream_inner_strong.lock().unwrap();
+                let mut stream_inner = stream_inner_strong.borrow_mut();
                 let _ = stream_inner.pause();
                 (error_callback.lock().unwrap())(StreamError::DeviceNotAvailable);
             }
@@ -664,7 +664,7 @@ impl Device {
             add_disconnect_listener(&stream, error_callback_disconnect)?;
         }
 
-        stream.inner.lock().unwrap().audio_unit.start()?;
+        stream.inner.borrow_mut().audio_unit.start()?;
 
         Ok(stream)
     }
@@ -769,7 +769,7 @@ impl Device {
             add_disconnect_listener(&stream, error_callback_disconnect)?;
         }
 
-        stream.inner.lock().unwrap().audio_unit.start()?;
+        stream.inner.borrow_mut().audio_unit.start()?;
 
         Ok(stream)
     }
@@ -930,26 +930,26 @@ fn set_sample_rate(
 
 #[derive(Clone)]
 pub struct Stream {
-    inner: Arc<Mutex<StreamInner>>,
+    inner: Rc<RefCell<StreamInner>>,
 }
 
 impl Stream {
     fn new(inner: StreamInner) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(inner)),
+            inner: Rc::new(RefCell::new(inner)),
         }
     }
 }
 
 impl StreamTrait for Stream {
     fn play(&self) -> Result<(), PlayStreamError> {
-        let mut stream = self.inner.lock().unwrap();
+        let mut stream = self.inner.borrow_mut();
 
         stream.play()
     }
 
     fn pause(&self) -> Result<(), PauseStreamError> {
-        let mut stream = self.inner.lock().unwrap();
+        let mut stream = self.inner.borrow_mut();
 
         stream.pause()
     }

--- a/src/host/coreaudio/mod.rs
+++ b/src/host/coreaudio/mod.rs
@@ -25,7 +25,7 @@ pub use self::macos::{
     Device, Host, Stream,
 };
 
-/// Common helper methods used by both macOS and iOS
+// Common helper methods used by both macOS and iOS
 
 fn check_os_status(os_status: OSStatus) -> Result<(), BackendSpecificError> {
     match coreaudio::Error::from_os_status(os_status) {
@@ -105,7 +105,7 @@ impl From<coreaudio::Error> for BuildStreamError {
 
 impl From<coreaudio::Error> for SupportedStreamConfigsError {
     fn from(err: coreaudio::Error) -> SupportedStreamConfigsError {
-        let description = format!("{}", err);
+        let description = format!("{err}");
         let err = BackendSpecificError { description };
         // Check for possible DeviceNotAvailable variant
         SupportedStreamConfigsError::BackendSpecific { err }
@@ -114,7 +114,7 @@ impl From<coreaudio::Error> for SupportedStreamConfigsError {
 
 impl From<coreaudio::Error> for DefaultStreamConfigError {
     fn from(err: coreaudio::Error) -> DefaultStreamConfigError {
-        let description = format!("{}", err);
+        let description = format!("{err}");
         let err = BackendSpecificError { description };
         // Check for possible DeviceNotAvailable variant
         DefaultStreamConfigError::BackendSpecific { err }


### PR DESCRIPTION
Fixex standard clippy warnings, as well as a more impactful change in CoreAudio (macOS): to resolve the `clippy::arc-with-non-send-sync` warning, it replaces `Arc<Mutex<StreamInner>>` with `Rc<RefCell<StreamInner>>`.

## CoreAudio changes (review requested)
The main change replaces `Arc<Mutex<StreamInner>>` with `Rc<RefCell<StreamInner>>` in the macOS CoreAudio implementation. Rationale:

- `StreamInner` contains `AudioUnit` and `AudioObjectPropertyListener` which are not `Send`/`Sync`
- The `Arc<Mutex<>>` provided no thread-safety benefits since the inner types aren't thread-safe
- Stream usage patterns in CPAL are single-threaded
- `Rc<RefCell<>>` is more appropriate for single-threaded shared ownership

This changes fundamental synchronization primitives in the CoreAudio backend. While the change is theoretically sound and all tests pass, extra scrutiny would be appreciated to ensure that we are not missing some edge cases.