### PR TITLE
docs: show the config conversion in the output stream example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,8 @@
 //! use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 //! # let host = cpal::default_host();
 //! # let device = host.default_output_device().unwrap();
-//! # let config = device.default_output_config().unwrap().into();
+//! # let supported_config = device.default_output_config().unwrap();
+//! let config = supported_config.into();
 //! let stream = device.build_output_stream(
 //!     config,
 //!     move |data: &mut [f32], _: &cpal::CallbackInfo| {


### PR DESCRIPTION
Fixes #816. The output stream example built `config` from a hidden line, so readers could not see that a `SupportedStreamConfig` has to be converted with `into()` before it is passed to `build_output_stream`. This makes that line visible, matching the later example in the same module.