### PR TITLE
ci: test compatibility with multiple windows crate versions

### DIFF
--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -357,6 +357,6 @@ jobs:
           echo "Cargo.lock entry:"
           grep -A 5 "name = \"windows\"" Cargo.lock | head -10
 
-      - name: Test WASAPI with windows v${{ matrix.windows-version }}
+      - name: Check WASAPI with windows v${{ matrix.windows-version }}
         run: |
-          cargo test --verbose
+          cargo check --verbose

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -196,14 +196,8 @@ jobs:
         with:
           tool: cross
 
-      - name: Check without features
-        run: cross check --target ${{ matrix.target }} --workspace --no-default-features --verbose
-
       - name: Test without features
         run: cross test --target ${{ matrix.target }} --workspace --no-default-features --verbose
-
-      - name: Check all features
-        run: cross check --target ${{ matrix.target }} --workspace --all-features --verbose
 
       - name: Test all features
         run: cross test --target ${{ matrix.target }} --workspace --all-features --verbose

--- a/.github/workflows/cpal.yml
+++ b/.github/workflows/cpal.yml
@@ -60,7 +60,7 @@ jobs:
 
   cargo-publish:
     if: github.event_name == 'release'
-    needs: [test-native, test-cross, test-wasm, test-android, test-ios]
+    needs: [test-native, test-cross, test-wasm, test-android, test-ios, test-windows-versions]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -318,3 +318,51 @@ jobs:
 
       - name: Build iOS example
         run: cd examples/ios-feedback && xcodebuild -scheme cpal-ios-example -configuration Debug -derivedDataPath build -sdk iphonesimulator
+
+  # Windows crate compatibility testing
+  test-windows-versions:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - windows-version: "0.59.0"
+          - windows-version: "0.60.0"
+          - windows-version: "0.61.3"
+          # Skip 0.62.x since we already test current version in test-native
+    name: test-windows-v${{ matrix.windows-version }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install dependencies
+        run: |
+          choco install llvm
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-v${{ matrix.windows-version }}
+
+      - name: Lock windows crate to specific version
+        shell: bash
+        run: |
+          # Generate Cargo.lock first if it doesn't exist
+          cargo generate-lockfile
+
+          # Use cargo update --precise to lock the windows crate to a specific version
+          cargo update --precise ${{ matrix.windows-version }} windows
+
+          # Verify the version was locked correctly
+          echo "Locked windows crate version:"
+          cargo tree | grep "windows v" || echo "Windows crate not found in dependency tree"
+
+          # Also check Cargo.lock
+          echo "Cargo.lock entry:"
+          grep -A 5 "name = \"windows\"" Cargo.lock | head -10
+
+      - name: Test WASAPI with windows v${{ matrix.windows-version }}
+        run: |
+          cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - CI: Fix cargo publish to trigger on GitHub releases instead of every master commit.
 - CI: Replace cargo install commands with cached tool installation for faster builds.
 - CI: Update actions to latest versions (checkout@v5, rust-cache@v2).
+- CI: Verify compatibility with windows crates since v0.58.
 - CoreAudio: Change `Device::supported_configs` to return a single element containing the available sample rate range when all elements have the same `mMinimum` and `mMaximum` values.
 - CoreAudio: Change default audio device detection to be lazy when building a stream, instead of during device enumeration.
 - CoreAudio: Add `i8`, `i32` and `I24` sample format support (24-bit samples stored in 4 bytes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - iOS: Fix example by properly activating audio session.
 - WASAPI: Expose `IMMDevice` from WASAPI host Device.
 - WASAPI: Add `I24` and `U24` sample format support (24-bit samples stored in 4 bytes).
-- WASAPI: Update `windows` to 0.62.
+- WASAPI: Update `windows` to >= 0.58, <= 0.62.
 - Wasm: Removed optional `wee-alloc` feature for security reasons.
 
 # Version 0.16.0 (2025-06-07)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,11 @@ hound = "3.5"
 ringbuf = "0.4.8"
 clap = { version = "4.5", features = ["derive"] }
 
-# When updating windows, also update the "windows-version" matrix in the CI workflow.
-# We want to test compatibility with versions 12 months before the latest release.
+# Support a range of versions in order to avoid duplication of this crate. Make sure to test all
+# versions when bumping to a new release, and only increase the minimum when absolutely necessary.
+# When updating this, also update the "windows-version" matrix in the CI workflow.
 [target.'cfg(target_os = "windows")'.dependencies]
-windows = { version = "0.62", features = [
+windows = { version = ">=0.58, <=0.62", features = [
     "Win32_Media_Audio",
     "Win32_Foundation",
     "Win32_Devices_Properties",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ hound = "3.5"
 ringbuf = "0.4.8"
 clap = { version = "4.5", features = ["derive"] }
 
+# When updating windows, also update the "windows-version" matrix in the CI workflow.
+# We want to test compatibility with versions 12 months before the latest release.
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.62", features = [
     "Win32_Media_Audio",

--- a/src/host/wasapi/device.rs
+++ b/src/host/wasapi/device.rs
@@ -337,7 +337,7 @@ impl Device {
     /// Ensures that `future_audio_client` contains a `Some` and returns a locked mutex to it.
     fn ensure_future_audio_client(
         &self,
-    ) -> Result<MutexGuard<Option<IAudioClientWrapper>>, windows::core::Error> {
+    ) -> Result<MutexGuard<'_, Option<IAudioClientWrapper>>, windows::core::Error> {
         let mut lock = self.future_audio_client.lock().unwrap();
         if lock.is_some() {
             return Ok(lock);

--- a/src/host/wasapi/stream.rs
+++ b/src/host/wasapi/stream.rs
@@ -345,8 +345,6 @@ fn boost_current_thread_priority(buffer_size: BufferSize, sample_rate: crate::Sa
 
 #[cfg(not(feature = "audio_thread_priority"))]
 fn boost_current_thread_priority(_: BufferSize, _: crate::SampleRate) {
-    use windows::Win32::Foundation::HANDLE;
-
     unsafe {
         let thread_handle = Threading::GetCurrentThread();
 


### PR DESCRIPTION
Tests `windows` crate versions of the past 12 months for compatibility.

Supersedes #893