### PR TITLE
feat: make Stream implement Send on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - CoreAudio: Add `i8`, `i32` and `I24` sample format support (24-bit samples stored in 4 bytes).
 - CoreAudio: Add support for loopback recording (recording system audio output) on macOS.
 - CoreAudio: Update `mach2` to 0.5.
+- CoreAudio: Make `Stream` implement `Send` on macOS by refactoring internal synchronization.
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose `IMMDevice` from WASAPI host Device.
 - WASAPI: Add `I24` and `U24` sample format support (24-bit samples stored in 4 bytes).

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -18,13 +18,12 @@ use objc2_audio_toolbox::{
 };
 use objc2_core_audio::{
     kAudioDevicePropertyAvailableNominalSampleRates, kAudioDevicePropertyBufferFrameSize,
-    kAudioDevicePropertyBufferFrameSizeRange, kAudioDevicePropertyDeviceIsAlive,
-    kAudioDevicePropertyNominalSampleRate, kAudioDevicePropertyStreamConfiguration,
-    kAudioDevicePropertyStreamFormat, kAudioObjectPropertyElementMaster,
-    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
-    kAudioObjectPropertyScopeOutput, AudioDeviceID, AudioObjectGetPropertyData,
-    AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-    AudioObjectPropertyScope, AudioObjectSetPropertyData,
+    kAudioDevicePropertyBufferFrameSizeRange, kAudioDevicePropertyNominalSampleRate,
+    kAudioDevicePropertyStreamConfiguration, kAudioDevicePropertyStreamFormat,
+    kAudioObjectPropertyElementMaster, kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput, AudioDeviceID,
+    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
+    AudioObjectPropertyAddress, AudioObjectPropertyScope, AudioObjectSetPropertyData,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -36,7 +35,6 @@ pub use super::enumerate::{
 use std::fmt;
 use std::mem::{self};
 use std::ptr::{null, NonNull};
-use std::rc::Rc;
 use std::slice;
 use std::sync::mpsc::{channel, RecvTimeoutError};
 use std::sync::{Arc, Mutex};
@@ -248,45 +246,6 @@ fn get_io_buffer_frame_size_range(
         min: buffer_size_range.mMinimum as u32,
         max: buffer_size_range.mMaximum as u32,
     })
-}
-
-/// Register the on-disconnect callback.
-/// This will both stop the stream and call the error callback with DeviceNotAvailable.
-/// This function should only be called once per stream.
-fn add_disconnect_listener<E>(
-    stream: &Stream,
-    error_callback: Arc<Mutex<E>>,
-) -> Result<(), BuildStreamError>
-where
-    E: FnMut(StreamError) + Send + 'static,
-{
-    let stream_inner_weak = Rc::downgrade(&stream.inner);
-    let mut stream_inner = stream.inner.borrow_mut();
-    stream_inner._disconnect_listener = Some(AudioObjectPropertyListener::new(
-        stream_inner.device_id,
-        AudioObjectPropertyAddress {
-            mSelector: kAudioDevicePropertyDeviceIsAlive,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMaster,
-        },
-        move || {
-            if let Some(stream_inner_strong) = stream_inner_weak.upgrade() {
-                match stream_inner_strong.try_borrow_mut() {
-                    Ok(mut stream_inner) => {
-                        let _ = stream_inner.pause();
-                    }
-                    Err(_) => {
-                        // Could not acquire mutable borrow. This can occur if there are
-                        // overlapping borrows, if the stream is already in use, or if a panic
-                        // occurred during a previous borrow. Still notify about device
-                        // disconnection even if we can't pause.
-                    }
-                }
-                (error_callback.lock().unwrap())(StreamError::DeviceNotAvailable);
-            }
-        },
-    )?);
-    Ok(())
 }
 
 impl DeviceTrait for Device {
@@ -765,21 +724,38 @@ impl Device {
             Ok(())
         })?;
 
-        let stream = Stream::new(StreamInner {
-            playing: true,
-            _disconnect_listener: None,
-            audio_unit,
-            device_id: self.audio_device_id,
-            _loopback_device: loopback_aggregate,
-        });
+        // Create error callback for stream - either dummy or real based on device type
+        let error_callback_for_stream: super::ErrorCallback = if is_default_device(self) {
+            Box::new(|_: StreamError| {})
+        } else {
+            let error_callback_clone = error_callback_disconnect.clone();
+            Box::new(move |err: StreamError| {
+                if let Ok(mut cb) = error_callback_clone.lock() {
+                    cb(err);
+                }
+            })
+        };
 
-        // If we didn't request the default device, stop the stream if the
-        // device disconnects.
-        if !is_default_device(self) {
-            add_disconnect_listener(&stream, error_callback_disconnect)?;
-        }
+        let stream = Stream::new(
+            StreamInner {
+                playing: true,
+                audio_unit,
+                device_id: self.audio_device_id,
+                _loopback_device: loopback_aggregate,
+            },
+            error_callback_for_stream,
+        )?;
 
-        stream.inner.borrow_mut().audio_unit.start()?;
+        stream
+            .inner
+            .lock()
+            .map_err(|_| BuildStreamError::BackendSpecific {
+                err: BackendSpecificError {
+                    description: "Failed to acquire stream lock".to_string(),
+                },
+            })?
+            .audio_unit
+            .start()?;
 
         Ok(stream)
     }
@@ -871,21 +847,38 @@ impl Device {
             Ok(())
         })?;
 
-        let stream = Stream::new(StreamInner {
-            playing: true,
-            _disconnect_listener: None,
-            audio_unit,
-            device_id: self.audio_device_id,
-            _loopback_device: None,
-        });
+        // Create error callback for stream - either dummy or real based on device type
+        let error_callback_for_stream: super::ErrorCallback = if is_default_device(self) {
+            Box::new(|_: StreamError| {})
+        } else {
+            let error_callback_clone = error_callback_disconnect.clone();
+            Box::new(move |err: StreamError| {
+                if let Ok(mut cb) = error_callback_clone.lock() {
+                    cb(err);
+                }
+            })
+        };
 
-        // If we didn't request the default device, stop the stream if the
-        // device disconnects.
-        if !is_default_device(self) {
-            add_disconnect_listener(&stream, error_callback_disconnect)?;
-        }
+        let stream = Stream::new(
+            StreamInner {
+                playing: true,
+                audio_unit,
+                device_id: self.audio_device_id,
+                _loopback_device: None,
+            },
+            error_callback_for_stream,
+        )?;
 
-        stream.inner.borrow_mut().audio_unit.start()?;
+        stream
+            .inner
+            .lock()
+            .map_err(|_| BuildStreamError::BackendSpecific {
+                err: BackendSpecificError {
+                    description: "Failed to acquire stream lock".to_string(),
+                },
+            })?
+            .audio_unit
+            .start()?;
 
         Ok(stream)
     }

--- a/src/host/coreaudio/macos/enumerate.rs
+++ b/src/host/coreaudio/macos/enumerate.rs
@@ -73,9 +73,6 @@ impl Devices {
     }
 }
 
-unsafe impl Send for Devices {}
-unsafe impl Sync for Devices {}
-
 impl Iterator for Devices {
     type Item = Device;
     fn next(&mut self) -> Option<Device> {


### PR DESCRIPTION
`Stream` can now be moved between threads safely on macOS.

- Replaced `Rc<RefCell<>>` with `Arc<Mutex<>>` for thread-safe access to stream state
- Extracted device disconnection handling into a separate `DisconnectManager` to isolate non-`Send` `AudioObjectPropertyListener`
- Removed unnecessary `unsafe impl Send` implementations that are now automatically derived

The mutex is only locked during `play()` and `pause()` operations, so performance impact is negligible. The audio callback is completely unaffected.