### PR TITLE
Support pipewire stream properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `StreamTrait::stop` ends a stream gracefully, draining buffered audio before halting (blocking up to a caller-supplied timeout). Dropping a stream still halts immediately without draining.
 - `CallbackInfo::xrun()` reports buffer over/underruns via the data callback.
+- **PipeWire**: Add `Host::set_stream_properties` to set identifying node properties
+  (e.g. `node.name`, `media.name`) on streams created by the host.
 - **AudioWorklet**: Input streams are now supported.
 - **WebAudio**: Input streams are now supported.
 

--- a/src/host/pipewire/device.rs
+++ b/src/host/pipewire/device.rs
@@ -4,7 +4,7 @@ use std::{
     hash::{Hash, Hasher},
     rc::Rc,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicU32, Ordering},
         mpsc,
     },
@@ -88,6 +88,7 @@ pub struct Device {
     address: Option<String>,
     driver: Option<String>,
     connect_automatically: Arc<AtomicBool>,
+    stream_properties: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl Device {
@@ -181,6 +182,16 @@ impl Device {
                 *pw::keys::NODE_LATENCY,
                 format!("{buffer_size}/{rate}", rate = config.sample_rate),
             );
+        }
+
+        // Apply user-configured properties last so they override cpal's defaults
+        // (see `Host::set_stream_properties`).
+        let extra = self
+            .stream_properties
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        for (key, value) in extra.iter() {
+            properties.insert(key.as_str(), value.as_str());
         }
         properties
     }
@@ -785,7 +796,10 @@ fn remote_props() -> Option<PropertiesBox> {
     Some(props)
 }
 
-pub fn init_devices(connect_automatically: Arc<AtomicBool>) -> Option<Vec<Device>> {
+pub fn init_devices(
+    connect_automatically: Arc<AtomicBool>,
+    stream_properties: Arc<Mutex<Vec<(String, String)>>>,
+) -> Option<Vec<Device>> {
     let _pw = PwInitGuard::new();
     let mainloop = MainLoopRc::new(None).ok()?;
     let context = ContextRc::new(&mainloop, None).ok()?;
@@ -1102,6 +1116,7 @@ pub fn init_devices(connect_automatically: Arc<AtomicBool>) -> Option<Vec<Device
         device.min_quantum = settings.min_quantum;
         device.max_quantum = settings.max_quantum;
         device.connect_automatically = connect_automatically.clone();
+        device.stream_properties = stream_properties.clone();
     }
 
     // Resolve each discovered hardware node: global settings apply unless the node
@@ -1117,6 +1132,7 @@ pub fn init_devices(connect_automatically: Arc<AtomicBool>) -> Option<Vec<Device
                 device.min_quantum = settings.min_quantum;
                 device.max_quantum = settings.max_quantum;
                 device.connect_automatically = connect_automatically.clone();
+                device.stream_properties = stream_properties.clone();
                 device
             }),
     );

--- a/src/host/pipewire/mod.rs
+++ b/src/host/pipewire/mod.rs
@@ -1,5 +1,5 @@
 use std::sync::{
-    Arc,
+    Arc, Mutex,
     atomic::{AtomicBool, Ordering},
 };
 
@@ -18,27 +18,32 @@ mod utils;
 ///
 /// # PipeWire-Specific Configuration
 ///
-/// PipeWire provides a configuration option to control graph connection behavior:
+/// PipeWire provides configuration options specific to this backend:
 /// - Port auto-connection via [`set_connect_automatically`](Host::set_connect_automatically)
+/// - Custom stream node properties via [`set_stream_properties`](Host::set_stream_properties)
 pub struct Host {
     // Keeps PipeWire initialized for the lifetime of the host, preventing
     // pw_deinit() from running between device enumeration and stream creation.
     _pw: PwInitGuard,
     devices: Vec<Device>,
     connect_automatically: Arc<AtomicBool>,
+    stream_properties: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 impl Host {
     pub fn new() -> Result<Self, Error> {
         let _pw = PwInitGuard::new();
         let connect_automatically = Arc::new(AtomicBool::new(true));
-        let devices = init_devices(connect_automatically.clone()).ok_or_else(|| {
-            Error::with_message(ErrorKind::HostUnavailable, "PipeWire is not available")
-        })?;
+        let stream_properties = Arc::new(Mutex::new(Vec::new()));
+        let devices = init_devices(connect_automatically.clone(), stream_properties.clone())
+            .ok_or_else(|| {
+                Error::with_message(ErrorKind::HostUnavailable, "PipeWire is not available")
+            })?;
         Ok(Self {
             _pw,
             devices,
             connect_automatically,
+            stream_properties,
         })
     }
 
@@ -53,6 +58,21 @@ impl Host {
     /// Default: `true`
     pub fn set_connect_automatically(&mut self, connect: bool) {
         self.connect_automatically.store(connect, Ordering::Relaxed);
+    }
+
+    /// Sets custom properties on stream nodes created by this host.
+    ///
+    /// User properties override cpal's defaults for matching keys (e.g. `node.name`, `media.name`).
+    /// Calling this replaces any properties set by a previous call.
+    pub fn set_stream_properties<I: IntoIterator<Item = (String, String)>>(
+        &mut self,
+        properties: I,
+    ) {
+        let mut guard = self
+            .stream_properties
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        *guard = properties.into_iter().collect();
     }
 }
 


### PR DESCRIPTION
This should knock off https://github.com/RustAudio/cpal/issues/1186 from https://github.com/RustAudio/cpal/issues/1220.

Edit: Tested, was able to validate that overriding props like `node.name`, `node.description` (overrode defaults), `node.dont-reconnect`, `node.force-quantum` (unset by default), and also a custom one like `cpal.demo` all set.