### PR TITLE
AAudio AudioPerformanceMode::LowLatency

### DIFF
--- a/src/host/aaudio/mod.rs
+++ b/src/host/aaudio/mod.rs
@@ -406,7 +406,8 @@ impl DeviceTrait for Device {
         let builder = ndk::audio::AudioStreamBuilder::new()?
             .direction(ndk::audio::AudioDirection::Input)
             .channel_count(channel_count)
-            .format(format);
+            .format(format)
+            .performance_mode(ndk::audio::AudioPerformanceMode::LowLatency);
 
         build_input_stream(
             self,
@@ -455,7 +456,8 @@ impl DeviceTrait for Device {
         let builder = ndk::audio::AudioStreamBuilder::new()?
             .direction(ndk::audio::AudioDirection::Output)
             .channel_count(channel_count)
-            .format(format);
+            .format(format)
+            .performance_mode(ndk::audio::AudioPerformanceMode::LowLatency);
 
         build_output_stream(
             self,


### PR DESCRIPTION
Current cpal implementation results in noisy audio on Android. Please consider defaulting to AudioPerformanceMode::LowLatency.

I forked and made this change as suggested in https://github.com/RustAudio/cpal/issues/902, and it resolved the noise issues. This should be the default.
