### PR TITLE
feat(coreaudio): report device transport as InterfaceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InputStreamTimestamp`/`OutputStreamTimestamp` merged into `StreamTimestamp`; `capture`/`playback` renamed `device`.
 - Renamed the `wasm-beep` and `audioworklet-beep` examples to `webaudio` and `audioworklet`.
 - **ALSA**: Update `alsa` dependency to 0.12.
+- **CoreAudio**: `DeviceDescription::interface_type()` now reports the device transport (built-in, USB, Bluetooth, Thunderbolt, HDMI, and others) instead of only marking aggregate devices.
 - **Linux**: `realtime` can now promote threads without requiring `realtime-dbus`.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InputStreamTimestamp`/`OutputStreamTimestamp` merged into `StreamTimestamp`; `capture`/`playback` renamed `device`.
 - Renamed the `wasm-beep` and `audioworklet-beep` examples to `webaudio` and `audioworklet`.
 - **ALSA**: Update `alsa` dependency to 0.12.
-- **CoreAudio**: `DeviceDescription::interface_type()` now reports the device transport (built-in, USB, Bluetooth, Thunderbolt, HDMI, and others) instead of only marking aggregate devices.
+- **CoreAudio**: `DeviceDescription::interface_type()` now reports the device transport instead of only marking aggregate devices.
 - **Linux**: `realtime` can now promote threads without requiring `realtime-dbus`.
 
 ### Deprecated

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -30,9 +30,9 @@ use objc2_core_audio::{
     kAudioDevicePropertyBufferFrameSizeRange, kAudioDevicePropertyDeviceUID,
     kAudioDevicePropertyLatency, kAudioDevicePropertyNominalSampleRate,
     kAudioDevicePropertySafetyOffset, kAudioDevicePropertyStreamConfiguration,
-    kAudioDevicePropertyStreamFormat, kAudioObjectPropertyClass, kAudioObjectPropertyElementMain,
-    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
-    kAudioObjectPropertyScopeOutput,
+    kAudioDevicePropertyStreamFormat, kAudioDevicePropertyTransportType, kAudioObjectPropertyClass,
+    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -405,6 +405,64 @@ impl Device {
         status == 0 && class_id == kAudioAggregateDeviceClassID
     }
 
+    /// `None` when the property is unavailable or names a transport with no
+    /// `InterfaceType` counterpart, so the field is left unset rather than wrong.
+    fn transport_interface_type(&self) -> Option<InterfaceType> {
+        let property_address = AudioObjectPropertyAddress {
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        };
+
+        let mut transport: u32 = 0;
+        let data_size = size_of::<u32>() as u32;
+
+        // SAFETY: AudioObjectGetPropertyData writes a UInt32 for
+        // kAudioDevicePropertyTransportType. The status is checked before use.
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                self.audio_device_id,
+                NonNull::from(&property_address),
+                0,
+                null(),
+                NonNull::from(&data_size),
+                NonNull::from(&mut transport).cast(),
+            )
+        };
+        if status != 0 {
+            return None;
+        }
+
+        // Four-character codes from AudioHardwareBase.h.
+        const BUILT_IN: u32 = u32::from_be_bytes(*b"bltn");
+        const USB: u32 = u32::from_be_bytes(*b"usb ");
+        const BLUETOOTH: u32 = u32::from_be_bytes(*b"blue");
+        const BLUETOOTH_LE: u32 = u32::from_be_bytes(*b"blea");
+        const VIRTUAL: u32 = u32::from_be_bytes(*b"virt");
+        const AGGREGATE: u32 = u32::from_be_bytes(*b"grup");
+        const THUNDERBOLT: u32 = u32::from_be_bytes(*b"thun");
+        const HDMI: u32 = u32::from_be_bytes(*b"hdmi");
+        const DISPLAY_PORT: u32 = u32::from_be_bytes(*b"dprt");
+        const FIREWIRE: u32 = u32::from_be_bytes(*b"1394");
+        const PCI: u32 = u32::from_be_bytes(*b"pci ");
+        const AIRPLAY: u32 = u32::from_be_bytes(*b"airp");
+
+        match transport {
+            BUILT_IN => Some(InterfaceType::BuiltIn),
+            USB => Some(InterfaceType::Usb),
+            BLUETOOTH | BLUETOOTH_LE => Some(InterfaceType::Bluetooth),
+            VIRTUAL => Some(InterfaceType::Virtual),
+            AGGREGATE => Some(InterfaceType::Aggregate),
+            THUNDERBOLT => Some(InterfaceType::Thunderbolt),
+            HDMI => Some(InterfaceType::Hdmi),
+            DISPLAY_PORT => Some(InterfaceType::DisplayPort),
+            FIREWIRE => Some(InterfaceType::FireWire),
+            PCI => Some(InterfaceType::Pci),
+            AIRPLAY => Some(InterfaceType::Network),
+            _ => None,
+        }
+    }
+
     fn description(&self) -> Result<crate::DeviceDescription, Error> {
         let name = get_device_name(self.audio_device_id).context("Failed to get device name")?;
 
@@ -422,8 +480,11 @@ impl Device {
 
         let mut builder = DeviceDescriptionBuilder::new(name).direction(direction);
 
-        // Check if this is an aggregate device
-        if self.is_aggregate_device() {
+        // TransportType also reports "grup" for aggregates; the class check
+        // remains for devices that do not expose the property.
+        if let Some(interface_type) = self.transport_interface_type() {
+            builder = builder.interface_type(interface_type);
+        } else if self.is_aggregate_device() {
             builder = builder.interface_type(InterfaceType::Aggregate);
         }
 

--- a/src/host/coreaudio/macos/device.rs
+++ b/src/host/coreaudio/macos/device.rs
@@ -30,9 +30,16 @@ use objc2_core_audio::{
     kAudioDevicePropertyBufferFrameSizeRange, kAudioDevicePropertyDeviceUID,
     kAudioDevicePropertyLatency, kAudioDevicePropertyNominalSampleRate,
     kAudioDevicePropertySafetyOffset, kAudioDevicePropertyStreamConfiguration,
-    kAudioDevicePropertyStreamFormat, kAudioDevicePropertyTransportType, kAudioObjectPropertyClass,
-    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
-    kAudioObjectPropertyScopeInput, kAudioObjectPropertyScopeOutput,
+    kAudioDevicePropertyStreamFormat, kAudioDevicePropertyTransportType,
+    kAudioDeviceTransportTypeAVB, kAudioDeviceTransportTypeAggregate,
+    kAudioDeviceTransportTypeAirPlay, kAudioDeviceTransportTypeBluetooth,
+    kAudioDeviceTransportTypeBluetoothLE, kAudioDeviceTransportTypeBuiltIn,
+    kAudioDeviceTransportTypeDisplayPort, kAudioDeviceTransportTypeFireWire,
+    kAudioDeviceTransportTypeHDMI, kAudioDeviceTransportTypePCI,
+    kAudioDeviceTransportTypeThunderbolt, kAudioDeviceTransportTypeUSB,
+    kAudioDeviceTransportTypeVirtual, kAudioObjectPropertyClass, kAudioObjectPropertyElementMain,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput,
+    kAudioObjectPropertyScopeOutput,
 };
 use objc2_core_audio_types::{
     AudioBuffer, AudioBufferList, AudioStreamBasicDescription, AudioValueRange,
@@ -415,7 +422,7 @@ impl Device {
         };
 
         let mut transport: u32 = 0;
-        let data_size = size_of::<u32>() as u32;
+        let mut data_size = size_of::<u32>() as u32;
 
         // SAFETY: AudioObjectGetPropertyData writes a UInt32 for
         // kAudioDevicePropertyTransportType. The status is checked before use.
@@ -425,7 +432,7 @@ impl Device {
                 NonNull::from(&property_address),
                 0,
                 null(),
-                NonNull::from(&data_size),
+                NonNull::from(&mut data_size),
                 NonNull::from(&mut transport).cast(),
             )
         };
@@ -433,32 +440,23 @@ impl Device {
             return None;
         }
 
-        // Four-character codes from AudioHardwareBase.h.
-        const BUILT_IN: u32 = u32::from_be_bytes(*b"bltn");
-        const USB: u32 = u32::from_be_bytes(*b"usb ");
-        const BLUETOOTH: u32 = u32::from_be_bytes(*b"blue");
-        const BLUETOOTH_LE: u32 = u32::from_be_bytes(*b"blea");
-        const VIRTUAL: u32 = u32::from_be_bytes(*b"virt");
-        const AGGREGATE: u32 = u32::from_be_bytes(*b"grup");
-        const THUNDERBOLT: u32 = u32::from_be_bytes(*b"thun");
-        const HDMI: u32 = u32::from_be_bytes(*b"hdmi");
-        const DISPLAY_PORT: u32 = u32::from_be_bytes(*b"dprt");
-        const FIREWIRE: u32 = u32::from_be_bytes(*b"1394");
-        const PCI: u32 = u32::from_be_bytes(*b"pci ");
-        const AIRPLAY: u32 = u32::from_be_bytes(*b"airp");
-
+        #[allow(non_upper_case_globals)]
         match transport {
-            BUILT_IN => Some(InterfaceType::BuiltIn),
-            USB => Some(InterfaceType::Usb),
-            BLUETOOTH | BLUETOOTH_LE => Some(InterfaceType::Bluetooth),
-            VIRTUAL => Some(InterfaceType::Virtual),
-            AGGREGATE => Some(InterfaceType::Aggregate),
-            THUNDERBOLT => Some(InterfaceType::Thunderbolt),
-            HDMI => Some(InterfaceType::Hdmi),
-            DISPLAY_PORT => Some(InterfaceType::DisplayPort),
-            FIREWIRE => Some(InterfaceType::FireWire),
-            PCI => Some(InterfaceType::Pci),
-            AIRPLAY => Some(InterfaceType::Network),
+            kAudioDeviceTransportTypeBuiltIn => Some(InterfaceType::BuiltIn),
+            kAudioDeviceTransportTypeUSB => Some(InterfaceType::Usb),
+            kAudioDeviceTransportTypeBluetooth | kAudioDeviceTransportTypeBluetoothLE => {
+                Some(InterfaceType::Bluetooth)
+            }
+            kAudioDeviceTransportTypeVirtual => Some(InterfaceType::Virtual),
+            kAudioDeviceTransportTypeAggregate => Some(InterfaceType::Aggregate),
+            kAudioDeviceTransportTypeThunderbolt => Some(InterfaceType::Thunderbolt),
+            kAudioDeviceTransportTypeHDMI => Some(InterfaceType::Hdmi),
+            kAudioDeviceTransportTypeDisplayPort => Some(InterfaceType::DisplayPort),
+            kAudioDeviceTransportTypeFireWire => Some(InterfaceType::FireWire),
+            kAudioDeviceTransportTypePCI => Some(InterfaceType::Pci),
+            kAudioDeviceTransportTypeAirPlay | kAudioDeviceTransportTypeAVB => {
+                Some(InterfaceType::Network)
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
## Motivation

On macOS, `interface_type()` is only set for aggregate devices — built-in
microphones, USB interfaces and Bluetooth headsets all report `Unknown`.

The WASAPI backend already fills this field from its endpoint properties.
CoreAudio exposes the same information through `kAudioDevicePropertyTransportType`,
and `InterfaceType` already has variants for nearly every value it returns, so
this closes the asymmetry without an API change.

## Result

Same machine, before and after — all four are ordinary devices, not edge cases:

| Device | Before | After |
|---|---|---|
| MacBook Pro Microphone | `Unknown` | `BuiltIn` |
| MacBook Pro Speakers | `Unknown` | `BuiltIn` |
| BlackHole 2ch | `Unknown` | `Virtual` |
| Microsoft Teams Audio | `Unknown` | `Virtual` |

## Notes

- Returns `Option`, so an unmapped transport leaves the field unset rather than
  claiming `Unknown`.
- `is_aggregate_device()` is kept as a fallback: `TransportType` reports `grup`
  for aggregates too, and I would rather not drop a path I cannot reproduce.
- `airp` (AirPlay) maps to `Network` — the one mapping I would gladly change.
- Tested on macOS 26.6 against built-in and virtual devices. The FireWire, PCI
  and DisplayPort arms are unverified: no such hardware here.