### PR TITLE
fix: device property usage for buffer size handling

### DIFF
--- a/src/host/coreaudio/macos/mod.rs
+++ b/src/host/coreaudio/macos/mod.rs
@@ -249,9 +249,7 @@ mod test {
                 &default_config,
                 move |data: &mut [f32], info: &crate::OutputCallbackInfo| {
                     let mut sizes = default_buffer_sizes_clone.lock().unwrap();
-                    if sizes.len() < 5 {
-                        sizes.push(data.len());
-                    }
+                    sizes.push(data.len());
                     write_silence(data, info);
                 },
                 move |err| println!("Error: {err}"),
@@ -287,9 +285,7 @@ mod test {
                 &fixed_config,
                 move |data: &mut [f32], info: &crate::OutputCallbackInfo| {
                     let mut sizes = fixed_buffer_sizes_clone.lock().unwrap();
-                    if sizes.len() < 5 {
-                        sizes.push(data.len());
-                    }
+                    sizes.push(data.len());
                     write_silence(data, info);
                 },
                 move |err| println!("Error: {err}"),


### PR DESCRIPTION
The CI is showing non-deterministic behavior for `test-macos-arm64` that I cannot reproduce locally. This is an attempt to fix that by clarifying and correcting the `Scope` and `Element` for device-level properties, always using `Scope::Global` and `Element::Output` for buffer frame size operations.