### PR TITLE
feat: add Sample::bits_per_sample()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased
 
-- ASIO: Fix linker flags for MinGW cross-compilation.
+- Added `Sample::bits_per_sample` method.
 - ALSA(process_output): Pass `silent=true` to `PCM.try_recover`, so it doesn't write to stderr.
 - ALSA: Fix buffer and period size by selecting the closest supported values.
 - ALSA: Change ALSA periods from 4 to 2.
 - ALSA: Change card enumeration to work like `aplay -L` does.
+- ASIO: Fix linker flags for MinGW cross-compilation.
 - CoreAudio: Change `Device::supported_configs` to return a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values.
 - CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - iOS: Fix example by properly activating audio session.

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -71,14 +71,18 @@ impl SampleFormat {
     #[must_use]
     pub fn sample_size(&self) -> usize {
         match *self {
-            SampleFormat::I8 | SampleFormat::U8 => mem::size_of::<i8>(),
-            SampleFormat::I16 | SampleFormat::U16 => mem::size_of::<i16>(),
+            SampleFormat::I8 => mem::size_of::<i8>(),
+            SampleFormat::U8 => mem::size_of::<u8>(),
+            SampleFormat::I16 => mem::size_of::<i16>(),
+            SampleFormat::U16 => mem::size_of::<u16>(),
             SampleFormat::I24 => mem::size_of::<i32>(),
             // SampleFormat::U24 => mem::size_of::<i32>(),
-            SampleFormat::I32 | SampleFormat::U32 => mem::size_of::<i32>(),
+            SampleFormat::I32 => mem::size_of::<i32>(),
+            SampleFormat::U32 => mem::size_of::<u32>(),
             // SampleFormat::I48 => mem::size_of::<i64>(),
             // SampleFormat::U48 => mem::size_of::<i64>(),
-            SampleFormat::I64 | SampleFormat::U64 => mem::size_of::<i64>(),
+            SampleFormat::I64 => mem::size_of::<i64>(),
+            SampleFormat::U64 => mem::size_of::<u64>(),
             SampleFormat::F32 => mem::size_of::<f32>(),
             SampleFormat::F64 => mem::size_of::<f64>(),
         }

--- a/src/samples_formats.rs
+++ b/src/samples_formats.rs
@@ -6,8 +6,8 @@ pub use dasp_sample::{FromSample, Sample, I24, I48, U24, U48};
 
 /// Format that each sample has. Usually, this corresponds to the sampling
 /// depth of the audio source. For example, 16 bit quantized samples can be
-/// encoded in `i16` or `u16`. Note that the sampling depth is not directly
-/// visible for formats where [`is_float`] is true.
+/// encoded in `i16` or `u16`. Note that the quantized sampling depth is not
+/// directly visible for formats where [`is_float`] is true.
 ///
 /// Also note that the backend must support the encoding of the quantized
 /// samples in the given format, as there is no generic transformation from one
@@ -76,12 +76,35 @@ impl SampleFormat {
             SampleFormat::I24 => mem::size_of::<i32>(),
             // SampleFormat::U24 => mem::size_of::<i32>(),
             SampleFormat::I32 | SampleFormat::U32 => mem::size_of::<i32>(),
-
             // SampleFormat::I48 => mem::size_of::<i64>(),
             // SampleFormat::U48 => mem::size_of::<i64>(),
             SampleFormat::I64 | SampleFormat::U64 => mem::size_of::<i64>(),
             SampleFormat::F32 => mem::size_of::<f32>(),
             SampleFormat::F64 => mem::size_of::<f64>(),
+        }
+    }
+
+    /// Returns the number of bits of a sample of this format. Note that this is
+    /// not necessarily the same as the size of the primitive used to represent
+    /// this sample format (e.g., I24 has size of i32 but 24 bits per sample).
+    #[inline]
+    #[must_use]
+    pub fn bits_per_sample(&self) -> u32 {
+        match *self {
+            SampleFormat::I8 => i8::BITS,
+            SampleFormat::U8 => u8::BITS,
+            SampleFormat::I16 => i16::BITS,
+            SampleFormat::U16 => u16::BITS,
+            SampleFormat::I24 => 24,
+            // SampleFormat::U24 => 24,
+            SampleFormat::I32 => i32::BITS,
+            SampleFormat::U32 => u32::BITS,
+            // SampleFormat::I48 => 48,
+            // SampleFormat::U48 => 48,
+            SampleFormat::I64 => i64::BITS,
+            SampleFormat::U64 => u64::BITS,
+            SampleFormat::F32 => 32,
+            SampleFormat::F64 => 64,
         }
     }
 


### PR DESCRIPTION
We already had `Sample::sample_size()` which returns the size in bytes of a format. This does not always correspond with the number of bits. For example, `I24` is stored in 4 bytes but with 24 bits storing audio, not 32. This PR introduces a new function `Sample::bits_per_sample()` to do that.

For `F32` or `F64` we could argue what it should return. This method returns 32/64 bits of _bit depth (storage)_ instead of 24/58 bits of _precision (effective resolution)_.