### PR TITLE
Add arm64 Linux Support with Docker and CI

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -105,7 +105,7 @@ jobs:
         run: cross test --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
 
   linux-check-and-test-arm64:
-    runs-on: ubuntu-22.04-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Build Docker container for arm64
         run: docker build -f Dockerfile.arm64 -t cpal-arm64 .

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -110,9 +110,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Debug testing...
-        run: ls -la
-
       - name: Build Docker container for arm64
         run: docker build -f Dockerfile.arm64 -t cpal-arm64 .
       

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -107,6 +107,12 @@ jobs:
   linux-check-and-test-arm64:
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Debug testing...
+        run: ls -la
+
       - name: Build Docker container for arm64
         run: docker build -f Dockerfile.arm64 -t cpal-arm64 .
       

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -104,6 +104,18 @@ jobs:
       - name: Test all features for armv7
         run: cross test --target armv7-unknown-linux-gnueabihf --workspace --all-features --verbose
 
+  linux-check-and-test-arm64:
+    runs-on: ubuntu-22.04-arm64
+    steps:
+      - name: Build Docker container for arm64
+        run: docker build -f Dockerfile.arm64 -t cpal-arm64 .
+      
+      - name: Run without features
+        run: docker run --rm cpal-arm64 cargo test --all --no-default-features --verbose
+
+      - name: Run all features
+        run: docker run --rm cpal-arm64 cargo test --all --all-features --verbose
+
   asmjs-wasm32-test:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - CoreAudio: Detect default audio device lazily when building a stream, instead of during device enumeration.
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose IMMDevice from WASAPI host Device.
+- ALSA: Added support for arm64 Linux development, introducing a new Dockerfile.
 
 # Version 0.16.0 (2025-06-07)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
-ENV PKG_CONFIG_ALLOW_CROSS 1
-ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig/
 
 RUN dpkg --add-architecture armhf && \
     apt-get update && \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,6 +7,7 @@ RUN apt-get update && \
         libjack-jackd2-dev \
         libjack-jackd2-0 \
         pkg-config \
+        libdbus-1-dev \
 
 # Set /cpal/ to working directory
 WORKDIR /cpal

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,3 +12,6 @@ RUN apt-get update && \
 # Set /cpal/ to working directory
 WORKDIR /cpal
 COPY . .
+
+# When running this Docker container, ensure ALSA devices are exposed 
+# using `--device /dev/snd` and `--group-add audio`

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,7 +7,7 @@ RUN apt-get update && \
         libjack-jackd2-dev \
         libjack-jackd2-0 \
         pkg-config \
-        libdbus-1-dev \
+        libdbus-1-dev
 
 # Set /cpal/ to working directory
 WORKDIR /cpal

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,13 @@
+FROM rust:latest
+
+# Install required dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        libasound2-dev \
+        libjack-jackd2-dev \
+        libjack-jackd2-0 \
+        pkg-config \
+
+# Set /cpal/ to working directory
+WORKDIR /cpal
+COPY . .


### PR DESCRIPTION
I added basic support for arm64 Linux to CPAL by introducing a new `Dockerfile.arm64` to provide a ready-to-use environment for arm64 systems.

Additionally, the PR includes a new GitHub Actions workflow configured to run a GitHub-hosted ubuntu-22.04-arm64 runner, which automatically builds and tests CPAL on arm64 Linux for every push and pull request.  Manual testing has verified that the Docker environment builds and runs tests correctly on arm64 hardware. I also added an entry to `CHANGELOG.md` to include these changes.

Hopefully this is a good 1000th PR for CPAL. I didn't want to mess this one up!