### PR TITLE
doc: record UnsupportedConfig on the supported-configs queries

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -182,9 +182,12 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
     ///
     /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
     /// - [`ErrorKind::UnsupportedOperation`] if the device does not support input.
+    /// - [`ErrorKind::UnsupportedConfig`] if the backend could not determine what the device
+    ///   supports.
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
     /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
+    /// [`ErrorKind::UnsupportedConfig`]: crate::ErrorKind::UnsupportedConfig
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error>;
 
     /// An iterator yielding output stream configurations that are supported by the device.
@@ -193,9 +196,12 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
     ///
     /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
     /// - [`ErrorKind::UnsupportedOperation`] if the device does not support output.
+    /// - [`ErrorKind::UnsupportedConfig`] if the backend could not determine what the device
+    ///   supports.
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
     /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
+    /// [`ErrorKind::UnsupportedConfig`]: crate::ErrorKind::UnsupportedConfig
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error>;
 
     /// The default input stream configuration for the device.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -181,13 +181,13 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
     /// # Errors
     ///
     /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
-    /// - [`ErrorKind::UnsupportedOperation`] if the device does not support input.
     /// - [`ErrorKind::UnsupportedConfig`] if the backend could not determine what the device
     ///   supports.
+    /// - [`ErrorKind::UnsupportedOperation`] if the device does not support input.
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
-    /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
     /// [`ErrorKind::UnsupportedConfig`]: crate::ErrorKind::UnsupportedConfig
+    /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
     fn supported_input_configs(&self) -> Result<Self::SupportedInputConfigs, Error>;
 
     /// An iterator yielding output stream configurations that are supported by the device.
@@ -195,13 +195,13 @@ pub trait DeviceTrait: PartialEq + Eq + Hash + Debug + Display {
     /// # Errors
     ///
     /// - [`ErrorKind::DeviceNotAvailable`] if the device has been disconnected.
-    /// - [`ErrorKind::UnsupportedOperation`] if the device does not support output.
     /// - [`ErrorKind::UnsupportedConfig`] if the backend could not determine what the device
     ///   supports.
+    /// - [`ErrorKind::UnsupportedOperation`] if the device does not support output.
     ///
     /// [`ErrorKind::DeviceNotAvailable`]: crate::ErrorKind::DeviceNotAvailable
-    /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
     /// [`ErrorKind::UnsupportedConfig`]: crate::ErrorKind::UnsupportedConfig
+    /// [`ErrorKind::UnsupportedOperation`]: crate::ErrorKind::UnsupportedOperation
     fn supported_output_configs(&self) -> Result<Self::SupportedOutputConfigs, Error>;
 
     /// The default input stream configuration for the device.


### PR DESCRIPTION
`DeviceTrait::supported_input_configs` and `supported_output_configs` list `DeviceNotAvailable` and `UnsupportedOperation`, but the WASAPI backend also answers `UnsupportedConfig` from `supported_formats`, which both of them call: once when `IsFormatSupported` cannot vouch for the mix format, and once when that format maps to no `SampleFormat` cpal has.

Documentation only; no behaviour change.