### PR TITLE
Update documentation for Windows minimum version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -339,6 +339,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump overall MSRV to 1.78.
+- Bumped minimum Windows version to 10.
 - **ALSA**: Update `alsa` dependency to 0.11.
 - **ALSA**: Bump MSRV to 1.82.
 - **CoreAudio**: Update `core-audio-rs` dependency to 0.14.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrated to Rust 2024.
+- Bump minimum Windows version to 10 (since 0.17.2).
 - Bump `audio_thread_priority` dependency to 0.36.
 - `DeviceTrait` and `StreamTrait` now require `Send + Sync` as supertrait bounds.
 - `StreamTrait::play` is renamed to `start`.
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Update `alsa` dependency to 0.12.
 - **Linux**: `realtime` can now promote threads without requiring `realtime-dbus`.
 - **PipeWire**: Set `node.rate` property so that `default.clock.allowed-rates` PipeWire config works.
-- Bump minimum Windows version to 10 (since 0.17.2).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ALSA**: Update `alsa` dependency to 0.12.
 - **Linux**: `realtime` can now promote threads without requiring `realtime-dbus`.
 - **PipeWire**: Set `node.rate` property so that `default.clock.allowed-rates` PipeWire config works.
+- Bump minimum Windows version to 10 (since 0.17.2).
 
 ### Deprecated
 
@@ -339,7 +340,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump overall MSRV to 1.78.
-- Bumped minimum Windows version to 10.
 - **ALSA**: Update `alsa` dependency to 0.11.
 - **ALSA**: Bump MSRV to 1.82.
 - **CoreAudio**: Update `core-audio-rs` dependency to 0.14.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The minimum Rust version (MSRV) and minimum operating system / runtime version b
 | JACK | Linux, BSD, macOS, Windows | 1.85 | — |
 | PipeWire | Linux, BSD | 1.85 | PipeWire 0.3.53 |
 | PulseAudio | Linux, BSD | 1.88 | — |
-| WASAPI / ASIO | Windows | 1.85 | Windows 8 |
+| WASAPI / ASIO | Windows | 1.85 | Windows 10 |
 | WASM (`wasm32-unknown`) | WebAssembly | 1.85 | — |
 | WASM (`wasm32-wasip1`) | WebAssembly | 1.85 | — |
 | WASM (`audioworklet`) | WebAssembly | nightly | — |


### PR DESCRIPTION
# Summary
Update the documented minimum Windows version to reflect the Windows versions supported by cpal's current MSRV. Originally mentioned here: https://github.com/RustAudio/cpal/issues/1302#issuecomment-5496440590

Brought to my attention by LastExceed while discussing https://github.com/RustAudio/cpal/issues/1343, I just wrote up the quick PR

# Changes
- Updated the minimum windows version in the README.md
- Added an entry in the changelog documenting when it was originally, actually raised