### PR TITLE
fix(pipewire): fix 24bit sample format mapping

### DIFF
--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -190,6 +190,9 @@ jobs:
       PKG_CONFIG_ALLOW_CROSS: "1"
       PKG_CONFIG_PATH: /usr/lib/mipsel-linux-gnu/pkgconfig/
       CARGO_TARGET_MIPSEL_UNKNOWN_LINUX_GNU_LINKER: mipsel-linux-gnu-gcc
+      # Nightly's default force-frame-pointers setting for this target gets forwarded by cc-rs
+      # to mipsel-linux-gnu-gcc as -mno-omit-leaf-frame-pointer, which it doesn't recognize.
+      RUSTFLAGS: "-C force-frame-pointers=no"
     steps:
       - uses: actions/checkout@v5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PipeWire**: Fix streams starting audio before `play()` is called.
 - **PipeWire**: Fix rtkit burst limit errors from repeated real-time promotion on quantum jitter.
 - **PipeWire**: Fix real-time promotion blocking the audio callback thread on Linux.
+- **PipeWire**: Fix 24-bit sample format mapping.
 - **PipeWire**: Nodes with an `/Internal` media class are now enumerated as devices.
 - **PipeWire**: Streams for a specific device no longer auto-reroute if it disappears.
 - **PipeWire**: Build on 32-bit targets without native 64-bit atomics.

--- a/src/host/pipewire/stream.rs
+++ b/src/host/pipewire/stream.rs
@@ -191,13 +191,13 @@ impl From<SampleFormat> for AudioFormat {
             SampleFormat::U16 => Self::U16BE,
 
             #[cfg(target_endian = "little")]
-            SampleFormat::I24 => Self::S24LE,
+            SampleFormat::I24 => Self::S24_32LE,
             #[cfg(target_endian = "big")]
-            SampleFormat::I24 => Self::S24BE,
+            SampleFormat::I24 => Self::S24_32BE,
             #[cfg(target_endian = "little")]
-            SampleFormat::U24 => Self::U24LE,
+            SampleFormat::U24 => Self::U24_32LE,
             #[cfg(target_endian = "big")]
-            SampleFormat::U24 => Self::U24BE,
+            SampleFormat::U24 => Self::U24_32BE,
             #[cfg(target_endian = "little")]
             SampleFormat::I32 => Self::S32LE,
             #[cfg(target_endian = "big")]


### PR DESCRIPTION
Use correct pipewire AudioFormat for cpal's 4-byte I24, U24 representation.